### PR TITLE
Add auto-export options and note open control

### DIFF
--- a/src/infrastructure/obsidian-plugin/plugin.ts
+++ b/src/infrastructure/obsidian-plugin/plugin.ts
@@ -38,6 +38,9 @@ export interface AgentClientPluginSettings {
 	exportSettings: {
 		defaultFolder: string;
 		filenameTemplate: string;
+		autoExportOnNewChat: boolean;
+		autoExportOnCloseChat: boolean;
+		openFileAfterExport: boolean;
 	};
 	// WSL settings (Windows only)
 	windowsWslMode: boolean;
@@ -78,6 +81,9 @@ const DEFAULT_SETTINGS: AgentClientPluginSettings = {
 	exportSettings: {
 		defaultFolder: "Agent Client",
 		filenameTemplate: "agent_client_{date}_{time}",
+		autoExportOnNewChat: false,
+		autoExportOnCloseChat: false,
+		openFileAfterExport: true,
 	},
 	windowsWslMode: false,
 	windowsWslDistribution: undefined,
@@ -404,6 +410,21 @@ export default class AgentClientPlugin extends Plugin {
 								? rawExport.filenameTemplate
 								: DEFAULT_SETTINGS.exportSettings
 										.filenameTemplate,
+						autoExportOnNewChat:
+							typeof rawExport.autoExportOnNewChat === "boolean"
+								? rawExport.autoExportOnNewChat
+								: DEFAULT_SETTINGS.exportSettings
+										.autoExportOnNewChat,
+						autoExportOnCloseChat:
+							typeof rawExport.autoExportOnCloseChat === "boolean"
+								? rawExport.autoExportOnCloseChat
+								: DEFAULT_SETTINGS.exportSettings
+										.autoExportOnCloseChat,
+						openFileAfterExport:
+							typeof rawExport.openFileAfterExport === "boolean"
+								? rawExport.openFileAfterExport
+								: DEFAULT_SETTINGS.exportSettings
+										.openFileAfterExport,
 					};
 				}
 				return DEFAULT_SETTINGS.exportSettings;

--- a/src/presentation/components/settings/AgentClientSettingTab.ts
+++ b/src/presentation/components/settings/AgentClientSettingTab.ts
@@ -171,6 +171,56 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					}),
 			);
 
+		new Setting(containerEl)
+			.setName("Auto-export on new chat")
+			.setDesc(
+				"Automatically export the current chat when starting a new chat",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(
+						this.plugin.settings.exportSettings.autoExportOnNewChat,
+					)
+					.onChange(async (value) => {
+						this.plugin.settings.exportSettings.autoExportOnNewChat =
+							value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Auto-export on close chat")
+			.setDesc(
+				"Automatically export the current chat when closing the chat view",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(
+						this.plugin.settings.exportSettings
+							.autoExportOnCloseChat,
+					)
+					.onChange(async (value) => {
+						this.plugin.settings.exportSettings.autoExportOnCloseChat =
+							value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Open note after export")
+			.setDesc("Automatically open the exported note after exporting")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(
+						this.plugin.settings.exportSettings.openFileAfterExport,
+					)
+					.onChange(async (value) => {
+						this.plugin.settings.exportSettings.openFileAfterExport =
+							value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
 		new Setting(containerEl).setName("Developer").setHeading();
 
 		new Setting(containerEl)

--- a/src/presentation/views/chat/ChatView.tsx
+++ b/src/presentation/views/chat/ChatView.tsx
@@ -1,10 +1,4 @@
-import {
-	ItemView,
-	WorkspaceLeaf,
-	setIcon,
-	Platform,
-	Notice,
-} from "obsidian";
+import { ItemView, WorkspaceLeaf, setIcon, Platform, Notice } from "obsidian";
 import type { EventRef } from "obsidian";
 import * as React from "react";
 const {
@@ -662,12 +656,14 @@ function ChatComponent({
 
 		try {
 			const exporter = new ChatExporter(plugin);
+			const openFile = plugin.settings.exportSettings.openFileAfterExport;
 			const filePath = await exporter.exportToMarkdown(
 				messages,
 				activeAgentLabel,
 				session.agentId,
 				session.sessionId || "unknown",
 				session.createdAt,
+				openFile,
 			);
 			new Notice(`[Agent Client] Chat exported to ${filePath}`);
 		} catch (error) {
@@ -964,20 +960,14 @@ export class ChatView extends ItemView {
 		};
 
 		this.registerEvent(
-			workspace.on(
-				"agent-client:approve-active-permission",
-				() => {
-					void approveHandler();
-				},
-			),
+			workspace.on("agent-client:approve-active-permission", () => {
+				void approveHandler();
+			}),
 		);
 		this.registerEvent(
-			workspace.on(
-				"agent-client:reject-active-permission",
-				() => {
-					void rejectHandler();
-				},
-			),
+			workspace.on("agent-client:reject-active-permission", () => {
+				void rejectHandler();
+			}),
 		);
 	}
 }

--- a/src/shared/chat-exporter.ts
+++ b/src/shared/chat-exporter.ts
@@ -19,6 +19,7 @@ export class ChatExporter {
 		agentId: string,
 		sessionId: string,
 		sessionCreatedAt: Date,
+		openFile: boolean = true,
 	): Promise<string> {
 		const settings = this.plugin.settings.exportSettings;
 		const fileName = this.generateFileName(sessionCreatedAt);
@@ -61,9 +62,11 @@ export class ChatExporter {
 				);
 			}
 
-			// Open the exported file
-			const leaf = this.plugin.app.workspace.getLeaf(false);
-			await leaf.openFile(file);
+			// Open the exported file if requested
+			if (openFile) {
+				const leaf = this.plugin.app.workspace.getLeaf(false);
+				await leaf.openFile(file);
+			}
 
 			this.logger.log(`Chat exported to: ${filePath}`);
 			return filePath;


### PR DESCRIPTION
## Summary

Adds configurable auto-export functionality for chat sessions with three independent settings: auto-export on new chat, auto-export on close, and optional file opening after export.

## Key Changes

### 1. Export Settings (`plugin.ts`, `AgentClientSettingTab.ts`)

- **Auto-export on new chat**: Automatically save current chat before starting new session
- **Auto-export on close chat**: Automatically save chat when closing view
- **Open file after export**: Control whether exported file opens automatically (default: enabled)

All settings default to OFF except file opening (maintains existing behavior).

### 2. Export Flow (`chat.view-model.ts`)

- `autoExportIfEnabled(trigger)` method handles both triggers ("newChat" | "closeChat")
- Called in `createNewSession()` before clearing messages
- Called in `disconnect()` before session cleanup
- Shows `Notice` for all exports (manual and automatic)
- Silent failure on error to avoid interrupting workflow

### 3. ChatExporter Enhancement (`chat-exporter.ts`)

- Added `openFile: boolean = true` parameter to `exportToMarkdown()`
- Conditional file opening based on setting
- Backward compatible with default value

### 4. Architecture Notes

⚠️ ViewModel directly uses `ChatExporter` and `Notice` (not through Use Cases). This is acceptable for cross-cutting concerns like export, but could be refactored to `ExportChatUseCase` if complexity grows.

## Use Cases

- **Silent backup**: Enable both auto-exports with file opening OFF
- **Manual only**: Disable auto-exports, enable file opening for review
- **Full auto**: Enable all settings for maximum convenience

## Breaking Changes

None. All new settings default to preserve existing behavior.