### PR TITLE
Update WSL heading in settings tab

### DIFF
--- a/src/components/settings/AgentClientSettingTab.ts
+++ b/src/components/settings/AgentClientSettingTab.ts
@@ -85,7 +85,9 @@ export class AgentClientSettingTab extends PluginSettingTab {
 
 		// Windows WSL Settings (Windows only)
 		if (Platform.isWin) {
-			new Setting(containerEl).setName("Windows WSL").setHeading();
+			new Setting(containerEl)
+				.setName("Windows Subsystem for Linux")
+				.setHeading();
 
 			new Setting(containerEl)
 				.setName("Enable WSL mode")


### PR DESCRIPTION
Changed the heading from 'Windows WSL' to 'Windows Subsystem for Linux' for clarity in the AgentClientSettingTab component.