### PR TITLE
docs: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this bug?
+      placeholder: |
+        1. Open Obsidian
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+
+  - type: input
+    id: obsidian-version
+    attributes:
+      label: Obsidian version
+      placeholder: e.g., 1.5.0
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      placeholder: e.g., 0.5.1
+    validations:
+      required: true
+
+  - type: input
+    id: agent
+    attributes:
+      label: Agent
+      description: Which agent were you using?
+      placeholder: e.g., Claude Code, Codex, Gemini CLI, OpenCode
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Screenshots / Logs
+      description: Add any screenshots or console logs that might help
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://rait-09.github.io/obsidian-agent-client/
+    about: Check the documentation before opening an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature!
+
+        **Before submitting, please consider the project scope:**
+        - Features achievable via MCP or other standard protocols are out of scope (they should be provided as MCP servers)
+        - Agent-specific features are out of scope (they should be handled via agent config files)
+
+        See [CONTRIBUTING.md](../CONTRIBUTING.md) for more details.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: A brief summary of the feature (one line)
+      placeholder: e.g., Add keyboard shortcut to send message
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why do you need this feature? What problem does it solve?
+      placeholder: I often find myself...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any alternative solutions or workarounds?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context, screenshots, or references
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,40 @@
+name: Question
+description: Ask a question about usage or configuration
+labels: ["question"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question? We're happy to help!
+
+        You may also want to check the [documentation](https://rait-09.github.io/obsidian-agent-client/) first.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What I tried
+      description: What have you already tried or looked into?
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: If relevant, provide your OS, Obsidian version, plugin version, and agent
+      placeholder: |
+        - OS: macOS
+        - Obsidian: 1.5.0
+        - Plugin: 0.5.1
+        - Agent: Claude Code
+    validations:
+      required: false


### PR DESCRIPTION
## Description

Add GitHub Issue Forms templates to help contributors submit well-structured issues.

## Related issue

Closes #44

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor

## Contents

- **Bug Report** - OS, versions, steps to reproduce, expected/actual behavior
- **Feature Request** - Summary, motivation, proposed solution (includes scope policy reminder)
- **Question** - Question, what was tried, environment info
- **config.yml** - Link to documentation

## Checklist

- [x] No code changes
- [x] Documentation only
