### PR TITLE
fix: Make note links clickable in agent messages

### DIFF
--- a/src/components/chat/CollapsibleThought.tsx
+++ b/src/components/chat/CollapsibleThought.tsx
@@ -24,7 +24,7 @@ export function CollapsibleThought({ text, plugin }: CollapsibleThoughtProps) {
 			</div>
 			{isExpanded && (
 				<div className="agent-client-collapsible-thought-content">
-					<MarkdownTextRenderer text={text} app={plugin.app} />
+					<MarkdownTextRenderer text={text} plugin={plugin} />
 				</div>
 			)}
 		</div>

--- a/src/components/chat/MessageContentRenderer.tsx
+++ b/src/components/chat/MessageContentRenderer.tsx
@@ -36,9 +36,7 @@ export function MessageContentRenderer({
 			if (messageRole === "user") {
 				return <TextWithMentions text={content.text} plugin={plugin} />;
 			}
-			return (
-				<MarkdownTextRenderer text={content.text} app={plugin.app} />
-			);
+			return <MarkdownTextRenderer text={content.text} plugin={plugin} />;
 
 		case "text_with_context":
 			// User messages with auto-mention context


### PR DESCRIPTION
## Description

Make `[[note]]` links in agent messages clickable. Previously, note links were rendered but clicking them did nothing. Now they open the linked note in Obsidian.

The fix adds a click event handler for `.internal-link` elements in `MarkdownTextRenderer`, since ItemView doesn't handle internal link clicks automatically like FileView does.

## Related issue

Closes #43

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: macOS

## Screenshots

N/A (no UI changes)