### PR TITLE
feat: Send mentioned notes as embedded resources when agent supports embeddedContext

### DIFF
--- a/src/adapters/acp/acp-type-converter.ts
+++ b/src/adapters/acp/acp-type-converter.ts
@@ -52,7 +52,7 @@ export class AcpTypeConverter {
 	 * This converts our domain-layer prompt content to the ACP protocol format
 	 * for sending to the agent.
 	 *
-	 * @param content - Domain prompt content (text or image)
+	 * @param content - Domain prompt content (text, image, or resource)
 	 * @returns ACP ContentBlock for use with the prompt API
 	 */
 	static toAcpContentBlock(content: PromptContent): acp.ContentBlock {
@@ -64,6 +64,16 @@ export class AcpTypeConverter {
 					type: "image",
 					data: content.data,
 					mimeType: content.mimeType,
+				};
+			case "resource":
+				return {
+					type: "resource",
+					resource: {
+						uri: content.resource.uri,
+						mimeType: content.resource.mimeType,
+						text: content.resource.text,
+					},
+					annotations: content.annotations,
 				};
 		}
 	}

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -114,6 +114,7 @@ function ChatComponent({
 		{
 			sessionId: session.sessionId,
 			authMethods: session.authMethods,
+			promptCapabilities: session.promptCapabilities,
 		},
 		{
 			windowsWslMode: settings.windowsWslMode,

--- a/src/domain/models/prompt-content.ts
+++ b/src/domain/models/prompt-content.ts
@@ -29,6 +29,44 @@ export interface ImagePromptContent {
 }
 
 /**
+ * Annotations for resource content (ACP spec compliant)
+ *
+ * Provides hints to the agent about how to use or prioritize the resource.
+ */
+export interface ResourceAnnotations {
+	/** Intended audience(s) for this resource */
+	audience?: ("user" | "assistant")[];
+	/** Importance (0.0 = least important, 1.0 = most important) */
+	priority?: number;
+	/** Last modified timestamp (ISO 8601) */
+	lastModified?: string;
+}
+
+/**
+ * Embedded resource content in a prompt
+ *
+ * Used when agent supports embeddedContext capability.
+ * Contains file content with URI and metadata.
+ * This allows the agent to receive structured context about referenced files.
+ */
+export interface ResourcePromptContent {
+	type: "resource";
+	resource: {
+		/** Resource URI (e.g., "file:///path/to/note.md") */
+		uri: string;
+		/** MIME type of the resource */
+		mimeType: string;
+		/** Text content of the resource */
+		text: string;
+	};
+	/** Optional annotations for the resource */
+	annotations?: ResourceAnnotations;
+}
+
+/**
  * Union type for all prompt content types
  */
-export type PromptContent = TextPromptContent | ImagePromptContent;
+export type PromptContent =
+	| TextPromptContent
+	| ImagePromptContent
+	| ResourcePromptContent;

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -108,6 +108,12 @@ export interface UseChatReturn {
 export interface SessionContext {
 	sessionId: string | null;
 	authMethods: AuthenticationMethod[];
+	/** Prompt capabilities from agent initialization */
+	promptCapabilities?: {
+		image?: boolean;
+		audio?: boolean;
+		embeddedContext?: boolean;
+	};
 }
 
 /**
@@ -442,6 +448,9 @@ export function useChat(
 					vaultBasePath: options.vaultBasePath,
 					isAutoMentionDisabled: options.isAutoMentionDisabled,
 					convertToWsl: shouldConvertToWsl,
+					supportsEmbeddedContext:
+						sessionContext.promptCapabilities?.embeddedContext ??
+						false,
 				},
 				vaultAccess,
 				mentionService,
@@ -534,6 +543,7 @@ export function useChat(
 			mentionService,
 			sessionContext.sessionId,
 			sessionContext.authMethods,
+			sessionContext.promptCapabilities,
 			shouldConvertToWsl,
 			addMessage,
 		],

--- a/src/shared/message-service.ts
+++ b/src/shared/message-service.ts
@@ -23,9 +23,11 @@ import type { AuthenticationMethod } from "../domain/models/chat-session";
 import type {
 	PromptContent,
 	ImagePromptContent,
+	ResourcePromptContent,
 } from "../domain/models/prompt-content";
 import { extractMentionedNotes, type IMentionService } from "./mention-utils";
 import { convertWindowsPathToWsl } from "./wsl-utils";
+import { buildFileUri } from "./path-utils";
 
 // ============================================================================
 // Types
@@ -52,6 +54,9 @@ export interface PreparePromptInput {
 
 	/** Whether to convert paths to WSL format (Windows + WSL mode) */
 	convertToWsl?: boolean;
+
+	/** Whether agent supports embeddedContext capability */
+	supportsEmbeddedContext?: boolean;
 }
 
 /**
@@ -133,6 +138,9 @@ const MAX_SELECTION_LENGTH = 10000; // Maximum characters for selection
  * - Building context blocks for mentioned notes
  * - Adding auto-mention context for active note
  * - Creating agent content with context + user message + images
+ *
+ * When agent supports embeddedContext capability, mentioned notes are sent
+ * as Resource content blocks. Otherwise, they are embedded as XML text.
  */
 export async function preparePrompt(
 	input: PreparePromptInput,
@@ -142,9 +150,139 @@ export async function preparePrompt(
 	// Step 1: Extract all mentioned notes from the message
 	const mentionedNotes = extractMentionedNotes(input.message, mentionService);
 
-	// Step 2: Build context blocks for each mentioned note
+	// Step 2: Build context based on agent capabilities
+	if (input.supportsEmbeddedContext) {
+		return preparePromptWithEmbeddedContext(
+			input,
+			vaultAccess,
+			mentionedNotes,
+		);
+	} else {
+		return preparePromptWithTextContext(input, vaultAccess, mentionedNotes);
+	}
+}
+
+/**
+ * Prepare prompt using embedded Resource format (for embeddedContext-capable agents).
+ */
+async function preparePromptWithEmbeddedContext(
+	input: PreparePromptInput,
+	vaultAccess: IVaultAccess,
+	mentionedNotes: Array<{
+		noteTitle: string;
+		file: { path: string; stat: { mtime: number } } | undefined;
+	}>,
+): Promise<PreparePromptResult> {
+	const resourceBlocks: ResourcePromptContent[] = [];
+
+	// Build Resource blocks for each mentioned note
+	for (const { file } of mentionedNotes) {
+		if (!file) {
+			continue;
+		}
+
+		try {
+			const content = await vaultAccess.readNote(file.path);
+
+			let processedContent = content;
+			if (content.length > MAX_NOTE_LENGTH) {
+				processedContent =
+					content.substring(0, MAX_NOTE_LENGTH) +
+					`\n\n[Note: Truncated from ${content.length} to ${MAX_NOTE_LENGTH} characters]`;
+			}
+
+			let absolutePath = input.vaultBasePath
+				? `${input.vaultBasePath}/${file.path}`
+				: file.path;
+
+			if (input.convertToWsl) {
+				absolutePath = convertWindowsPathToWsl(absolutePath);
+			}
+
+			resourceBlocks.push({
+				type: "resource",
+				resource: {
+					uri: buildFileUri(absolutePath),
+					mimeType: "text/markdown",
+					text: processedContent,
+				},
+				annotations: {
+					audience: ["assistant"],
+					priority: 1.0, // Manual mentions are high priority
+					lastModified: new Date(file.stat.mtime).toISOString(),
+				},
+			});
+		} catch (error) {
+			console.error(`Failed to read note ${file.path}:`, error);
+		}
+	}
+
+	// Build auto-mention Resource block
+	const autoMentionBlocks: PromptContent[] = [];
+	if (input.activeNote && !input.isAutoMentionDisabled) {
+		const autoMentionResource = await buildAutoMentionResource(
+			input.activeNote,
+			input.vaultBasePath,
+			vaultAccess,
+			input.convertToWsl ?? false,
+		);
+		autoMentionBlocks.push(...autoMentionResource);
+	}
+
+	// Build content arrays
+	const displayContent: PromptContent[] = [
+		...(input.message
+			? [{ type: "text" as const, text: input.message }]
+			: []),
+		...(input.images || []),
+	];
+
+	const agentContent: PromptContent[] = [
+		...resourceBlocks,
+		...autoMentionBlocks,
+		...(input.message
+			? [{ type: "text" as const, text: input.message }]
+			: []),
+		...(input.images || []),
+	];
+
+	// Build auto-mention context metadata for UI
+	const autoMentionContext =
+		input.activeNote && !input.isAutoMentionDisabled
+			? {
+					noteName: input.activeNote.name,
+					notePath: input.activeNote.path,
+					selection: input.activeNote.selection
+						? {
+								fromLine:
+									input.activeNote.selection.from.line + 1,
+								toLine: input.activeNote.selection.to.line + 1,
+							}
+						: undefined,
+				}
+			: undefined;
+
+	return {
+		displayContent,
+		agentContent,
+		autoMentionContext,
+	};
+}
+
+/**
+ * Prepare prompt using XML text format (fallback for agents without embeddedContext).
+ */
+async function preparePromptWithTextContext(
+	input: PreparePromptInput,
+	vaultAccess: IVaultAccess,
+	mentionedNotes: Array<{
+		noteTitle: string;
+		file: { path: string; stat: { mtime: number } } | undefined;
+	}>,
+): Promise<PreparePromptResult> {
 	const contextBlocks: string[] = [];
 
+	// Build XML context blocks for each mentioned note
 	for (const { file } of mentionedNotes) {
 		if (!file) {
 			continue;
@@ -176,9 +314,9 @@ export async function preparePrompt(
 		}
 	}
 
-	// Step 3: Build context from active note (for agent only)
+	// Build auto-mention XML context
 	if (input.activeNote && !input.isAutoMentionDisabled) {
-		const autoMentionContextBlock = await buildAutoMentionContext(
+		const autoMentionContextBlock = await buildAutoMentionTextContext(
 			input.activeNote.path,
 			input.vaultBasePath,
 			vaultAccess,
@@ -188,15 +326,13 @@ export async function preparePrompt(
 		contextBlocks.push(autoMentionContextBlock);
 	}
 
-	// Step 4: Build agent message text (context blocks + original message)
+	// Build agent message text (context blocks + original message)
 	const agentMessageText =
 		contextBlocks.length > 0
 			? contextBlocks.join("\n") + "\n\n" + input.message
 			: input.message;
 
-	// Step 5: Build content arrays
-	// Only include text block if there's actual text content
-	// (API rejects empty text blocks)
+	// Build content arrays
 	const displayContent: PromptContent[] = [
 		...(input.message
 			? [{ type: "text" as const, text: input.message }]
@@ -211,7 +347,7 @@ export async function preparePrompt(
 		...(input.images || []),
 	];
 
-	// Step 6: Build auto-mention context metadata
+	// Build auto-mention context metadata for UI
 	const autoMentionContext =
 		input.activeNote && !input.isAutoMentionDisabled
 			? {
@@ -235,9 +371,92 @@ export async function preparePrompt(
 }
 
 /**
- * Build context from auto-mentioned note.
+ * Build Resource content blocks for auto-mentioned note.
  */
-async function buildAutoMentionContext(
+async function buildAutoMentionResource(
+	activeNote: NoteMetadata,
+	vaultPath: string,
+	vaultAccess: IVaultAccess,
+	convertToWsl: boolean,
+): Promise<PromptContent[]> {
+	let absolutePath = vaultPath
+		? `${vaultPath}/${activeNote.path}`
+		: activeNote.path;
+
+	if (convertToWsl) {
+		absolutePath = convertWindowsPathToWsl(absolutePath);
+	}
+
+	const uri = buildFileUri(absolutePath);
+
+	if (activeNote.selection) {
+		// Selection exists - send the selected content as a Resource
+		const fromLine = activeNote.selection.from.line + 1;
+		const toLine = activeNote.selection.to.line + 1;
+
+		try {
+			const content = await vaultAccess.readNote(activeNote.path);
+			const lines = content.split("\n");
+			const selectedLines = lines.slice(
+				activeNote.selection.from.line,
+				activeNote.selection.to.line + 1,
+			);
+			let selectedText = selectedLines.join("\n");
+
+			if (selectedText.length > MAX_SELECTION_LENGTH) {
+				selectedText =
+					selectedText.substring(0, MAX_SELECTION_LENGTH) +
+					`\n\n[Note: Truncated from ${selectedLines.join("\n").length} to ${MAX_SELECTION_LENGTH} characters]`;
+			}
+
+			return [
+				{
+					type: "resource",
+					resource: {
+						uri: uri,
+						mimeType: "text/markdown",
+						text: selectedText,
+					},
+					annotations: {
+						audience: ["assistant"],
+						priority: 0.8, // Selection is high priority
+						lastModified: new Date(
+							activeNote.modified,
+						).toISOString(),
+					},
+				} as ResourcePromptContent,
+				{
+					type: "text",
+					text: `The user has selected lines ${fromLine}-${toLine} in the above note. This is what they are currently focusing on.`,
+				},
+			];
+		} catch (error) {
+			console.error(
+				`Failed to read selection from ${activeNote.path}:`,
+				error,
+			);
+			return [
+				{
+					type: "text",
+					text: `The user has selected lines ${fromLine}-${toLine} in ${uri}. If relevant, use the Read tool to examine the specific lines.`,
+				},
+			];
+		}
+	}
+
+	// No selection - just inform about the opened note
+	return [
+		{
+			type: "text",
+			text: `The user has opened the note ${uri} in Obsidian. This may or may not be related to the current conversation. If it seems relevant, consider using the Read tool to examine its content.`,
+		},
+	];
+}
+
+/**
+ * Build XML text context from auto-mentioned note (fallback format).
+ */
+async function buildAutoMentionTextContext(
 	notePath: string,
 	vaultPath: string,
 	vaultAccess: IVaultAccess,

--- a/src/shared/path-utils.ts
+++ b/src/shared/path-utils.ts
@@ -37,3 +37,27 @@ export function toRelativePath(absolutePath: string, basePath: string): string {
 	}
 	return absolutePath;
 }
+
+/**
+ * Build a file URI from an absolute path.
+ * Handles both Windows and Unix paths.
+ *
+ * @param absolutePath - Absolute file path
+ * @returns file:// URI
+ *
+ * @example
+ * buildFileUri("/Users/user/note.md") // "file:///Users/user/note.md"
+ * buildFileUri("C:\\Users\\user\\note.md") // "file:///C:/Users/user/note.md"
+ */
+export function buildFileUri(absolutePath: string): string {
+	// Normalize backslashes to forward slashes
+	const normalizedPath = absolutePath.replace(/\\/g, "/");
+
+	// Windows path (e.g., C:/Users/...)
+	if (/^[A-Za-z]:/.test(normalizedPath)) {
+		return `file:///${normalizedPath}`;
+	}
+
+	// Unix path (e.g., /Users/...)
+	return `file://${normalizedPath}`;
+}


### PR DESCRIPTION
## Description

When the agent advertises the `embeddedContext` prompt capability, mentioned notes are now sent as ACP Resource content blocks instead of XML text format.

**Changes:**
- Add `ResourcePromptContent` and `ResourceAnnotations` types to domain models
- Add `resource` case to ACP type converter
- Add `buildFileUri` helper for `file://` URI construction
- Refactor `preparePrompt` to use embedded context or text context based on capability
- Pass `promptCapabilities` from session to `useChat` hook

**Resource annotations:**
- `audience: ["assistant"]`
- `priority`: 1.0 (manual mentions), 0.8 (auto-mention with selection)
- `lastModified`: ISO 8601 timestamp

Agents without `embeddedContext` capability continue to receive XML text format.

## Related issue

N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: macOS

## Screenshots

N/A
