### PR TITLE
fix: use GEMINI_API_KEY instead of GOOGLE_API_KEY for Gemini CLI

### DIFF
--- a/src/domain/models/agent-config.ts
+++ b/src/domain/models/agent-config.ts
@@ -59,7 +59,7 @@ export interface BaseAgentSettings {
  * Extends base settings with Gemini-specific requirements.
  */
 export interface GeminiAgentSettings extends BaseAgentSettings {
-	/** Google API key for Gemini (GOOGLE_API_KEY) */
+	/** Gemini API key (GEMINI_API_KEY) */
 	apiKey: string;
 }
 

--- a/src/hooks/useAgentSession.ts
+++ b/src/hooks/useAgentSession.ts
@@ -262,7 +262,7 @@ function buildAgentConfigWithApiKey(
 			...baseConfig,
 			env: {
 				...baseConfig.env,
-				GOOGLE_API_KEY: geminiSettings.apiKey,
+				GEMINI_API_KEY: geminiSettings.apiKey,
 			},
 		};
 	}


### PR DESCRIPTION
## Description

Fixed incorrect environment variable name for Gemini CLI API key authentication. The plugin was setting `GOOGLE_API_KEY` instead of `GEMINI_API_KEY`, causing "you must specify the GEMINI_API_KEY environment variable" error when using API key authentication.

## Related issue

#76

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Gemini CLI
- OS: macOS

## Screenshots

N/A
