### PR TITLE
fix: respect autoMentionActiveNote setting when sending messages

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -615,7 +615,12 @@ function ChatComponent({
 			const isFirstMessage = messages.length === 0;
 
 			await chat.sendMessage(content, {
-				activeNote: autoMention.activeNote,
+				// TODO: Refactor to handle settings inside useAutoMention hook
+				// Current: Pass null when setting is OFF to disable auto-mention
+				// Ideal: useAutoMention should accept settings and return effective values
+				activeNote: settings.autoMentionActiveNote
+					? autoMention.activeNote
+					: null,
 				vaultBasePath:
 					(plugin.app.vault.adapter as VaultAdapterWithBasePath)
 						.basePath || "",
@@ -642,6 +647,7 @@ function ChatComponent({
 			session.sessionId,
 			sessionHistory,
 			logger,
+			settings.autoMentionActiveNote,
 		],
 	);
 


### PR DESCRIPTION
## Description

Fixed a bug where auto-mention was applied to messages even when the "Auto-mention active note" setting was turned off. The setting was only controlling the UI badge visibility, but not the actual message sending logic.

## Related issue

Fixes #84

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: macOS

## Screenshots

N/A