### PR TITLE
fix: convert Windows path to WSL path in session/list filter

### DIFF
--- a/src/adapters/acp/acp.adapter.ts
+++ b/src/adapters/acp/acp.adapter.ts
@@ -1341,8 +1341,14 @@ export class AcpAdapter implements IAgentClient, IAcpClient {
 		try {
 			this.logger.log("[AcpAdapter] Listing sessions...");
 
+			// Convert Windows path to WSL path if in WSL mode
+			let filterCwd = cwd;
+			if (cwd && Platform.isWin && this.plugin.settings.windowsWslMode) {
+				filterCwd = convertWindowsPathToWsl(cwd);
+			}
+
 			const response = await this.connection.unstable_listSessions({
-				cwd: cwd ?? null,
+				cwd: filterCwd ?? null,
 				cursor: cursor ?? null,
 			});
 


### PR DESCRIPTION
## Description

In WSL mode, the "Show current vault only" filter in Session History didn't work correctly. Sessions were created with WSL paths (`/mnt/c/Users/...`), but the filter was sending Windows paths (`C:\Users\...`) to the agent's `session/list` API, causing a path mismatch.

This fix applies the same WSL path conversion used in `newSession` to the `listSessions` method.

## Related issue

Fixes #83

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Codex
- OS: Windows (WSL mode)

## Screenshots

<!-- N/A -->
