### PR TITLE
fix: use FileSystemAdapter.getBasePath() for vault path retrieval (#90)

### DIFF
--- a/src/components/chat/ToolCallRenderer.tsx
+++ b/src/components/chat/ToolCallRenderer.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 const { useState, useMemo } = React;
+import { FileSystemAdapter } from "obsidian";
 import type { MessageContent } from "../../domain/models/chat-message";
 import type { IAcpClient } from "../../adapters/acp/acp.adapter";
 import type AgentClientPlugin from "../../plugin";
@@ -51,8 +52,11 @@ export function ToolCallRenderer({
 
 	// Get vault path for relative path display
 	const vaultPath = useMemo(() => {
-		const adapter = plugin.app.vault.adapter as { basePath?: string };
-		return adapter.basePath || "";
+		const adapter = plugin.app.vault.adapter;
+		if (adapter instanceof FileSystemAdapter) {
+			return adapter.getBasePath();
+		}
+		return "";
 	}, [plugin]);
 
 	// Get showEmojis setting


### PR DESCRIPTION
## Description

The previous implementation accessed the internal `adapter.basePath` property via type casting, which could return `undefined` in some Windows environments. This caused the plugin to fall back to `process.cwd()`, sending incorrect working directory paths to agents and resulting in "Session Creation Failed" errors.

This change uses the official `FileSystemAdapter.getBasePath()` API to reliably retrieve the vault path on all desktop platforms.

## Related issue

#90

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code, OpenCode, Codex
- OS: macOS, Windows, Linux

## Screenshots

N/A
