### PR TITLE
docs: add Kiro to custom agents examples

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -81,7 +81,7 @@ https://github.com/user-attachments/assets/1c538349-b3fb-44dd-a163-7331cbca7824
 - [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html)
 - [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html)
 - [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html)
-- [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)（OpenCode、Qwen Code、Mistral Vibeなど）
+- [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)（OpenCode、Qwen Code、Kiro、Mistral Vibeなど）
 
 **[ドキュメント全文](https://rait-09.github.io/obsidian-agent-client/)**
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Open a terminal (Terminal on macOS/Linux, PowerShell on Windows) and run the fol
 - [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html)
 - [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html)
 - [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html)
-- [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html) (OpenCode, Qwen Code, Mistral Vibe, etc.)
+- [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html) (OpenCode, Qwen Code, Kiro, Mistral Vibe, etc.)
 
 **[Full Documentation](https://rait-09.github.io/obsidian-agent-client/)**
 

--- a/docs/agent-setup/custom-agents.md
+++ b/docs/agent-setup/custom-agents.md
@@ -4,7 +4,7 @@ You can use any agent that implements the [Agent Client Protocol (ACP)](https://
 
 ## Install and Configure
 
-1. Install your ACP-compatible agent (e.g., [OpenCode](https://github.com/sst/opencode), [Qwen Code](https://github.com/QwenLM/qwen-code)).
+1. Install your ACP-compatible agent (e.g., [OpenCode](https://github.com/sst/opencode), [Qwen Code](https://github.com/QwenLM/qwen-code), [Kiro](https://kiro.dev/)).
 
 2. Find the installation path by running the following command in your terminal (Terminal on macOS/Linux, PowerShell on Windows):
 
@@ -54,6 +54,20 @@ where.exe your-agent
 | **Path** | `/usr/local/bin/qwen` |
 | **Arguments** | `--experimental-acp` |
 | **Environment variables** | (optional) |
+
+### Kiro
+
+| Field | Value |
+|-------|-------|
+| **Agent ID** | `kiro-cli` |
+| **Display name** | `Kiro` |
+| **Path** | `/path/to/home/.local/bin/kiro-cli` |
+| **Arguments** | `acp` |
+| **Environment variables** | (optional) |
+
+::: tip
+Replace `/path/to/home` with your home directory (e.g., `/Users/john` on macOS, `/home/john` on Linux). `$HOME` and `~` may not be supported.
+:::
 
 ## Authentication
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -11,7 +11,7 @@ Agent Client supports multiple AI agents. Choose one to start:
 | **[Claude Code](/agent-setup/claude-code)** | Anthropic | via [Zed's SDK adapter](https://github.com/zed-industries/claude-code-acp) |
 | **[Codex](/agent-setup/codex)** | OpenAI | via [Zed's adapter](https://github.com/zed-industries/codex-acp) |
 | **[Gemini CLI](/agent-setup/gemini-cli)** | Google | with `--experimental-acp` option |
-| **[Custom](/agent-setup/custom-agents)** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., OpenCode, Qwen Code) |
+| **[Custom](/agent-setup/custom-agents)** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., OpenCode, Qwen Code, Kiro) |
 
 ## Step 2: Install and Configure the Agent
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ Agent Client is an Obsidian plugin that brings AI coding agents directly into yo
 | **[Claude Code](https://github.com/anthropics/claude-code)** | Anthropic | via [Zed’s SDK adapter](https://github.com/zed-industries/claude-code-acp) |
 | **[Codex](https://github.com/openai/codex)** | OpenAI | via [Zed’s adapter](https://github.com/zed-industries/codex-acp) |
 | **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** | Google | with `--experimental-acp` option |
-| **Custom** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., OpenCode, Qwen Code) |
+| **Custom** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., OpenCode, Qwen Code, Kiro) |
 
 ### Key Features
 


### PR DESCRIPTION
Add Kiro CLI to the list of custom agent examples in documentation.

Kiro CLI supports ACP (Agent Client Protocol): https://kiro.dev/docs/cli/acp/

Changes:
- Add Kiro to custom-agents.md with configuration example
- Add Kiro to README.md and README.ja.md
- Add Kiro to docs/index.md and docs/getting-started/quick-start.md