### PR TITLE
fix: clamp floating window position to viewport bounds

### DIFF
--- a/src/components/chat/FloatingButton.tsx
+++ b/src/components/chat/FloatingButton.tsx
@@ -63,7 +63,15 @@ function FloatingButtonComponent({ plugin }: FloatingButtonProps) {
 
 	// Dragging state
 	const [position, setPosition] = useState<{ x: number; y: number } | null>(
-		() => settings.floatingButtonPosition,
+		() => {
+			if (!settings.floatingButtonPosition) return null;
+			return clampPosition(
+				settings.floatingButtonPosition.x,
+				settings.floatingButtonPosition.y,
+				BUTTON_SIZE,
+				BUTTON_SIZE,
+			);
+		},
 	);
 	const [isDragging, setIsDragging] = useState(false);
 	const dragOffset = useRef({ x: 0, y: 0 });

--- a/src/components/chat/FloatingChatView.tsx
+++ b/src/components/chat/FloatingChatView.tsx
@@ -248,13 +248,28 @@ function FloatingChatComponent({
 	const [isExpanded, setIsExpanded] = useState(initialExpanded);
 	const [size, setSize] = useState(settings.floatingWindowSize);
 	const [position, setPosition] = useState(() => {
-		if (initialPosition) return initialPosition;
-		if (settings.floatingWindowPosition)
-			return settings.floatingWindowPosition;
-		return {
-			x: window.innerWidth - settings.floatingWindowSize.width - 50,
-			y: window.innerHeight - settings.floatingWindowSize.height - 50,
-		};
+		if (initialPosition) {
+			return clampPosition(
+				initialPosition.x,
+				initialPosition.y,
+				settings.floatingWindowSize.width,
+				settings.floatingWindowSize.height,
+			);
+		}
+		if (settings.floatingWindowPosition) {
+			return clampPosition(
+				settings.floatingWindowPosition.x,
+				settings.floatingWindowPosition.y,
+				settings.floatingWindowSize.width,
+				settings.floatingWindowSize.height,
+			);
+		}
+		return clampPosition(
+			window.innerWidth - settings.floatingWindowSize.width - 50,
+			window.innerHeight - settings.floatingWindowSize.height - 50,
+			settings.floatingWindowSize.width,
+			settings.floatingWindowSize.height,
+		);
 	});
 	const [isDragging, setIsDragging] = useState(false);
 	const dragOffset = useRef({ x: 0, y: 0 });


### PR DESCRIPTION
Fixes issue where floating window and button appear off-screen on smaller displays when position was saved on a larger screen.

Now clamps all position sources (saved settings, initial position, and default position) to ensure elements remain within viewport bounds using the existing clampPosition utility.

## Description

An issue that came up as I switched between using the the plugin between the desktop iMac and the Macbook Pro.