### PR TITLE
fix: use $SHELL env var instead of hardcoded shell paths (#131)

### DIFF
--- a/src/adapters/acp/acp.adapter.ts
+++ b/src/adapters/acp/acp.adapter.ts
@@ -36,7 +36,7 @@ import {
 } from "../../shared/wsl-utils";
 import { resolveCommandDirectory } from "../../shared/path-utils";
 import { getEnhancedWindowsEnv } from "../../shared/windows-env";
-import { escapeShellArgWindows } from "../../shared/shell-utils";
+import { escapeShellArgWindows, getLoginShell } from "../../shared/shell-utils";
 
 /**
  * Extended ACP Client interface for UI layer.
@@ -260,7 +260,7 @@ export class AcpAdapter implements IAgentClient, IAcpClient {
 		// On macOS and Linux, wrap the command in a login shell to inherit the user's environment
 		// This ensures that PATH modifications in .zshrc/.bash_profile are available
 		else if (Platform.isMacOS || Platform.isLinux) {
-			const shell = Platform.isMacOS ? "/bin/zsh" : "/bin/bash";
+			const shell = getLoginShell();
 			const commandString = [command, ...args]
 				.map((arg) => "'" + arg.replace(/'/g, "'\\''") + "'")
 				.join(" ");

--- a/src/shared/shell-utils.ts
+++ b/src/shared/shell-utils.ts
@@ -1,3 +1,5 @@
+import { Platform } from "obsidian";
+
 /**
  * Shell escaping utilities for different platforms.
  */
@@ -19,4 +21,16 @@ export function escapeShellArgWindows(arg: string): string {
 		return `"${escaped}"`;
 	}
 	return escaped;
+}
+
+/**
+ * Resolve the login shell for the current platform.
+ * Uses $SHELL environment variable when available (covers NixOS, etc.),
+ * falls back to platform defaults (/bin/zsh on macOS, /bin/sh on Linux).
+ */
+export function getLoginShell(): string {
+	if (process.env.SHELL) {
+		return process.env.SHELL;
+	}
+	return Platform.isMacOS ? "/bin/zsh" : "/bin/sh";
 }

--- a/src/shared/terminal-manager.ts
+++ b/src/shared/terminal-manager.ts
@@ -6,7 +6,7 @@ import { Platform } from "obsidian";
 import { wrapCommandForWsl } from "./wsl-utils";
 import { resolveCommandDirectory } from "./path-utils";
 import { getEnhancedWindowsEnv } from "./windows-env";
-import { escapeShellArgWindows } from "./shell-utils";
+import { escapeShellArgWindows, getLoginShell } from "./shell-utils";
 
 interface TerminalProcess {
 	id: string;
@@ -84,7 +84,7 @@ export class TerminalManager {
 		}
 		// On macOS and Linux, wrap the command in a login shell to inherit the user's environment
 		else if (Platform.isMacOS || Platform.isLinux) {
-			const shell = Platform.isMacOS ? "/bin/zsh" : "/bin/bash";
+			const shell = getLoginShell();
 			let commandString: string;
 			if (args.length > 0) {
 				// args provided: escape each argument individually


### PR DESCRIPTION
## Description

Replace hardcoded `/bin/bash` and `/bin/zsh` paths with a `getLoginShell()` utility that respects the `$SHELL` environment variable. This fixes compatibility with distributions like NixOS that store shell binaries in non-standard paths (e.g., `/nix/store/.../bash`).

Changes:
- Added `getLoginShell()` to `src/shared/shell-utils.ts` — uses `$SHELL` with fallback to `/bin/zsh` (macOS) or `/bin/sh` (Linux)
- Updated `AcpAdapter.initialize()` and `TerminalManager.createTerminal()` to use the new utility

## Related issue

Related to #131

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: macOS, Linux (Ubuntu)

## Screenshots

N/A
