### PR TITLE
feat: add export chat command to command palette (#135)

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -496,16 +496,33 @@ function ChatComponent({
 			void handleStopGeneration();
 		});
 
+		const exportRef = (
+			workspace as unknown as {
+				on: (
+					name: string,
+					callback: CustomEventCallback,
+				) => ReturnType<typeof workspace.on>;
+			}
+		).on("agent-client:export-chat", (targetViewId?: string) => {
+			// Only respond if this view is the target (or no target specified)
+			if (targetViewId && targetViewId !== viewId) {
+				return;
+			}
+			void handleExportChat();
+		});
+
 		return () => {
 			workspace.offref(approveRef);
 			workspace.offref(rejectRef);
 			workspace.offref(cancelRef);
+			workspace.offref(exportRef);
 		};
 	}, [
 		plugin.app.workspace,
 		permission.approveActivePermission,
 		permission.rejectActivePermission,
 		handleStopGeneration,
+		handleExportChat,
 		viewId,
 	]);
 

--- a/src/components/chat/FloatingChatView.tsx
+++ b/src/components/chat/FloatingChatView.tsx
@@ -674,16 +674,30 @@ function FloatingChatComponent({
 			void handleStopGeneration();
 		});
 
+		const exportRef = (
+			workspace as unknown as {
+				on: (
+					name: string,
+					callback: CustomEventCallback,
+				) => ReturnType<typeof workspace.on>;
+			}
+		).on("agent-client:export-chat", (targetViewId?: string) => {
+			if (targetViewId && targetViewId !== viewId) return;
+			void handleExportChat();
+		});
+
 		return () => {
 			workspace.offref(approveRef);
 			workspace.offref(rejectRef);
 			workspace.offref(cancelRef);
+			workspace.offref(exportRef);
 		};
 	}, [
 		plugin.app.workspace,
 		permission.approveActivePermission,
 		permission.rejectActivePermission,
 		handleStopGeneration,
+		handleExportChat,
 		viewId,
 	]);
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -730,6 +730,17 @@ export default class AgentClientPlugin extends Plugin {
 				);
 			},
 		});
+
+		this.addCommand({
+			id: "export-chat",
+			name: "Export chat",
+			callback: () => {
+				this.app.workspace.trigger(
+					"agent-client:export-chat" as "quit",
+					this.lastActiveChatViewId,
+				);
+			},
+		});
 	}
 
 	/**


### PR DESCRIPTION
## Description

Add an "Export chat" command to the command palette, allowing users to export the active chat session without clicking the header button. Follows the same event-driven pattern as `cancel-current-message` — fires `agent-client:export-chat` via workspace event, handled by both ChatView and FloatingChatView.

## Related issue

Related to #135

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: macOS

## Screenshots

