### PR TITLE
perf: memoize message renderers to fix long session slowdown

### DIFF
--- a/src/components/chat/MessageContentRenderer.tsx
+++ b/src/components/chat/MessageContentRenderer.tsx
@@ -22,7 +22,7 @@ interface MessageContentRendererProps {
 	) => Promise<void>;
 }
 
-export function MessageContentRenderer({
+export const MessageContentRenderer = React.memo(function MessageContentRenderer({
 	content,
 	plugin,
 	messageId,
@@ -130,4 +130,4 @@ export function MessageContentRenderer({
 		default:
 			return <span>Unsupported content type</span>;
 	}
-}
+});

--- a/src/components/chat/MessageRenderer.tsx
+++ b/src/components/chat/MessageRenderer.tsx
@@ -59,7 +59,7 @@ function groupContent(
 	return groups;
 }
 
-export function MessageRenderer({
+export const MessageRenderer = React.memo(function MessageRenderer({
 	message,
 	plugin,
 	acpClient,
@@ -110,4 +110,4 @@ export function MessageRenderer({
 			})}
 		</div>
 	);
-}
+});

--- a/src/components/chat/ToolCallRenderer.tsx
+++ b/src/components/chat/ToolCallRenderer.tsx
@@ -21,7 +21,7 @@ interface ToolCallRendererProps {
 	) => Promise<void>;
 }
 
-export function ToolCallRenderer({
+export const ToolCallRenderer = React.memo(function ToolCallRenderer({
 	content,
 	plugin,
 	acpClient,
@@ -689,4 +689,4 @@ function DiffRenderer({
 			)}
 		</div>
 	);
-}
+});


### PR DESCRIPTION
## Problem

The chat pane becomes progressively slower during long Claude Code sessions. After ~300+ messages with many tool calls and agent thoughts, scrolling gets heavy, streaming feels laggy, and the UI is noticeably sluggish.

I was having this problem with sessions that run for a while - after 200-300 messages the plugin starts to feel really slow. The issue #180 has an excellent root cause analysis that explains why.

## Root Cause (from #180)

When streaming updates arrive (agent_message_chunk, tool_call_update, etc.), the `messages` array is recreated every time. Without `React.memo` on the message rendering components, React has to reconcile ALL historical messages on every single streaming chunk - even though only the latest message is changing.

For a session with 300 messages and 300 tool calls, thats a LOT of wasted re-renders.

## What I changed

Wrapped 3 components in `React.memo`:

1. **`MessageRenderer`** - renders individual chat messages
2. **`MessageContentRenderer`** - renders message content (text, tool calls, images, etc.)
3. **`ToolCallRenderer`** - renders tool call blocks with output, diffs, terminal

The change is minimal - just converting from:
```tsx
export function MessageRenderer({ ... }) {
```
to:
```tsx
export const MessageRenderer = React.memo(function MessageRenderer({ ... }) {
```

`React.memo` does shallow prop comparison, so when the parent re-renders because a NEW message is streaming in, the existing historical messages skip re-rendering because their props (message object reference) havent changed.

## Why this helps

This is the "high priority item #3" from the analysis in #180. Historical messages that are already complete dont need to re-render when a new chunk arrives for the latest message. With memo, only the actively streaming message re-renders on each update.

The issue reporter estimated this would give the biggest improvement alongside virtualization and batched updates. I chose to do the memoization first because its the lowest risk change (no behavioral change, just skipping unnecessary work).

## What I did NOT change

- No virtualization (that would be a larger change)
- No streaming throttle/batching (also larger scope)
- No changes to the useChat hook or state management

These could be done as follow-up PRs for further improvement.

Ref #180