### PR TITLE
fix: floating chat button not hiding when enableFloatingChat is toggle off

### DIFF
--- a/src/components/settings/AgentClientSettingTab.ts
+++ b/src/components/settings/AgentClientSettingTab.ts
@@ -366,8 +366,9 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						const wasEnabled =
 							this.plugin.settings.enableFloatingChat;
-						this.plugin.settings.enableFloatingChat = value;
-						await this.plugin.saveSettings();
+						await this.plugin.settingsStore.updateSettings({
+							enableFloatingChat: value,
+						});
 
 						// Handle dynamic toggle of floating chat
 						if (value && !wasEnabled) {


### PR DESCRIPTION
## Description

Use settingsStore.updateSettings() instead of directly mutating plugin.settings so that React's useSyncExternalStore is notified and FloatingButtonComponent re-renders.

## Related issue

<!-- e.g., Closes #123 -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for braxd names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: <!-- e.g., Claude Code, Codex, Gemini CLI, OpenCode -->
- OS: <!-- e.g., macOS, Windows, Linux -->

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->
