### PR TITLE
feat: add copy-to-clipboard button on message hover

### DIFF
--- a/src/components/chat/MessageRenderer.tsx
+++ b/src/components/chat/MessageRenderer.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { setIcon } from "obsidian";
 import type {
 	ChatMessage,
 	MessageContent,
@@ -6,6 +7,13 @@ import type {
 import type { IAcpClient } from "../../adapters/acp/acp.adapter";
 import type AgentClientPlugin from "../../plugin";
 import { MessageContentRenderer } from "./MessageContentRenderer";
+
+function extractTextContent(contents: MessageContent[]): string {
+	return contents
+		.filter((c) => c.type === "text" || c.type === "text_with_context")
+		.map((c) => ("text" in c ? c.text : ""))
+		.join("\n");
+}
 
 interface MessageRendererProps {
 	message: ChatMessage;
@@ -66,10 +74,34 @@ export const MessageRenderer = React.memo(function MessageRenderer({
 	onApprovePermission,
 }: MessageRendererProps) {
 	const groups = groupContent(message.content);
+	const [copied, setCopied] = React.useState(false);
+	const [hovered, setHovered] = React.useState(false);
+
+	const handleCopy = React.useCallback(() => {
+		const text = extractTextContent(message.content);
+		if (!text) return;
+		void navigator.clipboard.writeText(text).then(() => {
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		});
+	}, [message.content]);
+
+	const copyButtonRef = React.useCallback(
+		(el: HTMLButtonElement | null) => {
+			if (el) setIcon(el, copied ? "check" : "copy");
+		},
+		[copied],
+	);
+
+	const hasText = message.content.some(
+		(c) => (c.type === "text" || c.type === "text_with_context") && c.text,
+	);
 
 	return (
 		<div
 			className={`agent-client-message-renderer ${message.role === "user" ? "agent-client-message-user" : "agent-client-message-assistant"}`}
+			onMouseEnter={hasText ? () => setHovered(true) : undefined}
+			onMouseLeave={hasText ? () => setHovered(false) : undefined}
 		>
 			{groups.map((group, idx) => {
 				if (group.type === "attachments") {
@@ -108,6 +140,16 @@ export const MessageRenderer = React.memo(function MessageRenderer({
 					);
 				}
 			})}
+			{hasText && hovered && (
+				<div className="agent-client-message-actions">
+					<button
+						className="agent-client-message-action-button"
+						onClick={handleCopy}
+						aria-label="Copy message"
+						ref={copyButtonRef}
+					/>
+				</div>
+			)}
 		</div>
 	);
 });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -294,8 +294,7 @@ export default class AgentClientPlugin extends Plugin {
 			checkCallback: (checking) => {
 				if (!this.settings.enableFloatingChat) return false;
 				const focused = this.viewRegistry.getFocused();
-				if (!(focused && focused.viewType === "floating"))
-					return false;
+				if (!(focused && focused.viewType === "floating")) return false;
 				if (checking) return true;
 				focused.collapse();
 			},
@@ -307,8 +306,7 @@ export default class AgentClientPlugin extends Plugin {
 			checkCallback: (checking) => {
 				if (!this.settings.enableFloatingChat) return false;
 				const focused = this.viewRegistry.getFocused();
-				if (!(focused && focused.viewType === "floating"))
-					return false;
+				if (!(focused && focused.viewType === "floating")) return false;
 				if (checking) return true;
 				this.closeFloatingChat(focused.viewId);
 			},

--- a/styles.css
+++ b/styles.css
@@ -1296,6 +1296,7 @@ If your plugin does not need CSS, delete this file.
 
 /* Message Renderer */
 .agent-client-message-renderer {
+	position: relative;
 	padding: 0px 16px;
 	width: 100%;
 	margin: 4px 0;
@@ -1317,6 +1318,37 @@ If your plugin does not need CSS, delete this file.
 	background-color: transparent;
 	border: none;
 	border-radius: 0;
+}
+
+.agent-client-message-actions {
+	position: absolute;
+	bottom: 4px;
+	right: 4px;
+	display: flex;
+	gap: 2px;
+}
+
+.agent-client-message-action-button {
+	background: var(--background-primary);
+	border: 1px solid var(--background-modifier-border);
+	cursor: pointer;
+	color: var(--text-muted);
+	padding: 4px;
+	border-radius: 4px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.agent-client-message-action-button:hover {
+	color: var(--text-normal);
+	background-color: var(--background-modifier-hover);
+}
+
+.agent-client-message-action-button svg {
+	width: 14px;
+	height: 14px;
 }
 
 /* Text with Mentions */


### PR DESCRIPTION
## Description

Show a copy button when hovering over any message (user or assistant) that contains text content. Uses callback ref for reliable icon rendering on conditional mount, and handles text_with_context alongside plain text extraction.

## Related issue

<!-- e.g., Closes #123 -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: <!-- e.g., Claude Code, Codex, Gemini CLI, OpenCode -->
- OS: <!-- e.g., macOS, Windows, Linux -->

## Screenshots

<img width="608" height="386" alt="Screenshot 2026-03-27 at 23 15 35" src="https://github.com/user-attachments/assets/b0d9eb2f-a132-4365-9604-462171692a67" />
