### PR TITLE
fix: enable horizontal scroll for wide markdown content (mermaid, tables, svg)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1350,17 +1350,12 @@ If your plugin does not need CSS, delete this file.
 	max-width: 100%;
 }
 
-.agent-client-markdown-text-renderer .markdown-rendered {
-	font-size: inherit;
-	overflow-wrap: break-word;
-	word-wrap: break-word;
-	word-break: break-word;
-	max-width: 100%;
-}
-
-.agent-client-markdown-text-renderer .markdown-rendered pre {
-	max-width: 100%;
+.agent-client-markdown-text-renderer.markdown-rendered pre,
+.agent-client-markdown-text-renderer.markdown-rendered table,
+.agent-client-markdown-text-renderer.markdown-rendered .mermaid,
+.agent-client-markdown-text-renderer.markdown-rendered svg {
 	overflow-x: auto;
+	display: block;
 }
 
 /* Tool Call Diff Renderer */


### PR DESCRIPTION
## Description

Fix CSS selector from descendant (.a .b) to compound (.a.b) since both classes are on the same element. Remove redundant markdown-rendered rule and max-width constraint that prevented overflow-x scrolling.

## Related issue

<!-- e.g., Closes #123 -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: <!-- e.g., Claude Code, Codex, Gemini CLI, OpenCode -->
- OS: <!-- e.g., macOS, Windows, Linux -->

## Screenshots
<img width="608" height="521" alt="Screenshot 2026-03-27 at 23 18 07" src="https://github.com/user-attachments/assets/e724ffc0-c43d-4a08-a350-1161f57d5bc1" />
