### PR TITLE
[codex] Refine auto-mention selection range formatting

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -29,6 +29,10 @@ import { getLogger } from "../../shared/logger";
 import type { ErrorInfo } from "../../domain/models/agent-error";
 import type { AgentUpdateNotification } from "../../shared/agent-update-checker";
 import { useSettings } from "../../hooks/useSettings";
+import {
+	formatSelectionRangeLabel,
+	toDisplaySelectionRange,
+} from "../../shared/selection-range";
 
 // ============================================================================
 // Image Constants
@@ -1176,12 +1180,12 @@ export function ChatInput({
 							@{autoMention.activeNote.name}
 							{autoMention.activeNote.selection && (
 								<span className="agent-client-selection-indicator">
-									{":"}
-									{autoMention.activeNote.selection.from
-										.line + 1}
-									-
-									{autoMention.activeNote.selection.to.line +
-										1}
+									{" "}
+									{formatSelectionRangeLabel(
+										toDisplaySelectionRange(
+											autoMention.activeNote.selection,
+										),
+									)}
 								</span>
 							)}
 						</span>

--- a/src/components/chat/TextWithMentions.tsx
+++ b/src/components/chat/TextWithMentions.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import type AgentClientPlugin from "../../plugin";
+import { formatSelectionRangeLabel } from "../../shared/selection-range";
 
 interface TextWithMentionsProps {
 	text: string;
@@ -9,7 +10,9 @@ interface TextWithMentionsProps {
 		notePath: string;
 		selection?: {
 			fromLine: number;
+			fromColumn: number;
 			toLine: number;
+			toColumn: number;
 		};
 	};
 }
@@ -27,7 +30,7 @@ export function TextWithMentions({
 	// Add auto-mention badge first if provided
 	if (autoMentionContext) {
 		const displayText = autoMentionContext.selection
-			? `@${autoMentionContext.noteName}:${autoMentionContext.selection.fromLine}-${autoMentionContext.selection.toLine}`
+			? `@${autoMentionContext.noteName} ${formatSelectionRangeLabel(autoMentionContext.selection)}`
 			: `@${autoMentionContext.noteName}`;
 
 		parts.push(

--- a/src/domain/models/chat-message.ts
+++ b/src/domain/models/chat-message.ts
@@ -154,7 +154,9 @@ export type MessageContent =
 				notePath: string;
 				selection?: {
 					fromLine: number;
+					fromColumn: number;
 					toLine: number;
+					toColumn: number;
 				};
 			};
 	  }

--- a/src/shared/chat-exporter.ts
+++ b/src/shared/chat-exporter.ts
@@ -5,6 +5,7 @@ import type {
 } from "../domain/models/chat-message";
 import { getLogger, Logger } from "./logger";
 import { TFile } from "obsidian";
+import { formatSelectionRangeLabel } from "./selection-range";
 
 /**
  * Context for content conversion, tracking state across messages.
@@ -293,7 +294,7 @@ session_id: ${sessionId}${tagsLine}
 				if (content.autoMentionContext) {
 					const { noteName, selection } = content.autoMentionContext;
 					if (selection) {
-						exportText += `@[[${noteName}]]:${selection.fromLine}-${selection.toLine}\n`;
+						exportText += `@[[${noteName}]] ${formatSelectionRangeLabel(selection)}\n`;
 					} else {
 						exportText += `@[[${noteName}]]\n`;
 					}

--- a/src/shared/message-service.ts
+++ b/src/shared/message-service.ts
@@ -34,6 +34,12 @@ import type {
 import { extractMentionedNotes, type IMentionService } from "./mention-utils";
 import { convertWindowsPathToWsl } from "./wsl-utils";
 import { buildFileUri } from "./path-utils";
+import {
+	extractSelectionText,
+	formatAutoMentionPrefix,
+	formatSelectionRangeLabel,
+	toDisplaySelectionRange,
+} from "./selection-range";
 
 // ============================================================================
 // Types
@@ -90,7 +96,9 @@ export interface PreparePromptResult {
 		notePath: string;
 		selection?: {
 			fromLine: number;
+			fromColumn: number;
 			toLine: number;
+			toColumn: number;
 		};
 	};
 }
@@ -259,9 +267,12 @@ async function preparePromptWithEmbeddedContext(
 	// This allows @[[note]] to be restored when loading a saved session
 	const autoMentionPrefix =
 		input.activeNote && !input.isAutoMentionDisabled
-			? input.activeNote.selection
-				? `@[[${input.activeNote.name}]]:${input.activeNote.selection.from.line + 1}-${input.activeNote.selection.to.line + 1}\n`
-				: `@[[${input.activeNote.name}]]\n`
+			? formatAutoMentionPrefix(
+					input.activeNote.name,
+					input.activeNote.selection
+						? toDisplaySelectionRange(input.activeNote.selection)
+						: undefined,
+				)
 			: "";
 
 	const agentContent: PromptContent[] = [
@@ -287,9 +298,9 @@ async function preparePromptWithEmbeddedContext(
 					notePath: input.activeNote.path,
 					selection: input.activeNote.selection
 						? {
-								fromLine:
-									input.activeNote.selection.from.line + 1,
-								toLine: input.activeNote.selection.to.line + 1,
+								...toDisplaySelectionRange(
+									input.activeNote.selection,
+								),
 							}
 						: undefined,
 				}
@@ -365,9 +376,12 @@ async function preparePromptWithTextContext(
 	// This allows @[[note]] to be restored when loading a saved session
 	const autoMentionPrefix =
 		input.activeNote && !input.isAutoMentionDisabled
-			? input.activeNote.selection
-				? `@[[${input.activeNote.name}]]:${input.activeNote.selection.from.line + 1}-${input.activeNote.selection.to.line + 1}\n`
-				: `@[[${input.activeNote.name}]]\n`
+			? formatAutoMentionPrefix(
+					input.activeNote.name,
+					input.activeNote.selection
+						? toDisplaySelectionRange(input.activeNote.selection)
+						: undefined,
+				)
 			: "";
 
 	// Build agent message text (context blocks + auto-mention prefix + original message)
@@ -404,9 +418,9 @@ async function preparePromptWithTextContext(
 					notePath: input.activeNote.path,
 					selection: input.activeNote.selection
 						? {
-								fromLine:
-									input.activeNote.selection.from.line + 1,
-								toLine: input.activeNote.selection.to.line + 1,
+								...toDisplaySelectionRange(
+									input.activeNote.selection,
+								),
 							}
 						: undefined,
 				}
@@ -440,23 +454,21 @@ async function buildAutoMentionResource(
 	const uri = buildFileUri(absolutePath);
 
 	if (activeNote.selection) {
-		// Selection exists - send the selected content as a Resource
-		const fromLine = activeNote.selection.from.line + 1;
-		const toLine = activeNote.selection.to.line + 1;
+		const displayRange = toDisplaySelectionRange(activeNote.selection);
+		const rangeLabel = formatSelectionRangeLabel(displayRange);
 
 		try {
 			const content = await vaultAccess.readNote(activeNote.path);
-			const lines = content.split("\n");
-			const selectedLines = lines.slice(
-				activeNote.selection.from.line,
-				activeNote.selection.to.line + 1,
+			let selectedText = extractSelectionText(
+				content,
+				activeNote.selection,
 			);
-			let selectedText = selectedLines.join("\n");
+			const originalLength = selectedText.length;
 
 			if (selectedText.length > maxSelectionLength) {
 				selectedText =
 					selectedText.substring(0, maxSelectionLength) +
-					`\n\n[Note: Truncated from ${selectedLines.join("\n").length} to ${maxSelectionLength} characters]`;
+					`\n\n[Note: Truncated from ${originalLength} to ${maxSelectionLength} characters]`;
 			}
 
 			return [
@@ -477,7 +489,7 @@ async function buildAutoMentionResource(
 				} as ResourcePromptContent,
 				{
 					type: "text",
-					text: `The user has selected lines ${fromLine}-${toLine} in the above note. This is what they are currently focusing on.`,
+					text: `The user has selected ${rangeLabel} in the above note. This is what they are currently focusing on.`,
 				},
 			];
 		} catch (error) {
@@ -488,7 +500,7 @@ async function buildAutoMentionResource(
 			return [
 				{
 					type: "text",
-					text: `The user has selected lines ${fromLine}-${toLine} in ${uri}. If relevant, use the Read tool to examine the specific lines.`,
+					text: `The user has selected ${rangeLabel} in ${uri}. If relevant, use the Read tool to examine the specific range.`,
 				},
 			];
 		}
@@ -521,26 +533,22 @@ async function buildAutoMentionTextContext(
 	}
 
 	if (selection) {
-		const fromLine = selection.from.line + 1;
-		const toLine = selection.to.line + 1;
+		const displayRange = toDisplaySelectionRange(selection);
+		const rangeLabel = formatSelectionRangeLabel(displayRange);
 
 		try {
 			const content = await vaultAccess.readNote(notePath);
-			const lines = content.split("\n");
-			const selectedLines = lines.slice(
-				selection.from.line,
-				selection.to.line + 1,
-			);
-			let selectedText = selectedLines.join("\n");
+			let selectedText = extractSelectionText(content, selection);
+			const originalLength = selectedText.length;
 
 			let truncationNote = "";
 			if (selectedText.length > maxSelectionLength) {
 				selectedText = selectedText.substring(0, maxSelectionLength);
-				truncationNote = `\n\n[Note: The selection was truncated. Original length: ${selectedLines.join("\n").length} characters, showing first ${maxSelectionLength} characters]`;
+				truncationNote = `\n\n[Note: The selection was truncated. Original length: ${originalLength} characters, showing first ${maxSelectionLength} characters]`;
 			}
 
-			return `<obsidian_opened_note selection="lines ${fromLine}-${toLine}">
-The user opened the note ${absolutePath} in Obsidian and selected the following text (lines ${fromLine}-${toLine}):
+			return `<obsidian_opened_note selection="${rangeLabel}">
+The user opened the note ${absolutePath} in Obsidian and selected the following text (${rangeLabel}):
 
 ${selectedText}${truncationNote}
 
@@ -548,7 +556,7 @@ This is what the user is currently focusing on.
 </obsidian_opened_note>`;
 		} catch (error) {
 			console.error(`Failed to read selection from ${notePath}:`, error);
-			return `<obsidian_opened_note selection="lines ${fromLine}-${toLine}">The user opened the note ${absolutePath} in Obsidian and is focusing on lines ${fromLine}-${toLine}. This may or may not be related to the current conversation. If it seems relevant, consider using the Read tool to examine the specific lines.</obsidian_opened_note>`;
+			return `<obsidian_opened_note selection="${rangeLabel}">The user opened the note ${absolutePath} in Obsidian and is focusing on ${rangeLabel}. This may or may not be related to the current conversation. If it seems relevant, consider using the Read tool to examine the specific range.</obsidian_opened_note>`;
 		}
 	}
 

--- a/src/shared/selection-range.test.ts
+++ b/src/shared/selection-range.test.ts
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+	formatSelectionRangeLabel,
+	formatAutoMentionPrefix,
+	extractSelectionText,
+} from "./selection-range.ts";
+
+test("formatSelectionRangeLabel renders a single-line selection with columns", () => {
+	assert.equal(
+		formatSelectionRangeLabel({
+			fromLine: 45,
+			fromColumn: 12,
+			toLine: 45,
+			toColumn: 28,
+		}),
+		"L45:C12-C28",
+	);
+});
+
+test("formatSelectionRangeLabel renders a multi-line selection with full endpoints", () => {
+	assert.equal(
+		formatSelectionRangeLabel({
+			fromLine: 45,
+			fromColumn: 12,
+			toLine: 47,
+			toColumn: 3,
+		}),
+		"L45:C12-L47:C3",
+	);
+});
+
+test("formatAutoMentionPrefix includes the formatted range when selection exists", () => {
+	assert.equal(
+		formatAutoMentionPrefix("台灣零售與電商競爭分析", {
+			fromLine: 45,
+			fromColumn: 12,
+			toLine: 45,
+			toColumn: 28,
+		}),
+		"@[[台灣零售與電商競爭分析]] L45:C12-C28\n",
+	);
+});
+
+test("formatAutoMentionPrefix falls back to plain note mention without selection", () => {
+	assert.equal(
+		formatAutoMentionPrefix("台灣零售與電商競爭分析"),
+		"@[[台灣零售與電商競爭分析]]\n",
+	);
+});
+
+test("extractSelectionText returns only the selected columns for a single-line selection", () => {
+	assert.equal(
+		extractSelectionText(
+			["0123456789", "abcdefghij"].join("\n"),
+			{
+				from: { line: 0, ch: 2 },
+				to: { line: 0, ch: 6 },
+			},
+		),
+		"2345",
+	);
+});
+
+test("extractSelectionText returns only the selected span for a multi-line selection", () => {
+	assert.equal(
+		extractSelectionText(
+			["0123456789", "abcdefghij", "KLMNOPQRST"].join("\n"),
+			{
+				from: { line: 0, ch: 8 },
+				to: { line: 2, ch: 3 },
+			},
+		),
+		["89", "abcdefghij", "KLM"].join("\n"),
+	);
+});

--- a/src/shared/selection-range.ts
+++ b/src/shared/selection-range.ts
@@ -1,0 +1,81 @@
+import type { EditorPosition } from "../domain/ports/vault-access.port";
+
+export interface DisplaySelectionRange {
+	fromLine: number;
+	fromColumn: number;
+	toLine: number;
+	toColumn: number;
+}
+
+export function toDisplaySelectionRange(selection: {
+	from: EditorPosition;
+	to: EditorPosition;
+}): DisplaySelectionRange {
+	return {
+		fromLine: selection.from.line + 1,
+		fromColumn: selection.from.ch + 1,
+		toLine: selection.to.line + 1,
+		toColumn: selection.to.ch + 1,
+	};
+}
+
+export function formatSelectionRangeLabel(
+	range: DisplaySelectionRange,
+): string {
+	if (range.fromLine === range.toLine) {
+		return `L${range.fromLine}:C${range.fromColumn}-C${range.toColumn}`;
+	}
+
+	return `L${range.fromLine}:C${range.fromColumn}-L${range.toLine}:C${range.toColumn}`;
+}
+
+export function formatAutoMentionPrefix(
+	noteName: string,
+	range?: DisplaySelectionRange,
+): string {
+	const base = `@[[${noteName}]]`;
+	return range ? `${base} ${formatSelectionRangeLabel(range)}\n` : `${base}\n`;
+}
+
+export function extractSelectionText(
+	content: string,
+	selection: {
+		from: EditorPosition;
+		to: EditorPosition;
+	},
+): string {
+	const lines = content.split("\n");
+
+	if (selection.from.line === selection.to.line) {
+		return (
+			lines[selection.from.line]?.slice(
+				selection.from.ch,
+				selection.to.ch,
+			) ?? ""
+		);
+	}
+
+	const selectedParts: string[] = [];
+
+	for (
+		let lineIndex = selection.from.line;
+		lineIndex <= selection.to.line;
+		lineIndex++
+	) {
+		const line = lines[lineIndex] ?? "";
+
+		if (lineIndex === selection.from.line) {
+			selectedParts.push(line.slice(selection.from.ch));
+			continue;
+		}
+
+		if (lineIndex === selection.to.line) {
+			selectedParts.push(line.slice(0, selection.to.ch));
+			continue;
+		}
+
+		selectedParts.push(line);
+	}
+
+	return selectedParts.join("\n");
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,6 @@
 		"lib": ["DOM", "ES5", "ES6", "ES7"],
 		"jsx": "react-jsx"
 	},
-	"include": ["src/**/*.ts", "src/**/*.tsx"]
+	"include": ["src/**/*.ts", "src/**/*.tsx"],
+	"exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- switch auto-mention selection labels from line-only ranges to explicit line/column ranges such as `L45:C12-C28`
- reuse the same range formatter across the input badge, chat message rendering, exported markdown, and prompt prefixes
- extract selected text by exact columns instead of whole-line slicing so partial-line edits send precise context to the agent

## Why
The previous auto-mention format only showed line ranges like `45-45`, which was ambiguous for single-line partial selections. It also sent the full selected lines to the agent even when the user highlighted only part of a line. This made fine-grained edit requests harder to target.

## Changes
- add `selection-range.ts` to centralize display formatting and exact selection extraction
- extend auto-mention selection metadata to include columns
- update `message-service` to use the new formatter and exact selection slicing in both embedded-context and text-context flows
- update the chat input badge, message rendering, and markdown export to display the same `Lx:Cy...` format
- add targeted tests for range formatting and exact selection extraction
- exclude `*.test.ts` from the plugin TypeScript build so test helpers do not block plugin bundling

## Validation
- `node --test src/shared/selection-range.test.ts`
- `npm run build`
- locally deployed and reloaded the plugin in Obsidian for manual verification
