### PR TITLE
Render tool content and collapse tool output by default

### DIFF
--- a/src/acp/type-converter.ts
+++ b/src/acp/type-converter.ts
@@ -36,8 +36,7 @@ export class AcpTypeConverter {
 	 * Convert ACP ToolCallContent to domain ToolCallContent.
 	 *
 	 * Filters out content types that are not supported by the domain model:
-	 * - Supports: "diff", "terminal"
-	 * - Ignores: "content" (not implemented in UI)
+	 * - Supports: "diff", "terminal", "content" (text)
 	 *
 	 * @param acpContent - Tool call content from ACP protocol
 	 * @returns Domain model tool call content, or undefined if input is null/empty
@@ -75,8 +74,14 @@ export class AcpTypeConverter {
 					type: "terminal",
 					terminalId: item.terminalId,
 				});
+			} else if (item.type === "content") {
+				if (item.content?.type === "text") {
+					converted.push({
+						type: "content",
+						text: item.content.text,
+					});
+				}
 			}
-			// "content" type is intentionally ignored (not implemented in UI)
 		}
 
 		return converted.length > 0 ? converted : undefined;

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -46,7 +46,7 @@ export type ToolKind =
  * Content that can be included in a tool call result.
  * Currently supports diffs and terminal output.
  */
-export type ToolCallContent = DiffContent | TerminalContent;
+export type ToolCallContent = DiffContent | TerminalContent | TextToolContent;
 
 /**
  * Represents a file modification with before/after content.
@@ -64,6 +64,15 @@ export interface DiffContent {
 export interface TerminalContent {
 	type: "terminal";
 	terminalId: string;
+}
+
+/**
+ * Plain text tool output content.
+ * Used by ACP tool_call/tool_call_update payloads with content.type === "content".
+ */
+export interface TextToolContent {
+	type: "content";
+	text: string;
 }
 
 // ============================================================================

--- a/src/ui/ToolCallBlock.tsx
+++ b/src/ui/ToolCallBlock.tsx
@@ -43,9 +43,6 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 	const [selectedOptionId, setSelectedOptionId] = useState<
 		string | undefined
 	>(permissionRequest?.selectedOptionId);
-	const hasToolOutput = Boolean(toolContent && toolContent.length > 0);
-	const [isOutputExpanded, setIsOutputExpanded] = useState(false);
-	const hadToolOutputRef = React.useRef(hasToolOutput);
 
 	// Update selectedOptionId when permissionRequest changes
 	React.useEffect(() => {
@@ -53,18 +50,6 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 			setSelectedOptionId(permissionRequest?.selectedOptionId);
 		}
 	}, [permissionRequest?.selectedOptionId]);
-
-	React.useEffect(() => {
-		if (!hadToolOutputRef.current && hasToolOutput) {
-			setIsOutputExpanded(status === "failed");
-		}
-
-		if (status === "failed") {
-			setIsOutputExpanded(true);
-		}
-
-		hadToolOutputRef.current = hasToolOutput;
-	}, [hasToolOutput, status]);
 
 	// Get vault path for relative path display
 	const vaultPath = useMemo(() => {
@@ -125,27 +110,6 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 						/>
 					)}
 				</div>
-				{hasToolOutput && (
-					<button
-						type="button"
-						className="agent-client-tool-call-output-toggle"
-						onClick={() => setIsOutputExpanded(!isOutputExpanded)}
-					>
-						<span className="agent-client-tool-call-output-toggle-text">
-							{isOutputExpanded
-								? "Hide tool output"
-								: "Show tool output"}
-						</span>
-						<LucideIcon
-							name={
-								isOutputExpanded
-									? "chevron-up"
-									: "chevron-right"
-							}
-							className="agent-client-tool-call-output-toggle-icon"
-						/>
-					</button>
-				)}
 				{kind === "execute" &&
 					rawInput &&
 					typeof rawInput.command === "string" && (
@@ -174,8 +138,7 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 			</div>
 
 			{/* Tool call content (diffs, terminal output, etc.) */}
-			{isOutputExpanded &&
-				toolContent &&
+			{toolContent &&
 				toolContent.map((item, index) => {
 					if (item.type === "terminal") {
 						return (

--- a/src/ui/ToolCallBlock.tsx
+++ b/src/ui/ToolCallBlock.tsx
@@ -9,7 +9,7 @@ import { PermissionBanner } from "./PermissionBanner";
 import { LucideIcon } from "./shared/IconButton";
 import { toRelativePath } from "../utils/paths";
 import * as Diff from "diff";
-// import { MarkdownRenderer } from "./shared/MarkdownRenderer";
+import { MarkdownRenderer } from "./shared/MarkdownRenderer";
 
 interface ToolCallBlockProps {
 	content: Extract<MessageContent, { type: "tool_call" }>;
@@ -43,6 +43,9 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 	const [selectedOptionId, setSelectedOptionId] = useState<
 		string | undefined
 	>(permissionRequest?.selectedOptionId);
+	const hasToolOutput = Boolean(toolContent && toolContent.length > 0);
+	const [isOutputExpanded, setIsOutputExpanded] = useState(false);
+	const hadToolOutputRef = React.useRef(hasToolOutput);
 
 	// Update selectedOptionId when permissionRequest changes
 	React.useEffect(() => {
@@ -50,6 +53,18 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 			setSelectedOptionId(permissionRequest?.selectedOptionId);
 		}
 	}, [permissionRequest?.selectedOptionId]);
+
+	React.useEffect(() => {
+		if (!hadToolOutputRef.current && hasToolOutput) {
+			setIsOutputExpanded(status === "failed");
+		}
+
+		if (status === "failed") {
+			setIsOutputExpanded(true);
+		}
+
+		hadToolOutputRef.current = hasToolOutput;
+	}, [hasToolOutput, status]);
 
 	// Get vault path for relative path display
 	const vaultPath = useMemo(() => {
@@ -110,6 +125,27 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 						/>
 					)}
 				</div>
+				{hasToolOutput && (
+					<button
+						type="button"
+						className="agent-client-tool-call-output-toggle"
+						onClick={() => setIsOutputExpanded(!isOutputExpanded)}
+					>
+						<span className="agent-client-tool-call-output-toggle-text">
+							{isOutputExpanded
+								? "Hide tool output"
+								: "Show tool output"}
+						</span>
+						<LucideIcon
+							name={
+								isOutputExpanded
+									? "chevron-up"
+									: "chevron-right"
+							}
+							className="agent-client-tool-call-output-toggle-icon"
+						/>
+					</button>
+				)}
 				{kind === "execute" &&
 					rawInput &&
 					typeof rawInput.command === "string" && (
@@ -138,7 +174,8 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 			</div>
 
 			{/* Tool call content (diffs, terminal output, etc.) */}
-			{toolContent &&
+			{isOutputExpanded &&
+				toolContent &&
 				toolContent.map((item, index) => {
 					if (item.type === "terminal") {
 						return (
@@ -165,6 +202,19 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 										.diffCollapseThreshold
 								}
 							/>
+						);
+					}
+					if (item.type === "content") {
+						return (
+							<div
+								key={index}
+								className="agent-client-message-tool-call-content"
+							>
+								<MarkdownRenderer
+									text={item.text}
+									plugin={plugin}
+								/>
+							</div>
 						);
 					}
 					return null;

--- a/styles.css
+++ b/styles.css
@@ -251,32 +251,14 @@ If your plugin does not need CSS, delete this file.
 	font-size: 0.9em;
 }
 
-.agent-client-tool-call-output-toggle {
-	margin-left: auto;
-	display: inline-flex;
-	align-items: center;
-	gap: 4px;
-	padding: 2px 6px !important;
-	border: 1px solid var(--background-modifier-border) !important;
-	border-radius: 4px !important;
-	background: var(--background-secondary) !important;
-	color: var(--text-muted) !important;
-	font-size: 0.85em;
-	cursor: pointer;
-	outline: none !important;
-	box-shadow: none !important;
-	min-height: unset !important;
-	line-height: 1.2;
-}
-
-.agent-client-tool-call-output-toggle:hover {
-	background: var(--background-modifier-hover) !important;
-	color: var(--text-normal) !important;
-}
-
-.agent-client-tool-call-output-toggle-icon svg {
-	width: 13px;
-	height: 13px;
+.agent-client-message-tool-call-content {
+	padding: 8px 12px;
+	font-size: 13px;
+	user-select: text;
+	overflow-wrap: break-word;
+	word-wrap: break-word;
+	word-break: break-word;
+	max-width: 100%;
 }
 
 /* Plan */

--- a/styles.css
+++ b/styles.css
@@ -251,6 +251,34 @@ If your plugin does not need CSS, delete this file.
 	font-size: 0.9em;
 }
 
+.agent-client-tool-call-output-toggle {
+	margin-left: auto;
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 2px 6px !important;
+	border: 1px solid var(--background-modifier-border) !important;
+	border-radius: 4px !important;
+	background: var(--background-secondary) !important;
+	color: var(--text-muted) !important;
+	font-size: 0.85em;
+	cursor: pointer;
+	outline: none !important;
+	box-shadow: none !important;
+	min-height: unset !important;
+	line-height: 1.2;
+}
+
+.agent-client-tool-call-output-toggle:hover {
+	background: var(--background-modifier-hover) !important;
+	color: var(--text-normal) !important;
+}
+
+.agent-client-tool-call-output-toggle-icon svg {
+	width: 13px;
+	height: 13px;
+}
+
 /* Plan */
 .agent-client-message-plan {
 	padding: 8px;


### PR DESCRIPTION
## Description

This PR improves tool-call output rendering in the Obsidian Agent Client UI and reduces duplicate visual noise in chat.

### What changed

1. Added support for ACP tool content items of type `content` so text output from tools is rendered in the tool block.
2. Added a collapsible tool output section in each tool-call block.
3. Tool output is hidden by default and can be expanded with a toggle.
4. Tool output auto-expands when a tool call fails so error details are immediately visible.
5. Added styling for the new show/hide control.

### Why

When agents summarize tool output in their assistant message, users were seeing the same report twice (once in tool output and again in assistant text).  
Collapsing tool output by default keeps chat readable while preserving full details on demand.

## Related issue

N/A

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [ ] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

Lint note: current branch still reports existing baseline sentence-case lint violations in unrelated files.

## Testing environment

- Agent: OpenCode (via ACP in Obsidian Agent Client)
- OS: macOS

## Screenshots
Default collapsed tool output:
<img width="990" height="421" alt="Screenshot 2026-04-21 at 1 33 39 PM" src="https://github.com/user-attachments/assets/43eff50e-da4c-4701-b513-bea6208a7cee" />
Clip to open and see detailed tool output:
<img width="972" height="218" alt="Screenshot 2026-04-21 at 1 33 57 PM" src="https://github.com/user-attachments/assets/f6f8e676-16b7-4864-982e-302fa4c88087" />


