### PR TITLE
fix: fit floating window to viewport on expand and screen resize

### DIFF
--- a/src/ui/FloatingChatView.tsx
+++ b/src/ui/FloatingChatView.tsx
@@ -25,6 +25,16 @@ import { useSettings } from "../hooks/useSettings";
 // Helpers
 // ============================================================
 
+function clampSize(
+	width: number,
+	height: number,
+): { width: number; height: number } {
+	return {
+		width: Math.min(width, window.innerWidth),
+		height: Math.min(height, window.innerHeight),
+	};
+}
+
 function clampPosition(
 	x: number,
 	y: number,
@@ -35,6 +45,17 @@ function clampPosition(
 		x: Math.max(0, Math.min(x, window.innerWidth - width)),
 		y: Math.max(0, Math.min(y, window.innerHeight - height)),
 	};
+}
+
+function fitToViewport(
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+): { position: { x: number; y: number }; size: { width: number; height: number } } {
+	const size = clampSize(width, height);
+	const position = clampPosition(x, y, size.width, size.height);
+	return { position, size };
 }
 
 // ============================================================
@@ -297,6 +318,36 @@ function FloatingChatComponent({
 	useEffect(() => {
 		onExpandedChange?.(isExpanded);
 	}, [isExpanded, onExpandedChange]);
+
+	// Keep refs up-to-date for viewport resize handler
+	const positionRef = useRef(position);
+	const sizeRef = useRef(size);
+	useEffect(() => { positionRef.current = position; }, [position]);
+	useEffect(() => { sizeRef.current = size; }, [size]);
+
+	// Fit to viewport on expand, and re-fit whenever the viewport resizes
+	useEffect(() => {
+		if (!isExpanded) return;
+
+		const adjust = () => {
+			const { position: newPos, size: newSize } = fitToViewport(
+				positionRef.current.x,
+				positionRef.current.y,
+				sizeRef.current.width,
+				sizeRef.current.height,
+			);
+			if (newSize.width !== sizeRef.current.width || newSize.height !== sizeRef.current.height) {
+				setSize(newSize);
+			}
+			if (newPos.x !== positionRef.current.x || newPos.y !== positionRef.current.y) {
+				setPosition(newPos);
+			}
+		};
+
+		adjust();
+		window.addEventListener("resize", adjust);
+		return () => window.removeEventListener("resize", adjust);
+	}, [isExpanded]);
 
 	// Notify parent of container ref
 	useEffect(() => {


### PR DESCRIPTION
When the saved window size or position places the resize handle outside the current viewport (e.g. after moving to a smaller screen), the window is now automatically clamped to fit. Adds clampSize/fitToViewport helpers and a window resize listener that re-fits the window whenever the Obsidian frame changes dimensions.

