### PR TITLE
fix: guard registerView against hot-reload race condition

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -224,6 +224,10 @@ export default class AgentClientPlugin extends Plugin {
 		// Initialize settings store
 		this.settingsService = createSettingsService(this.settings, this);
 
+		// Detach stale leaves from a previous plugin instance to prevent
+		// "Attempting to register an existing view type" when Obsidian's
+		// hot-reload races onunload/onload (e.g. rapid toggle or npm run dev).
+		this.app.workspace.detachLeavesOfType(VIEW_TYPE_CHAT);
 		this.registerView(VIEW_TYPE_CHAT, (leaf) => new ChatView(leaf, this));
 
 		const ribbonIconEl = this.addRibbonIcon(


### PR DESCRIPTION
## Description

Rapid plugin toggle (3+ times in quick succession) causes a `registerView` error: *"Attempting to register an existing view type."* This can leave a zombie plugin instance running while Obsidian's UI shows it as disabled.

**Root cause:** `onunload()` from one toggle cycle hasn't completed before the next `onload()` fires. The stale view type registration from the previous instance collides with the new one.

**Fix:** Add `this.app.workspace.detachLeavesOfType(VIEW_TYPE_CHAT)` before `registerView()` in `onload()`. This forces stale leaves from a previous instance to detach and deregister the view type before re-registering.

**Files changed:** `src/plugin.ts` (+4 lines)

## Related issue

Fixes #235

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Kiro
- OS: macOS