### PR TITLE
fix: use checkCallback for commands to prevent floating chat focus steal

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -667,10 +667,14 @@ export default class AgentClientPlugin extends Plugin {
 			this.addCommand({
 				id: `switch-agent-to-${agent.id}`,
 				name: `Switch agent to ${agent.displayName}`,
-				callback: () => {
+				checkCallback: (checking) => {
+					const view =
+						this.app.workspace.getActiveViewOfType(ChatView);
+					if (!view) return false;
+					if (checking) return true;
 					this.app.workspace.trigger(
 						"agent-client:new-chat-requested" as "quit",
-						this.lastActiveChatViewId,
+						view.viewId,
 						agent.id,
 					);
 				},
@@ -682,10 +686,14 @@ export default class AgentClientPlugin extends Plugin {
 		this.addCommand({
 			id: "approve-active-permission",
 			name: "Approve active permission",
-			callback: () => {
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:approve-active-permission" as "quit",
-					this.lastActiveChatViewId,
+					view.viewId,
 				);
 			},
 		});
@@ -693,10 +701,14 @@ export default class AgentClientPlugin extends Plugin {
 		this.addCommand({
 			id: "reject-active-permission",
 			name: "Reject active permission",
-			callback: () => {
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:reject-active-permission" as "quit",
-					this.lastActiveChatViewId,
+					view.viewId,
 				);
 			},
 		});
@@ -704,10 +716,14 @@ export default class AgentClientPlugin extends Plugin {
 		this.addCommand({
 			id: "toggle-auto-mention",
 			name: "Toggle auto-mention",
-			callback: () => {
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:toggle-auto-mention" as "quit",
-					this.lastActiveChatViewId,
+					view.viewId,
 				);
 			},
 		});
@@ -715,10 +731,14 @@ export default class AgentClientPlugin extends Plugin {
 		this.addCommand({
 			id: "new-chat",
 			name: "New chat",
-			callback: () => {
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:new-chat-requested" as "quit",
-					this.lastActiveChatViewId,
+					view.viewId,
 				);
 			},
 		});
@@ -726,10 +746,14 @@ export default class AgentClientPlugin extends Plugin {
 		this.addCommand({
 			id: "cancel-current-message",
 			name: "Cancel current message",
-			callback: () => {
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:cancel-message" as "quit",
-					this.lastActiveChatViewId,
+					view.viewId,
 				);
 			},
 		});
@@ -737,10 +761,14 @@ export default class AgentClientPlugin extends Plugin {
 		this.addCommand({
 			id: "export-chat",
 			name: "Export chat",
-			callback: () => {
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:export-chat" as "quit",
-					this.lastActiveChatViewId,
+					view.viewId,
 				);
 			},
 		});


### PR DESCRIPTION
## Description

Sidebar panel hotkeys (`new-chat`, `approve-active-permission`, `cancel-current-message`, `export-chat`, `switch-agent-to-*`, etc.) stop responding when a floating chat window is open. Closing the floating window restores hotkey functionality.

**Root cause:** Two problems compound:

1. **Mount-time focus steal.** The floating chat's `ChatPanel` calls `plugin.setLastActiveChatViewId(viewId)` on mount, unconditionally setting `focusedViewId` to `"floating-chat-0"`.

2. **Commands use `callback` instead of `checkCallback`.** All affected commands use plain `callback` which is always available globally. They route through `getActiveChatView()` which searches only sidebar leaves for a match against `viewRegistry.focusedViewId`. When the focused ID is `"floating-chat-0"`, no sidebar leaf matches, and `getActiveChatView()` returns `null` – all commands silently no-op.

Ironically, the floating chat commands (`open-floating-chat-view`, `minimize-floating-chat-view`, `close-floating-chat-view`) already use `checkCallback` correctly.

**Fix:** Switch all affected commands from `callback` to `checkCallback` + `this.app.workspace.getActiveViewOfType(ChatView)`. This uses Obsidian's native workspace focus tracking (which leaf is active) instead of the plugin's custom `viewRegistry.focusedViewId`. Obsidian's focus tracking ignores floating windows (they aren't workspace leaves), so hotkeys route correctly regardless of floating chat state.

**Files changed:** `src/plugin.ts` (+42, -14)

## Related issue

Fixes #239

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Kiro
- OS: macOS