### PR TITLE
fix: stabilize attachment remove button with stable refs

### DIFF
--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -358,6 +358,7 @@ export function InputArea({
 	const removeFile = useCallback(
 		(id: string) => {
 			onAttachedFilesChange(attachedFiles.filter((f) => f.id !== id));
+			textareaRef.current?.focus();
 		},
 		[attachedFiles, onAttachedFilesChange],
 	);

--- a/src/ui/shared/AttachmentStrip.tsx
+++ b/src/ui/shared/AttachmentStrip.tsx
@@ -1,10 +1,48 @@
 import * as React from "react";
+import { useRef, useEffect } from "react";
 import { setIcon } from "obsidian";
 import type { AttachedFile } from "../../types/chat";
 
 interface AttachmentStripProps {
 	files: AttachedFile[];
 	onRemove: (id: string) => void;
+}
+
+/** Remove button with a stable ref so setIcon runs once on mount. */
+function RemoveButton({
+	fileId,
+	onRemove,
+}: {
+	fileId: string;
+	onRemove: (id: string) => void;
+}) {
+	const ref = useRef<HTMLButtonElement>(null);
+	useEffect(() => {
+		if (ref.current) setIcon(ref.current, "x");
+	}, []);
+	return (
+		<button
+			ref={ref}
+			className="agent-client-attachment-preview-remove"
+			onClick={() => onRemove(fileId)}
+			title="Remove attachment"
+			type="button"
+		/>
+	);
+}
+
+/** File icon with a stable ref so setIcon runs once on mount. */
+function FileIcon() {
+	const ref = useRef<HTMLSpanElement>(null);
+	useEffect(() => {
+		if (ref.current) setIcon(ref.current, "file");
+	}, []);
+	return (
+		<span
+			ref={ref}
+			className="agent-client-attachment-preview-file-icon"
+		/>
+	);
 }
 
 /**
@@ -30,26 +68,13 @@ export function AttachmentStrip({ files, onRemove }: AttachmentStripProps) {
 						/>
 					) : (
 						<div className="agent-client-attachment-preview-file">
-							<span
-								className="agent-client-attachment-preview-file-icon"
-								ref={(el) => {
-									if (el) setIcon(el, "file");
-								}}
-							/>
+							<FileIcon />
 							<span className="agent-client-attachment-preview-file-name">
 								{file.name ?? "file"}
 							</span>
 						</div>
 					)}
-					<button
-						className="agent-client-attachment-preview-remove"
-						onClick={() => onRemove(file.id)}
-						title="Remove attachment"
-						type="button"
-						ref={(el) => {
-							if (el) setIcon(el, "x");
-						}}
-					/>
+					<RemoveButton fileId={file.id} onRemove={onRemove} />
 				</div>
 			))}
 		</div>


### PR DESCRIPTION
## Description

The attachment remove button (`×`) in the chat input does not work. Clicking it has no effect – the attachment is not removed.

**Root cause:** The remove button in `AttachmentStrip.tsx` uses an inline callback ref:

```tsx
ref={(el) => {
    if (el) setIcon(el, "x");
}}
```

This creates a new function reference every render. React treats the changed callback ref as unmount/remount – calling `setIcon()` (which does `el.empty()` + append SVG) on every render cycle. Clicks on the `×` SVG get swallowed when the SVG child is replaced between mousedown and mouseup.

This is the same root cause class as the scroll-to-bottom button and context note toggle button – all use inline callback refs with `setIcon`.

**Fix:** Extract the remove button into a `RemoveButton` component with a stable `useRef` + `useEffect` for `setIcon`. The icon is set once on mount and the click handler uses a stable ref. Also adds focus restoration to the textarea after removal for keyboard accessibility.

**Files changed:** `src/ui/shared/AttachmentStrip.tsx` (+41, -15), `src/ui/InputArea.tsx` (+1)

## Related issue

Fixes #237

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Kiro
- OS: macOS