### PR TITLE
fix: propagate auto-allow permission setting to running agents

### DIFF
--- a/src/acp/acp-client.ts
+++ b/src/acp/acp-client.ts
@@ -385,6 +385,14 @@ export class AcpClient {
 	}
 
 	/**
+	 * Update the auto-allow permission setting on a live client.
+	 * Called by the plugin when the setting changes at runtime.
+	 */
+	updateAutoAllow(autoAllow: boolean): void {
+		this.permissionManager.setAutoAllow(autoAllow);
+	}
+
+	/**
 	 * Create a new chat session with the agent.
 	 */
 	async newSession(workingDirectory: string): Promise<SessionResult> {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -398,6 +398,16 @@ export default class AgentClientPlugin extends Plugin {
 	}
 
 	/**
+	 * Update auto-allow permission setting on all live AcpClient instances.
+	 * Called when the setting changes at runtime.
+	 */
+	updateAllAutoAllow(autoAllow: boolean): void {
+		for (const client of this._acpClients.values()) {
+			client.updateAutoAllow(autoAllow);
+		}
+	}
+
+	/**
 	 * Remove and disconnect the AcpClient for a specific view.
 	 * Called when a ChatView is closed.
 	 */

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -422,6 +422,8 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.autoAllowPermissions = value;
 						await this.plugin.saveSettings();
+						// Propagate to all live AcpClient instances
+						this.plugin.updateAllAutoAllow(value);
 					}),
 			);
 


### PR DESCRIPTION
## Description

Toggling "Auto-allow permissions" in plugin settings persists the value but has no effect on already-connected agents. Permission prompts continue to appear until the plugin or agent is restarted.

**Root cause:** `PermissionManager.setAutoAllow()` is only called during `AcpClient.initialize()` – when the agent first connects. The settings toggle calls `saveSettings()` which writes to `data.json`, but never propagates the new value to the `PermissionManager` instances in running `AcpClient`s. Each `PermissionManager` retains the stale `autoAllow: false` from when its agent connected.

**Fix:**

1. **`acp-client.ts`:** Add `updateAutoAllow(autoAllow: boolean)` public method that calls `this.permissionManager.setAutoAllow(autoAllow)`.
2. **`plugin.ts`:** Add `updateAllAutoAllow(autoAllow: boolean)` that iterates `_acpClients` and calls each client's `updateAutoAllow()`.
3. **`SettingsTab.ts`:** The auto-allow toggle's `onChange` calls `this.plugin.updateAllAutoAllow(value)` after `saveSettings()`.

**Files changed:** `src/acp/acp-client.ts` (+8), `src/plugin.ts` (+10), `src/ui/SettingsTab.ts` (+2)

## Related issue

N/A – discovered during development, filing fix directly per CONTRIBUTING.md (bug fixes can go straight to PR).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Kiro
- OS: macOS