### PR TITLE
fix: make cancel() idempotent when already disconnected

### DIFF
--- a/src/acp/acp-client.ts
+++ b/src/acp/acp-client.ts
@@ -498,13 +498,15 @@ export class AcpClient {
 	 * Cancel the current operation in a session.
 	 */
 	async cancel(sessionId: string): Promise<void> {
+		if (!this.connection) {
+			this.cancelAllOperations();
+			return;
+		}
 		try {
-			const connection = this.requireConnection();
-
 			this.logger.log(
 				"[AcpClient] Sending session/cancel notification...",
 			);
-			await connection.cancel({ sessionId });
+			await this.connection.cancel({ sessionId });
 			this.logger.log(
 				"[AcpClient] Cancellation request sent successfully",
 			);


### PR DESCRIPTION
## Description

Closing a tab (or an Obsidian leaf with an active session) logs a spurious warning to the developer console:

```
[AcpClient] Failed to send cancellation: Error: Connection not initialized. Call initialize() first.
```

No user-visible error. The tab closes correctly, the agent process is killed, no data is lost. But the console noise is confusing during debugging.

**Root cause:** Two async cleanup paths race when a tab closes:

- **Path A** (`handleCloseTab`): `removeClient(tabId)` → `client.disconnect()` → sets `this.connection = null`
- **Path B** (ChatPanel unmount): `closeSession()` → `agentClient.cancel(sessionId)` → `requireConnection()` → throws because connection is already null

Path A fires first (imperative call), then Path B fires when React unmounts the ChatPanel. By the time `cancel()` runs, `disconnect()` has already nulled the connection.

**Fix:** Make `cancel()` a no-op when already disconnected. Replace `requireConnection()` with a direct `this.connection` null check. If disconnected, still call `cancelAllOperations()` for local cleanup but skip the wire call. This makes `cancel()` idempotent-safe – the correct semantic when there is nothing to cancel on the wire.

**Files changed:** `src/acp/acp-client.ts` (+5, -3)

## Related issue

N/A – discovered during development, filing fix directly per CONTRIBUTING.md (bug fixes can go straight to PR).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Kiro
- OS: macOS