### PR TITLE
feat: internal tabbed multi-session support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ dev/
 
 # Local implementation plans and working documents
 plan/
+
+# Local dev tooling
+acp-swap.sh

--- a/src/hooks/useChatActions.ts
+++ b/src/hooks/useChatActions.ts
@@ -177,28 +177,32 @@ export function useChatActions(
 				}
 			}
 
-			await agent.sendMessage(content, {
-				activeNote: settings.autoMentionActiveNote
-					? suggestions.mentions.activeNote
-					: null,
-				vaultBasePath: vaultPath,
-				isAutoMentionDisabled:
-					suggestions.mentions.isAutoMentionDisabled,
-				images: images.length > 0 ? images : undefined,
-				resourceLinks:
-					resourceLinks.length > 0 ? resourceLinks : undefined,
-				isFirstMessage,
-			});
+			try {
+				await agent.sendMessage(content, {
+					activeNote: settings.autoMentionActiveNote
+						? suggestions.mentions.activeNote
+						: null,
+					vaultBasePath: vaultPath,
+					isAutoMentionDisabled:
+						suggestions.mentions.isAutoMentionDisabled,
+					images: images.length > 0 ? images : undefined,
+					resourceLinks:
+						resourceLinks.length > 0 ? resourceLinks : undefined,
+					isFirstMessage,
+				});
 
-			// Save session metadata locally on first message
-			if (isFirstMessage && session.sessionId) {
-				await sessionHistory.saveSessionLocally(
-					session.sessionId,
-					content,
-				);
-				logger.log(
-					`[ChatPanel] Session saved locally: ${session.sessionId}`,
-				);
+				// Save session metadata locally on first message
+				if (isFirstMessage && session.sessionId) {
+					await sessionHistory.saveSessionLocally(
+						session.sessionId,
+						content,
+					);
+					logger.log(
+						`[ChatPanel] Session saved locally: ${session.sessionId}`,
+					);
+				}
+			} catch (error) {
+				logger.error("[ChatPanel] Send message error:", error);
 			}
 		},
 		[
@@ -219,7 +223,11 @@ export function useChatActions(
 	const handleStopGeneration = useCallback(async () => {
 		logger.log("Cancelling current operation...");
 		const lastMessage = agent.lastUserMessage;
-		await agent.cancelOperation();
+		try {
+			await agent.cancelOperation();
+		} catch (error) {
+			logger.error("[ChatPanel] Cancel operation error:", error);
+		}
 		if (lastMessage) {
 			setRestoredMessage(lastMessage);
 		}
@@ -236,30 +244,35 @@ export function useChatActions(
 				return;
 			}
 
-			// Cancel ongoing generation before starting new chat
-			if (agent.isSending) {
-				await agent.cancelOperation();
+			try {
+				// Cancel ongoing generation before starting new chat
+				if (agent.isSending) {
+					await agent.cancelOperation();
+				}
+
+				logger.log(
+					`[Debug] Creating new session${isAgentSwitch ? ` with agent: ${requestedAgentId}` : ""}...`,
+				);
+
+				// Auto-export current chat before starting new one (if has messages)
+				if (messages.length > 0) {
+					await autoExportIfEnabled("newChat", messages, session);
+				}
+
+				suggestions.mentions.toggleAutoMention(false);
+				agent.clearMessages();
+
+				const newAgentId = isAgentSwitch
+					? requestedAgentId
+					: session.agentId;
+				await agent.restartSession(newAgentId);
+
+				// Invalidate session history cache when creating new session
+				sessionHistory.invalidateCache();
+			} catch (error) {
+				logger.error("[ChatPanel] New chat error:", error);
+				new Notice("[Agent Client] Failed to create new session");
 			}
-
-			logger.log(
-				`[Debug] Creating new session${isAgentSwitch ? ` with agent: ${requestedAgentId}` : ""}...`,
-			);
-
-			// Auto-export current chat before starting new one (if has messages)
-			if (messages.length > 0) {
-				await autoExportIfEnabled("newChat", messages, session);
-			}
-
-			suggestions.mentions.toggleAutoMention(false);
-			agent.clearMessages();
-
-			const newAgentId = isAgentSwitch
-				? requestedAgentId
-				: session.agentId;
-			await agent.restartSession(newAgentId);
-
-			// Invalidate session history cache when creating new session
-			sessionHistory.invalidateCache();
 		},
 		[
 			messages,

--- a/src/hooks/useHistoryModal.ts
+++ b/src/hooks/useHistoryModal.ts
@@ -28,6 +28,7 @@ export function useHistoryModal(
 	debugMode: boolean,
 	onAgentCwdChange?: (cwd: string) => void,
 	onLabelChange?: (label: string) => void,
+	currentSessionId?: string,
 ): {
 	handleOpenHistory: () => void;
 } {
@@ -46,6 +47,8 @@ export function useHistoryModal(
 	onLabelChangeRef.current = onLabelChange;
 	const onAgentCwdChangeRef = useRef(onAgentCwdChange);
 	onAgentCwdChangeRef.current = onAgentCwdChange;
+	const currentSessionIdRef = useRef(currentSessionId);
+	currentSessionIdRef.current = currentSessionId;
 
 	const handleRestoreSession = useCallback(
 		async (sessionId: string, cwd: string) => {
@@ -115,6 +118,13 @@ export function useHistoryModal(
 					newTitle,
 					sessionCwd,
 				);
+				// If the renamed session is open in this tab, update the tab label
+				if (
+					sessionId === currentSessionIdRef.current &&
+					onLabelChangeRef.current
+				) {
+					onLabelChangeRef.current(newTitle);
+				}
 				new Notice("[Agent Client] Title updated");
 			} catch (error) {
 				new Notice("[Agent Client] Failed to update title");

--- a/src/hooks/useHistoryModal.ts
+++ b/src/hooks/useHistoryModal.ts
@@ -29,6 +29,8 @@ export function useHistoryModal(
 	onAgentCwdChange?: (cwd: string) => void,
 	onLabelChange?: (label: string) => void,
 	currentSessionId?: string,
+	findTabBySessionId?: (sessionId: string) => { tabId: string; label: string } | null,
+	onSwitchToTab?: (tabId: string) => void,
 ): {
 	handleOpenHistory: () => void;
 } {
@@ -49,10 +51,24 @@ export function useHistoryModal(
 	onAgentCwdChangeRef.current = onAgentCwdChange;
 	const currentSessionIdRef = useRef(currentSessionId);
 	currentSessionIdRef.current = currentSessionId;
+	const findTabBySessionIdRef = useRef(findTabBySessionId);
+	findTabBySessionIdRef.current = findTabBySessionId;
+	const onSwitchToTabRef = useRef(onSwitchToTab);
+	onSwitchToTabRef.current = onSwitchToTab;
 
 	const handleRestoreSession = useCallback(
 		async (sessionId: string, cwd: string) => {
 			try {
+				// I20: If session is already open in another tab, switch to it
+				const existingTab = findTabBySessionIdRef.current?.(sessionId);
+				if (existingTab) {
+					onSwitchToTabRef.current?.(existingTab.tabId);
+					historyModalRef.current?.close();
+					new Notice(
+						`[Agent Client] Session already open in tab "${existingTab.label}"`,
+					);
+					return;
+				}
 				logger.log(`[ChatPanel] Restoring session: ${sessionId}`);
 				agent.clearMessages();
 				await sessionHistory.restoreSession(sessionId, cwd);

--- a/src/hooks/useHistoryModal.ts
+++ b/src/hooks/useHistoryModal.ts
@@ -27,11 +27,25 @@ export function useHistoryModal(
 	isSessionReady: boolean,
 	debugMode: boolean,
 	onAgentCwdChange?: (cwd: string) => void,
+	onLabelChange?: (label: string) => void,
 ): {
 	handleOpenHistory: () => void;
 } {
 	const logger = getLogger();
 	const historyModalRef = useRef<SessionHistoryModal | null>(null);
+
+	// ── Stable refs for values read at call time ──
+	// These prevent callbacks from depending on frequently-changing references
+	// (like sessionHistory.sessions which is a new array every render),
+	// which would cause the callbacks to be recreated every render,
+	// which would cause the useEffect syncing modal props to fire every render,
+	// which would call updateProps → root.render() → infinite re-render loop (I11/I12).
+	const sessionsRef = useRef(sessionHistory.sessions);
+	sessionsRef.current = sessionHistory.sessions;
+	const onLabelChangeRef = useRef(onLabelChange);
+	onLabelChangeRef.current = onLabelChange;
+	const onAgentCwdChangeRef = useRef(onAgentCwdChange);
+	onAgentCwdChangeRef.current = onAgentCwdChange;
 
 	const handleRestoreSession = useCallback(
 		async (sessionId: string, cwd: string) => {
@@ -39,19 +53,21 @@ export function useHistoryModal(
 				logger.log(`[ChatPanel] Restoring session: ${sessionId}`);
 				agent.clearMessages();
 				await sessionHistory.restoreSession(sessionId, cwd);
-				onAgentCwdChange?.(cwd);
+				onAgentCwdChangeRef.current?.(cwd);
+				// Update tab label from saved session title
+				const saved = sessionsRef.current.find(
+					(s) => s.sessionId === sessionId,
+				);
+				if (saved?.title && onLabelChangeRef.current) {
+					onLabelChangeRef.current(saved.title);
+				}
 				new Notice("[Agent Client] Session restored");
 			} catch (error) {
 				new Notice("[Agent Client] Failed to restore session");
 				logger.error("Session restore error:", error);
 			}
 		},
-		[
-			logger,
-			agent.clearMessages,
-			sessionHistory.restoreSession,
-			onAgentCwdChange,
-		],
+		[logger, agent.clearMessages, sessionHistory.restoreSession],
 	);
 
 	const handleForkSession = useCallback(
@@ -60,19 +76,21 @@ export function useHistoryModal(
 				logger.log(`[ChatPanel] Forking session: ${sessionId}`);
 				agent.clearMessages();
 				await sessionHistory.forkSession(sessionId, cwd);
-				onAgentCwdChange?.(cwd);
+				onAgentCwdChangeRef.current?.(cwd);
+				// Update tab label from the original session's title
+				const saved = sessionsRef.current.find(
+					(s) => s.sessionId === sessionId,
+				);
+				if (saved?.title && onLabelChangeRef.current) {
+					onLabelChangeRef.current(saved.title);
+				}
 				new Notice("[Agent Client] Session forked");
 			} catch (error) {
 				new Notice("[Agent Client] Failed to fork session");
 				logger.error("Session fork error:", error);
 			}
 		},
-		[
-			logger,
-			agent.clearMessages,
-			sessionHistory.forkSession,
-			onAgentCwdChange,
-		],
+		[logger, agent.clearMessages, sessionHistory.forkSession],
 	);
 
 	const handleDeleteSession = useCallback(
@@ -139,7 +157,7 @@ export function useHistoryModal(
 				onEditTitle: handleEditTitle,
 				onLoadMore: handleLoadMore,
 				onFetchSessions: handleFetchSessions,
-			});
+			}, () => { historyModalRef.current = null; });
 		}
 		historyModalRef.current.open();
 		void sessionHistory.fetchSessions(vaultPath);

--- a/src/hooks/useSessionHistory.ts
+++ b/src/hooks/useSessionHistory.ts
@@ -822,11 +822,7 @@ export function useSessionHistory(
 			hasMore: nextCursor !== undefined,
 
 			// Capability flags
-			canShowSessionHistory:
-				capabilities.canList ||
-				capabilities.canLoad ||
-				capabilities.canResume ||
-				capabilities.canFork,
+			canShowSessionHistory: true,
 			canRestore: capabilities.canLoad || capabilities.canResume,
 			canFork: capabilities.canFork,
 			canList: capabilities.canList,

--- a/src/hooks/useSessionHistory.ts
+++ b/src/hooks/useSessionHistory.ts
@@ -841,11 +841,7 @@ export function useSessionHistory(
 			hasMore: nextCursor !== undefined,
 
 			// Capability flags
-			canShowSessionHistory:
-				capabilities.canList ||
-				capabilities.canLoad ||
-				capabilities.canResume ||
-				capabilities.canFork,
+			canShowSessionHistory: true,
 			canRestore: capabilities.canLoad || capabilities.canResume,
 			canFork: capabilities.canFork,
 			canList: capabilities.canList,

--- a/src/hooks/useTabManager.ts
+++ b/src/hooks/useTabManager.ts
@@ -1,0 +1,245 @@
+/**
+ * Hook for managing tabbed sessions within a single ChatView.
+ *
+ * Each tab represents an independent agent session. The hook manages
+ * the tab list, active tab, and tab metadata (label, state).
+ * Tab creation/destruction of AcpClient instances is handled by the
+ * parent ChatView via plugin.getOrCreateAcpClient(tabId).
+ */
+
+import { useState, useCallback, useMemo } from "react";
+import type { TabInfo, TabState } from "../types/tab";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface UseTabManagerReturn {
+	/** All tabs in order */
+	tabs: TabInfo[];
+	/** Currently active tab ID */
+	activeTabId: string;
+	/** Currently active tab info */
+	activeTab: TabInfo;
+	/** Add a new tab and switch to it */
+	addTab: (agentId: string, label?: string) => string;
+	/** Remove a tab by ID. Returns the new active tab ID. */
+	removeTab: (tabId: string) => string | null;
+	/** Remove all tabs except the given one */
+	removeOtherTabs: (tabId: string) => void;
+	/** Remove all tabs to the right of the given one */
+	removeTabsToRight: (tabId: string) => void;
+	/** Switch to a tab */
+	setActiveTab: (tabId: string) => void;
+	/** Update a tab's label */
+	setTabLabel: (tabId: string, label: string) => void;
+	/** Update a tab's visual state */
+	setTabState: (tabId: string, state: TabState) => void;
+	/** Reorder: move tab from one index to another */
+	moveTab: (fromIndex: number, toIndex: number) => void;
+	/** Switch to next tab (cyclic) */
+	nextTab: () => void;
+	/** Switch to previous tab (cyclic) */
+	prevTab: () => void;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function generateTabId(): string {
+	return `tab-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function createTab(agentId: string, label?: string): TabInfo {
+	return {
+		tabId: generateTabId(),
+		agentId,
+		label:
+			label ||
+			`${agentId} ${new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`,
+		state: "disconnected",
+		createdAt: new Date(),
+	};
+}
+
+function truncateLabel(text: string, max = 25): string {
+	return text.length > max ? text.slice(0, max - 1) + "…" : text;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Manages tab state for a single ChatView.
+ *
+ * @param initialAgentId - Agent ID for the first tab (created on mount)
+ */
+export function useTabManager(initialAgentId: string): UseTabManagerReturn {
+	const [tabs, setTabs] = useState<TabInfo[]>(() => {
+		const first = createTab(initialAgentId);
+		return [first];
+	});
+	const [activeTabId, setActiveTabId] = useState<string>(
+		() => tabs[0].tabId,
+	);
+
+	const addTab = useCallback(
+		(agentId: string, label?: string): string => {
+			const tab = createTab(agentId, label);
+			setTabs((prev) => [...prev, tab]);
+			setActiveTabId(tab.tabId);
+			return tab.tabId;
+		},
+		[],
+	);
+
+	const removeTab = useCallback(
+		(tabId: string): string | null => {
+			let newActiveId: string | null = null;
+			setTabs((prev) => {
+				if (prev.length <= 1) return prev; // Don't remove last tab
+				const idx = prev.findIndex((t) => t.tabId === tabId);
+				if (idx === -1) return prev;
+				const next = prev.filter((t) => t.tabId !== tabId);
+				// If removing the active tab, activate the nearest neighbor
+				if (tabId === activeTabId) {
+					const newIdx = Math.min(idx, next.length - 1);
+					newActiveId = next[newIdx].tabId;
+					setActiveTabId(newActiveId);
+				} else {
+					newActiveId = activeTabId;
+				}
+				return next;
+			});
+			return newActiveId;
+		},
+		[activeTabId],
+	);
+
+	const removeOtherTabs = useCallback(
+		(tabId: string) => {
+			setTabs((prev) => prev.filter((t) => t.tabId === tabId));
+			setActiveTabId(tabId);
+		},
+		[],
+	);
+
+	const removeTabsToRight = useCallback(
+		(tabId: string) => {
+			setTabs((prev) => {
+				const idx = prev.findIndex((t) => t.tabId === tabId);
+				if (idx === -1) return prev;
+				return prev.slice(0, idx + 1);
+			});
+			// If active tab was to the right, switch to the kept tab
+			setTabs((prev) => {
+				if (!prev.find((t) => t.tabId === activeTabId)) {
+					setActiveTabId(tabId);
+				}
+				return prev;
+			});
+		},
+		[activeTabId],
+	);
+
+	const setTabLabel = useCallback(
+		(tabId: string, label: string) => {
+			setTabs((prev) =>
+				prev.map((t) =>
+					t.tabId === tabId
+						? { ...t, label: truncateLabel(label) }
+						: t,
+				),
+			);
+		},
+		[],
+	);
+
+	const setTabState = useCallback(
+		(tabId: string, state: TabState) => {
+			setTabs((prev) =>
+				prev.map((t) =>
+					t.tabId === tabId ? { ...t, state } : t,
+				),
+			);
+		},
+		[],
+	);
+
+	const moveTab = useCallback(
+		(fromIndex: number, toIndex: number) => {
+			setTabs((prev) => {
+				if (
+					fromIndex < 0 ||
+					fromIndex >= prev.length ||
+					toIndex < 0 ||
+					toIndex >= prev.length
+				)
+					return prev;
+				const next = [...prev];
+				const [moved] = next.splice(fromIndex, 1);
+				next.splice(toIndex, 0, moved);
+				return next;
+			});
+		},
+		[],
+	);
+
+	const nextTab = useCallback(() => {
+		setTabs((prev) => {
+			const idx = prev.findIndex((t) => t.tabId === activeTabId);
+			const nextIdx = (idx + 1) % prev.length;
+			setActiveTabId(prev[nextIdx].tabId);
+			return prev;
+		});
+	}, [activeTabId]);
+
+	const prevTab = useCallback(() => {
+		setTabs((prev) => {
+			const idx = prev.findIndex((t) => t.tabId === activeTabId);
+			const prevIdx = (idx - 1 + prev.length) % prev.length;
+			setActiveTabId(prev[prevIdx].tabId);
+			return prev;
+		});
+	}, [activeTabId]);
+
+	const activeTab = useMemo(
+		() =>
+			tabs.find((t) => t.tabId === activeTabId) ?? tabs[0],
+		[tabs, activeTabId],
+	);
+
+	return useMemo(
+		() => ({
+			tabs,
+			activeTabId,
+			activeTab,
+			addTab,
+			removeTab,
+			removeOtherTabs,
+			removeTabsToRight,
+			setActiveTab: setActiveTabId,
+			setTabLabel,
+			setTabState,
+			moveTab,
+			nextTab,
+			prevTab,
+		}),
+		[
+			tabs,
+			activeTabId,
+			activeTab,
+			addTab,
+			removeTab,
+			removeOtherTabs,
+			removeTabsToRight,
+			setTabLabel,
+			setTabState,
+			moveTab,
+			nextTab,
+			prevTab,
+		],
+	);
+}

--- a/src/hooks/useTabManager.ts
+++ b/src/hooks/useTabManager.ts
@@ -67,7 +67,7 @@ function createTab(agentId: string, label?: string): TabInfo {
 	};
 }
 
-function truncateLabel(text: string, max = 25): string {
+export function truncateLabel(text: string, max = 100): string {
 	return text.length > max ? text.slice(0, max - 1) + "…" : text;
 }
 

--- a/src/hooks/useTabManager.ts
+++ b/src/hooks/useTabManager.ts
@@ -150,24 +150,29 @@ export function useTabManager(initialAgentId: string): UseTabManagerReturn {
 
 	const setTabLabel = useCallback(
 		(tabId: string, label: string) => {
-			setTabs((prev) =>
-				prev.map((t) =>
+			const truncated = truncateLabel(label);
+			setTabs((prev) => {
+				const tab = prev.find((t) => t.tabId === tabId);
+				if (!tab || tab.label === truncated) return prev;
+				return prev.map((t) =>
 					t.tabId === tabId
-						? { ...t, label: truncateLabel(label) }
+						? { ...t, label: truncated }
 						: t,
-				),
-			);
+				);
+			});
 		},
 		[],
 	);
 
 	const setTabState = useCallback(
 		(tabId: string, state: TabState) => {
-			setTabs((prev) =>
-				prev.map((t) =>
+			setTabs((prev) => {
+				const tab = prev.find((t) => t.tabId === tabId);
+				if (!tab || tab.state === state) return prev;
+				return prev.map((t) =>
 					t.tabId === tabId ? { ...t, state } : t,
-				),
-			);
+				);
+			});
 		},
 		[],
 	);

--- a/src/hooks/useTabManager.ts
+++ b/src/hooks/useTabManager.ts
@@ -35,6 +35,8 @@ export interface UseTabManagerReturn {
 	setTabLabel: (tabId: string, label: string) => void;
 	/** Update a tab's visual state */
 	setTabState: (tabId: string, state: TabState) => void;
+	/** Reset a tab's label and state to defaults (used after error boundary retry) */
+	resetTab: (tabId: string) => void;
 	/** Reorder: move tab from one index to another */
 	moveTab: (fromIndex: number, toIndex: number) => void;
 	/** Switch to next tab (cyclic) */
@@ -51,13 +53,15 @@ function generateTabId(): string {
 	return `tab-${crypto.randomUUID().slice(0, 8)}`;
 }
 
+function defaultLabel(agentId: string): string {
+	return `${agentId} ${new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
+}
+
 function createTab(agentId: string, label?: string): TabInfo {
 	return {
 		tabId: generateTabId(),
 		agentId,
-		label:
-			label ||
-			`${agentId} ${new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`,
+		label: label || defaultLabel(agentId),
 		state: "disconnected",
 		createdAt: new Date(),
 	};
@@ -168,6 +172,16 @@ export function useTabManager(initialAgentId: string): UseTabManagerReturn {
 		[],
 	);
 
+	const resetTab = useCallback((tabId: string) => {
+		setTabs((prev) =>
+			prev.map((t) =>
+				t.tabId === tabId
+					? { ...t, label: defaultLabel(t.agentId), state: "disconnected" }
+					: t,
+			),
+		);
+	}, []);
+
 	const moveTab = useCallback(
 		(fromIndex: number, toIndex: number) => {
 			setTabs((prev) => {
@@ -223,6 +237,7 @@ export function useTabManager(initialAgentId: string): UseTabManagerReturn {
 			setActiveTab: setActiveTabId,
 			setTabLabel,
 			setTabState,
+			resetTab,
 			moveTab,
 			nextTab,
 			prevTab,
@@ -237,6 +252,7 @@ export function useTabManager(initialAgentId: string): UseTabManagerReturn {
 			removeTabsToRight,
 			setTabLabel,
 			setTabState,
+			resetTab,
 			moveTab,
 			nextTab,
 			prevTab,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -129,6 +129,10 @@ export interface AgentClientPluginSettings {
 	floatingWindowSize: { width: number; height: number };
 	floatingWindowPosition: { x: number; y: number } | null;
 	floatingButtonPosition: { x: number; y: number } | null;
+
+	// Tab settings
+	/** Maximum number of session tabs per view (default: 10) */
+	maxSessionTabs: number;
 }
 
 const DEFAULT_SETTINGS: AgentClientPluginSettings = {
@@ -200,6 +204,7 @@ const DEFAULT_SETTINGS: AgentClientPluginSettings = {
 	floatingWindowSize: { width: 400, height: 500 },
 	floatingWindowPosition: null,
 	floatingButtonPosition: null,
+	maxSessionTabs: 10,
 };
 
 export default class AgentClientPlugin extends Plugin {
@@ -270,6 +275,39 @@ export default class AgentClientPlugin extends Plugin {
 				void this.openNewChatViewWithAgent(
 					this.settings.defaultAgentId,
 				);
+			},
+		});
+
+		// Tab commands
+		this.addCommand({
+			id: "new-session-tab",
+			name: "New session tab",
+			callback: () => {
+				this.getActiveChatView()?.addTab();
+			},
+		});
+
+		this.addCommand({
+			id: "close-session-tab",
+			name: "Close session tab",
+			callback: () => {
+				this.getActiveChatView()?.closeActiveTab();
+			},
+		});
+
+		this.addCommand({
+			id: "next-session-tab",
+			name: "Next session tab",
+			callback: () => {
+				this.getActiveChatView()?.nextTab();
+			},
+		});
+
+		this.addCommand({
+			id: "previous-session-tab",
+			name: "Previous session tab",
+			callback: () => {
+				this.getActiveChatView()?.prevTab();
 			},
 		});
 
@@ -642,6 +680,22 @@ export default class AgentClientPlugin extends Plugin {
 		if (view) {
 			view.expand();
 		}
+	}
+
+	/**
+	 * Get the active sidebar ChatView (for tab commands).
+	 */
+	getActiveChatView(): ChatView | null {
+		const focusedId = this.lastActiveChatViewId;
+		if (!focusedId) return null;
+		const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_CHAT);
+		for (const leaf of leaves) {
+			const view = leaf.view;
+			if (view instanceof ChatView && view.viewId === focusedId) {
+				return view;
+			}
+		}
+		return null;
 	}
 
 	/**
@@ -1082,6 +1136,11 @@ export default class AgentClientPlugin extends Plugin {
 			})(),
 			floatingWindowPosition: xyPoint(raw.floatingWindowPosition),
 			floatingButtonPosition: xyPoint(raw.floatingButtonPosition),
+			maxSessionTabs: num(
+				raw.maxSessionTabs,
+				D.maxSessionTabs,
+				1,
+			),
 		};
 
 		this.ensureDefaultAgentId();

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -735,10 +735,14 @@ export default class AgentClientPlugin extends Plugin {
 			this.addCommand({
 				id: `switch-agent-to-${agent.id}`,
 				name: `Switch agent to ${agent.displayName}`,
-				callback: () => {
+				checkCallback: (checking) => {
+					const view =
+						this.app.workspace.getActiveViewOfType(ChatView);
+					if (!view) return false;
+					if (checking) return true;
 					this.app.workspace.trigger(
 						"agent-client:new-chat-requested" as "quit",
-						this.lastActiveChatViewId,
+						view.viewId,
 						agent.id,
 					);
 				},
@@ -750,10 +754,14 @@ export default class AgentClientPlugin extends Plugin {
 		this.addCommand({
 			id: "approve-active-permission",
 			name: "Approve active permission",
-			callback: () => {
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:approve-active-permission" as "quit",
-					this.lastActiveChatViewId,
+					view.viewId,
 				);
 			},
 		});
@@ -761,10 +769,14 @@ export default class AgentClientPlugin extends Plugin {
 		this.addCommand({
 			id: "reject-active-permission",
 			name: "Reject active permission",
-			callback: () => {
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:reject-active-permission" as "quit",
-					this.lastActiveChatViewId,
+					view.viewId,
 				);
 			},
 		});
@@ -772,10 +784,14 @@ export default class AgentClientPlugin extends Plugin {
 		this.addCommand({
 			id: "toggle-auto-mention",
 			name: "Toggle auto-mention",
-			callback: () => {
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:toggle-auto-mention" as "quit",
-					this.lastActiveChatViewId,
+					view.viewId,
 				);
 			},
 		});
@@ -783,10 +799,14 @@ export default class AgentClientPlugin extends Plugin {
 		this.addCommand({
 			id: "new-chat",
 			name: "New chat",
-			callback: () => {
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:new-chat-requested" as "quit",
-					this.lastActiveChatViewId,
+					view.viewId,
 				);
 			},
 		});
@@ -794,10 +814,14 @@ export default class AgentClientPlugin extends Plugin {
 		this.addCommand({
 			id: "cancel-current-message",
 			name: "Cancel current message",
-			callback: () => {
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:cancel-message" as "quit",
-					this.lastActiveChatViewId,
+					view.viewId,
 				);
 			},
 		});
@@ -805,10 +829,14 @@ export default class AgentClientPlugin extends Plugin {
 		this.addCommand({
 			id: "export-chat",
 			name: "Export chat",
-			callback: () => {
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:export-chat" as "quit",
-					this.lastActiveChatViewId,
+					view.viewId,
 				);
 			},
 		});

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -282,32 +282,48 @@ export default class AgentClientPlugin extends Plugin {
 		this.addCommand({
 			id: "new-session-tab",
 			name: "New session tab",
-			callback: () => {
-				this.getActiveChatView()?.addTab();
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
+				view.addTab();
 			},
 		});
 
 		this.addCommand({
 			id: "close-session-tab",
 			name: "Close session tab",
-			callback: () => {
-				this.getActiveChatView()?.closeActiveTab();
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
+				view.closeActiveTab();
 			},
 		});
 
 		this.addCommand({
 			id: "next-session-tab",
 			name: "Next session tab",
-			callback: () => {
-				this.getActiveChatView()?.nextTab();
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
+				view.nextTab();
 			},
 		});
 
 		this.addCommand({
 			id: "previous-session-tab",
 			name: "Previous session tab",
-			callback: () => {
-				this.getActiveChatView()?.prevTab();
+			checkCallback: (checking) => {
+				const view =
+					this.app.workspace.getActiveViewOfType(ChatView);
+				if (!view) return false;
+				if (checking) return true;
+				view.prevTab();
 			},
 		});
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -758,7 +758,7 @@ export default class AgentClientPlugin extends Plugin {
 					if (checking) return true;
 					this.app.workspace.trigger(
 						"agent-client:new-chat-requested" as "quit",
-						view.viewId,
+						view.getActiveTabId(),
 						agent.id,
 					);
 				},
@@ -777,7 +777,7 @@ export default class AgentClientPlugin extends Plugin {
 				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:approve-active-permission" as "quit",
-					view.viewId,
+					view.getActiveTabId(),
 				);
 			},
 		});
@@ -792,7 +792,7 @@ export default class AgentClientPlugin extends Plugin {
 				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:reject-active-permission" as "quit",
-					view.viewId,
+					view.getActiveTabId(),
 				);
 			},
 		});
@@ -807,7 +807,7 @@ export default class AgentClientPlugin extends Plugin {
 				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:toggle-auto-mention" as "quit",
-					view.viewId,
+					view.getActiveTabId(),
 				);
 			},
 		});
@@ -822,7 +822,7 @@ export default class AgentClientPlugin extends Plugin {
 				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:new-chat-requested" as "quit",
-					view.viewId,
+					view.getActiveTabId(),
 				);
 			},
 		});
@@ -837,7 +837,7 @@ export default class AgentClientPlugin extends Plugin {
 				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:cancel-message" as "quit",
-					view.viewId,
+					view.getActiveTabId(),
 				);
 			},
 		});
@@ -852,7 +852,7 @@ export default class AgentClientPlugin extends Plugin {
 				if (checking) return true;
 				this.app.workspace.trigger(
 					"agent-client:export-chat" as "quit",
-					view.viewId,
+					view.getActiveTabId(),
 				);
 			},
 		});

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -486,6 +486,27 @@ export default class AgentClientPlugin extends Plugin {
 		}
 	}
 
+	/**
+	 * Resolve the registry-stored leaf-level ID to the active tab's
+	 * tab.tabId, which is what ChatPanel listeners filter on. For floating
+	 * chats (no tabs) the floating viewId is returned unchanged because it
+	 * already matches what the registry stores.
+	 *
+	 * Use this in `addCommand` callbacks instead of `this.lastActiveChatViewId`
+	 * to ensure events route to the active tab's ChatPanel listener (I33).
+	 */
+	private getDispatchTargetId(): string | null {
+		const focusedId = this.lastActiveChatViewId;
+		if (!focusedId) return null;
+
+		const chatView = this.app.workspace
+			.getLeavesOfType(VIEW_TYPE_CHAT)
+			.find((l) => (l.view as ChatView)?.viewId === focusedId)
+			?.view as ChatView | undefined;
+
+		return chatView?.getActiveTabId() ?? focusedId;
+	}
+
 	async activateView() {
 		const { workspace } = this.app;
 
@@ -737,7 +758,7 @@ export default class AgentClientPlugin extends Plugin {
 				callback: () => {
 					this.app.workspace.trigger(
 						"agent-client:new-chat-requested",
-						this.lastActiveChatViewId,
+						this.getDispatchTargetId(),
 						agent.id,
 					);
 				},
@@ -752,7 +773,7 @@ export default class AgentClientPlugin extends Plugin {
 			callback: () => {
 				this.app.workspace.trigger(
 					"agent-client:approve-active-permission",
-					this.lastActiveChatViewId,
+					this.getDispatchTargetId(),
 				);
 			},
 		});
@@ -763,7 +784,7 @@ export default class AgentClientPlugin extends Plugin {
 			callback: () => {
 				this.app.workspace.trigger(
 					"agent-client:reject-active-permission",
-					this.lastActiveChatViewId,
+					this.getDispatchTargetId(),
 				);
 			},
 		});
@@ -774,7 +795,7 @@ export default class AgentClientPlugin extends Plugin {
 			callback: () => {
 				this.app.workspace.trigger(
 					"agent-client:toggle-auto-mention",
-					this.lastActiveChatViewId,
+					this.getDispatchTargetId(),
 				);
 			},
 		});
@@ -785,7 +806,7 @@ export default class AgentClientPlugin extends Plugin {
 			callback: () => {
 				this.app.workspace.trigger(
 					"agent-client:new-chat-requested",
-					this.lastActiveChatViewId,
+					this.getDispatchTargetId(),
 				);
 			},
 		});
@@ -796,7 +817,7 @@ export default class AgentClientPlugin extends Plugin {
 			callback: () => {
 				this.app.workspace.trigger(
 					"agent-client:cancel-message",
-					this.lastActiveChatViewId,
+					this.getDispatchTargetId(),
 				);
 			},
 		});
@@ -807,7 +828,7 @@ export default class AgentClientPlugin extends Plugin {
 			callback: () => {
 				this.app.workspace.trigger(
 					"agent-client:export-chat",
-					this.lastActiveChatViewId,
+					this.getDispatchTargetId(),
 				);
 			},
 		});

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -128,6 +128,10 @@ export interface AgentClientPluginSettings {
 	floatingWindowSize: { width: number; height: number };
 	floatingWindowPosition: { x: number; y: number } | null;
 	floatingButtonPosition: { x: number; y: number } | null;
+
+	// Tab settings
+	/** Maximum number of session tabs per view (default: 10) */
+	maxSessionTabs: number;
 }
 
 const DEFAULT_SETTINGS: AgentClientPluginSettings = {
@@ -199,6 +203,7 @@ const DEFAULT_SETTINGS: AgentClientPluginSettings = {
 	floatingWindowSize: { width: 400, height: 500 },
 	floatingWindowPosition: null,
 	floatingButtonPosition: null,
+	maxSessionTabs: 10,
 };
 
 export default class AgentClientPlugin extends Plugin {
@@ -269,6 +274,39 @@ export default class AgentClientPlugin extends Plugin {
 				void this.openNewChatViewWithAgent(
 					this.settings.defaultAgentId,
 				);
+			},
+		});
+
+		// Tab commands
+		this.addCommand({
+			id: "new-session-tab",
+			name: "New session tab",
+			callback: () => {
+				this.getActiveChatView()?.addTab();
+			},
+		});
+
+		this.addCommand({
+			id: "close-session-tab",
+			name: "Close session tab",
+			callback: () => {
+				this.getActiveChatView()?.closeActiveTab();
+			},
+		});
+
+		this.addCommand({
+			id: "next-session-tab",
+			name: "Next session tab",
+			callback: () => {
+				this.getActiveChatView()?.nextTab();
+			},
+		});
+
+		this.addCommand({
+			id: "previous-session-tab",
+			name: "Previous session tab",
+			callback: () => {
+				this.getActiveChatView()?.prevTab();
 			},
 		});
 
@@ -641,6 +679,22 @@ export default class AgentClientPlugin extends Plugin {
 		if (view) {
 			view.expand();
 		}
+	}
+
+	/**
+	 * Get the active sidebar ChatView (for tab commands).
+	 */
+	getActiveChatView(): ChatView | null {
+		const focusedId = this.lastActiveChatViewId;
+		if (!focusedId) return null;
+		const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_CHAT);
+		for (const leaf of leaves) {
+			const view = leaf.view;
+			if (view instanceof ChatView && view.viewId === focusedId) {
+				return view;
+			}
+		}
+		return null;
 	}
 
 	/**
@@ -1081,6 +1135,11 @@ export default class AgentClientPlugin extends Plugin {
 			})(),
 			floatingWindowPosition: xyPoint(raw.floatingWindowPosition),
 			floatingButtonPosition: xyPoint(raw.floatingButtonPosition),
+			maxSessionTabs: num(
+				raw.maxSessionTabs,
+				D.maxSessionTabs,
+				1,
+			),
 		};
 
 		this.ensureDefaultAgentId();

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -1,0 +1,37 @@
+/**
+ * Types for internal tabbed multi-session support.
+ *
+ * Each tab represents an independent agent session within a single
+ * ChatView leaf. Tabs are the multiplexing unit — one Obsidian leaf,
+ * N agent sessions.
+ */
+
+/**
+ * Visual state of a tab, derived from SessionState + permission status.
+ * Used by TabBar to render the correct icon shape/color/animation.
+ *
+ * Colorblind-safe: states are distinguished by shape first, color second,
+ * animation third. No red/green contrast dependency.
+ */
+export type TabState =
+	| "ready" // ● blue — idle, waiting for input
+	| "busy" // ◐ blue, spinning — agent processing
+	| "permission" // △ orange, pulsing — awaiting user approval
+	| "error" // ✕ red — session error
+	| "disconnected"; // ○ gray — session closed
+
+/**
+ * Metadata for a single tab in the tab bar.
+ */
+export interface TabInfo {
+	/** Unique identifier for this tab */
+	tabId: string;
+	/** Agent ID running in this tab */
+	agentId: string;
+	/** Short label displayed on the tab (≤25 chars) */
+	label: string;
+	/** Current visual state for the tab icon */
+	state: TabState;
+	/** Timestamp when this tab was created */
+	createdAt: Date;
+}

--- a/src/ui/ChatHeader.tsx
+++ b/src/ui/ChatHeader.tsx
@@ -123,7 +123,7 @@ function SidebarHeader({
 					</span>
 				)}
 				<NavActionButton
-					icon="plus"
+					icon="refresh-cw"
 					label="New chat"
 					onClick={onNewChat}
 				/>

--- a/src/ui/ChatHeader.tsx
+++ b/src/ui/ChatHeader.tsx
@@ -120,7 +120,7 @@ function SidebarHeader({
 					</span>
 				)}
 				<NavActionButton
-					icon="plus"
+					icon="refresh-cw"
 					label="New chat"
 					onClick={onNewChat}
 				/>

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -89,6 +89,10 @@ export interface ChatPanelProps {
 	viewHost?: IChatViewHost;
 	/** External container element for focus tracking (floating uses parent's container) */
 	containerEl?: HTMLElement | null;
+	/** Called when session state changes (for tab icon updates) */
+	onStateChange?: (state: import("../types/tab").TabState) => void;
+	/** Called when a suitable tab label is available (session title or first message) */
+	onLabelChange?: (label: string) => void;
 }
 
 // ============================================================================
@@ -129,6 +133,8 @@ export function ChatPanel({
 	onFloatingHeaderMouseDown,
 	viewHost: viewHostProp,
 	containerEl: containerElProp,
+	onStateChange,
+	onLabelChange,
 }: ChatPanelProps) {
 	// ============================================================
 	// Platform Check
@@ -320,10 +326,14 @@ export function ChatPanel({
 	// ============================================================
 	const handleNewChatWithPersist = useCallback(
 		async (requestedAgentId?: string) => {
-			await handleNewChat(requestedAgentId);
-			// Persist agent ID for this view (survives Obsidian restart)
-			if (requestedAgentId) {
-				onAgentIdChanged?.(requestedAgentId);
+			try {
+				await handleNewChat(requestedAgentId);
+				// Persist agent ID for this view (survives Obsidian restart)
+				if (requestedAgentId) {
+					onAgentIdChanged?.(requestedAgentId);
+				}
+			} catch (error) {
+				console.error("[Agent Client] New chat error:", error);
 			}
 		},
 		[handleNewChat, onAgentIdChanged],
@@ -340,14 +350,18 @@ export function ChatPanel({
 
 	const handleNewChatInDirectory = useCallback(
 		async (directory: string) => {
-			// Auto-export current chat before switching
-			if (messages.length > 0) {
-				await autoExportIfEnabled("newChat", messages, session);
+			try {
+				// Auto-export current chat before switching
+				if (messages.length > 0) {
+					await autoExportIfEnabled("newChat", messages, session);
+				}
+				agent.clearMessages();
+				setAgentCwd(directory);
+				await agent.restartSession(undefined, directory);
+				sessionHistory.invalidateCache();
+			} catch (error) {
+				console.error("[Agent Client] New chat in directory error:", error);
 			}
-			agent.clearMessages();
-			setAgentCwd(directory);
-			await agent.restartSession(undefined, directory);
-			sessionHistory.invalidateCache();
 		},
 		[
 			messages,
@@ -641,12 +655,16 @@ export function ChatPanel({
 		return () => {
 			logger.log("[ChatPanel] Cleanup: auto-export and close session");
 			void (async () => {
-				await autoExportRef.current(
-					"closeChat",
-					messagesRef.current,
-					sessionRef.current,
-				);
-				await closeSessionRef.current();
+				try {
+					await autoExportRef.current(
+						"closeChat",
+						messagesRef.current,
+						sessionRef.current,
+					);
+					await closeSessionRef.current();
+				} catch (error) {
+					logger.error("[ChatPanel] Cleanup error:", error);
+				}
 			})();
 		};
 	}, [logger]);
@@ -745,6 +763,53 @@ export function ChatPanel({
 	]);
 
 	// ============================================================
+	// Effects - Tab State & Label Reporting
+	// ============================================================
+	useEffect(() => {
+		if (!onStateChange) return;
+		if (errorInfo) {
+			onStateChange("error");
+		} else if (agent.hasActivePermission) {
+			onStateChange("permission");
+		} else if (isSending) {
+			onStateChange("busy");
+		} else if (isSessionReady) {
+			onStateChange("ready");
+		} else {
+			onStateChange("disconnected");
+		}
+	}, [
+		onStateChange,
+		errorInfo,
+		agent.hasActivePermission,
+		isSending,
+		isSessionReady,
+	]);
+
+	// Report label from first user message
+	const labelReportedRef = useRef(false);
+	useEffect(() => {
+		if (!onLabelChange || labelReportedRef.current) return;
+		if (messages.length > 0) {
+			const firstUserMsg = messages.find((m) => m.role === "user");
+			if (firstUserMsg) {
+				// content is MessageContent[] — extract text from the first text/text_with_context block
+				const textBlock = firstUserMsg.content.find(
+					(block) =>
+						block.type === "text" ||
+						block.type === "text_with_context",
+				);
+				const text =
+					textBlock && "text" in textBlock ? textBlock.text : "";
+				if (text.trim()) {
+					onLabelChange(text.trim());
+					labelReportedRef.current = true;
+				}
+			}
+		}
+	}, [onLabelChange, messages]);
+
+	// ============================================================
 	// Effects - Auto-mention Active Note Tracking
 	// ============================================================
 	useEffect(() => {
@@ -823,12 +888,16 @@ export function ChatPanel({
 				(targetViewId?: string) => {
 					if (targetViewId && targetViewId !== viewId) return;
 					void (async () => {
-						const success =
-							await approveActivePermissionRef.current();
-						if (!success) {
-							new Notice(
-								"[Agent Client] No active permission request",
-							);
+						try {
+							const success =
+								await approveActivePermissionRef.current();
+							if (!success) {
+								new Notice(
+									"[Agent Client] No active permission request",
+								);
+							}
+						} catch (error) {
+							console.error("[Agent Client] Approve permission error:", error);
 						}
 					})();
 				},
@@ -840,12 +909,16 @@ export function ChatPanel({
 				(targetViewId?: string) => {
 					if (targetViewId && targetViewId !== viewId) return;
 					void (async () => {
-						const success =
-							await rejectActivePermissionRef.current();
-						if (!success) {
-							new Notice(
-								"[Agent Client] No active permission request",
-							);
+						try {
+							const success =
+								await rejectActivePermissionRef.current();
+							if (!success) {
+								new Notice(
+									"[Agent Client] No active permission request",
+								);
+							}
+						} catch (error) {
+							console.error("[Agent Client] Reject permission error:", error);
 						}
 					})();
 				},
@@ -964,12 +1037,20 @@ export function ChatPanel({
 				setInputValue("");
 				setAttachedFiles([]);
 
-				await handleSendMessageRef.current(messageToSend, filesToSend);
+				try {
+					await handleSendMessageRef.current(messageToSend, filesToSend);
+				} catch (error) {
+					console.error("[Agent Client] Send message error:", error);
+				}
 				return true;
 			},
 			cancelOperation: async () => {
 				if (isSendingRef.current) {
-					await handleStopGenerationRef.current();
+					try {
+						await handleStopGenerationRef.current();
+					} catch (error) {
+						console.error("[Agent Client] Cancel operation error:", error);
+					}
 				}
 			},
 		});

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -93,6 +93,8 @@ export interface ChatPanelProps {
 	onStateChange?: (state: import("../types/tab").TabState) => void;
 	/** Called when a suitable tab label is available (session title or first message) */
 	onLabelChange?: (label: string) => void;
+	/** Whether this tab is the currently active tab (controls focus on activation) */
+	isActive?: boolean;
 }
 
 // ============================================================================
@@ -135,6 +137,7 @@ export function ChatPanel({
 	containerEl: containerElProp,
 	onStateChange,
 	onLabelChange,
+	isActive,
 }: ChatPanelProps) {
 	// ============================================================
 	// Platform Check
@@ -1171,6 +1174,7 @@ export function ChatPanel({
 			agentUpdateNotification={agentUpdateNotification}
 			onClearAgentUpdate={handleClearAgentUpdate}
 			messages={messages}
+			isActive={isActive}
 		/>
 	);
 

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -331,6 +331,7 @@ export function ChatPanel({
 		settings.debugMode,
 		setAgentCwd,
 		handleLabelChangeFromRestore,
+		session.sessionId ?? undefined,
 	);
 
 	// ============================================================

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -356,6 +356,7 @@ export function ChatPanel({
 			try {
 				await handleNewChat(requestedAgentId);
 				labelReportedRef.current = false;
+				onLabelChange?.("");
 				// Persist agent ID for this view (survives Obsidian restart)
 				if (requestedAgentId) {
 					onAgentIdChanged?.(requestedAgentId);

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -93,6 +93,8 @@ export interface ChatPanelProps {
 	onStateChange?: (state: import("../types/tab").TabState) => void;
 	/** Called when a suitable tab label is available (session title or first message) */
 	onLabelChange?: (label: string) => void;
+	/** Called when the session ID changes (for tab rename persistence) */
+	onSessionIdChange?: (sessionId: string | null) => void;
 	/** Whether this tab is the currently active tab (controls focus on activation) */
 	isActive?: boolean;
 }
@@ -137,6 +139,7 @@ export function ChatPanel({
 	containerEl: containerElProp,
 	onStateChange,
 	onLabelChange,
+	onSessionIdChange,
 	isActive,
 }: ChatPanelProps) {
 	// ============================================================
@@ -824,6 +827,11 @@ export function ChatPanel({
 			}
 		}
 	}, [onLabelChange, messages]);
+
+	// Report session ID changes to parent (for tab rename persistence)
+	useEffect(() => {
+		onSessionIdChange?.(session.sessionId);
+	}, [onSessionIdChange, session.sessionId]);
 
 	// ============================================================
 	// Effects - Auto-mention Active Note Tracking

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -1149,6 +1149,7 @@ export function ChatPanel({
 			terminalClient={terminalClientRef.current}
 			onApprovePermission={agent.approvePermission}
 			hasActivePermission={agent.hasActivePermission}
+			isActive={isActive}
 		/>
 	);
 

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -326,12 +326,18 @@ export function ChatPanel({
 	// Track whether tab label has been reported (reset on new chat / restore)
 	const labelReportedRef = useRef(false);
 
+	// Stable refs for tab callbacks (avoid re-render loops from inline arrow props)
+	const onStateChangeRef = useRef(onStateChange);
+	onStateChangeRef.current = onStateChange;
+	const onLabelChangeRef = useRef(onLabelChange);
+	onLabelChangeRef.current = onLabelChange;
+
 	const handleLabelChangeFromRestore = useCallback(
 		(label: string) => {
-			onLabelChange?.(label);
+			onLabelChangeRef.current?.(label);
 			labelReportedRef.current = true;
 		},
-		[onLabelChange],
+		[],
 	);
 
 	const { handleOpenHistory } = useHistoryModal(
@@ -356,7 +362,7 @@ export function ChatPanel({
 			try {
 				await handleNewChat(requestedAgentId);
 				labelReportedRef.current = false;
-				onLabelChange?.("");
+				onLabelChangeRef.current?.("");
 				// Persist agent ID for this view (survives Obsidian restart)
 				if (requestedAgentId) {
 					onAgentIdChanged?.(requestedAgentId);
@@ -795,20 +801,19 @@ export function ChatPanel({
 	// Effects - Tab State & Label Reporting
 	// ============================================================
 	useEffect(() => {
-		if (!onStateChange) return;
+		if (!onStateChangeRef.current) return;
 		if (errorInfo) {
-			onStateChange("error");
+			onStateChangeRef.current("error");
 		} else if (agent.hasActivePermission) {
-			onStateChange("permission");
+			onStateChangeRef.current("permission");
 		} else if (isSending) {
-			onStateChange("busy");
+			onStateChangeRef.current("busy");
 		} else if (isSessionReady) {
-			onStateChange("ready");
+			onStateChangeRef.current("ready");
 		} else {
-			onStateChange("disconnected");
+			onStateChangeRef.current("disconnected");
 		}
 	}, [
-		onStateChange,
 		errorInfo,
 		agent.hasActivePermission,
 		isSending,
@@ -817,7 +822,7 @@ export function ChatPanel({
 
 	// Report label from first user message
 	useEffect(() => {
-		if (!onLabelChange || labelReportedRef.current) return;
+		if (!onLabelChangeRef.current || labelReportedRef.current) return;
 		if (messages.length > 0) {
 			const firstUserMsg = messages.find((m) => m.role === "user");
 			if (firstUserMsg) {
@@ -830,12 +835,12 @@ export function ChatPanel({
 				const text =
 					textBlock && "text" in textBlock ? textBlock.text : "";
 				if (text.trim()) {
-					onLabelChange(text.trim());
+					onLabelChangeRef.current(text.trim());
 					labelReportedRef.current = true;
 				}
 			}
 		}
-	}, [onLabelChange, messages]);
+	}, [messages]);
 
 	// Report session ID changes to parent (for tab rename persistence)
 	useEffect(() => {

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -311,6 +311,17 @@ export function ChatPanel({
 		autoExportIfEnabled,
 	} = actions;
 
+	// Track whether tab label has been reported (reset on new chat / restore)
+	const labelReportedRef = useRef(false);
+
+	const handleLabelChangeFromRestore = useCallback(
+		(label: string) => {
+			onLabelChange?.(label);
+			labelReportedRef.current = true;
+		},
+		[onLabelChange],
+	);
+
 	const { handleOpenHistory } = useHistoryModal(
 		plugin,
 		agent,
@@ -319,6 +330,7 @@ export function ChatPanel({
 		isSessionReady,
 		settings.debugMode,
 		setAgentCwd,
+		handleLabelChangeFromRestore,
 	);
 
 	// ============================================================
@@ -328,6 +340,7 @@ export function ChatPanel({
 		async (requestedAgentId?: string) => {
 			try {
 				await handleNewChat(requestedAgentId);
+				labelReportedRef.current = false;
 				// Persist agent ID for this view (survives Obsidian restart)
 				if (requestedAgentId) {
 					onAgentIdChanged?.(requestedAgentId);
@@ -787,7 +800,6 @@ export function ChatPanel({
 	]);
 
 	// Report label from first user message
-	const labelReportedRef = useRef(false);
 	useEffect(() => {
 		if (!onLabelChange || labelReportedRef.current) return;
 		if (messages.length > 0) {

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -97,6 +97,10 @@ export interface ChatPanelProps {
 	onSessionIdChange?: (sessionId: string | null) => void;
 	/** Whether this tab is the currently active tab (controls focus on activation) */
 	isActive?: boolean;
+	/** Look up whether a session is already open in another tab (I20) */
+	findTabBySessionId?: (sessionId: string) => { tabId: string; label: string } | null;
+	/** Switch to a specific tab by ID (I20) */
+	onSwitchToTab?: (tabId: string) => void;
 }
 
 // ============================================================================
@@ -141,6 +145,8 @@ export function ChatPanel({
 	onLabelChange,
 	onSessionIdChange,
 	isActive,
+	findTabBySessionId,
+	onSwitchToTab,
 }: ChatPanelProps) {
 	// ============================================================
 	// Platform Check
@@ -338,6 +344,8 @@ export function ChatPanel({
 		setAgentCwd,
 		handleLabelChangeFromRestore,
 		session.sessionId ?? undefined,
+		findTabBySessionId,
+		onSwitchToTab,
 	);
 
 	// ============================================================

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -93,6 +93,8 @@ export interface ChatPanelProps {
 	onStateChange?: (state: import("../types/tab").TabState) => void;
 	/** Called when a suitable tab label is available (session title or first message) */
 	onLabelChange?: (label: string) => void;
+	/** Whether this tab is the currently active tab (controls focus on activation) */
+	isActive?: boolean;
 }
 
 // ============================================================================
@@ -135,6 +137,7 @@ export function ChatPanel({
 	containerEl: containerElProp,
 	onStateChange,
 	onLabelChange,
+	isActive,
 }: ChatPanelProps) {
 	// ============================================================
 	// Platform Check
@@ -1170,6 +1173,7 @@ export function ChatPanel({
 			agentUpdateNotification={agentUpdateNotification}
 			onClearAgentUpdate={handleClearAgentUpdate}
 			messages={messages}
+			isActive={isActive}
 		/>
 	);
 

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -1148,6 +1148,7 @@ export function ChatPanel({
 			terminalClient={terminalClientRef.current}
 			onApprovePermission={agent.approvePermission}
 			hasActivePermission={agent.hasActivePermission}
+			isActive={isActive}
 		/>
 	);
 

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -594,6 +594,7 @@ export function ChatPanel({
 		// Floating: create a shim with listener tracking
 		return {
 			app: plugin.app,
+			viewId,
 			registerDomEvent: ((
 				target: Window | Document | HTMLElement,
 				type: string,
@@ -994,7 +995,11 @@ export function ChatPanel({
 	const containerRef = useRef<HTMLDivElement>(null);
 	useEffect(() => {
 		const handleFocus = () => {
-			plugin.setLastActiveChatViewId(viewId);
+			// Use viewHost.viewId (leaf.id for sidebar, floating-chat-N
+			// for floating) — the registry-recognized container ID. Writing
+			// the bare `viewId` prop would be tab.tabId on sidebar tabs and
+			// silently rejected by ViewRegistry.setFocused (I34).
+			plugin.setLastActiveChatViewId(viewHost.viewId);
 		};
 
 		const container = containerElProp ?? containerRef.current;
@@ -1007,7 +1012,7 @@ export function ChatPanel({
 			container.removeEventListener("focus", handleFocus, true);
 			container.removeEventListener("click", handleFocus);
 		};
-	}, [plugin, viewId, containerElProp]);
+	}, [plugin, viewHost, containerElProp]);
 
 	// ============================================================
 	// Callback Registration for IChatViewContainer

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -1003,9 +1003,6 @@ export function ChatPanel({
 		container.addEventListener("focus", handleFocus, true);
 		container.addEventListener("click", handleFocus);
 
-		// Set as active on mount (first opened view becomes active)
-		plugin.setLastActiveChatViewId(viewId);
-
 		return () => {
 			container.removeEventListener("focus", handleFocus, true);
 			container.removeEventListener("click", handleFocus);

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -536,6 +536,11 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		}
 	}
 
+	/** Get the active tab's ID (used as viewId by ChatPanel) */
+	getActiveTabId(): string {
+		return this.tabManagerRef?.activeTabId ?? this.viewId;
+	}
+
 	/** Close the active tab (for Obsidian commands) */
 	closeActiveTab(): void {
 		if (this.tabManagerRef) {

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -343,6 +343,7 @@ function ChatComponent({
 						onError={(tabId) =>
 							handleTabStateChange(tabId, "error")
 						}
+						onRetry={(tabId) => tabManager.resetTab(tabId)}
 					>
 						<TabPanel
 							plugin={plugin}

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -24,7 +24,7 @@ import { TabErrorBoundary } from "./TabErrorBoundary";
 import { EditTitleModal } from "./SessionHistoryModal";
 
 // Hook imports
-import { useTabManager } from "../hooks/useTabManager";
+import { useTabManager, truncateLabel } from "../hooks/useTabManager";
 
 // Service imports
 import { VaultService } from "../services/vault-service";
@@ -201,6 +201,17 @@ function ChatComponent({
 				plugin.app,
 				tab.label,
 				async (newTitle) => {
+					const duplicate = tabs.find(
+						(t) =>
+							t.tabId !== tabId &&
+							t.label === truncateLabel(newTitle),
+					);
+					if (duplicate) {
+						new Notice(
+							"[Agent Client] A tab with that name already exists",
+						);
+						return;
+					}
 					tabManager.setTabLabel(tabId, newTitle);
 
 					// Persist to session history if this tab has a session

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -318,6 +318,7 @@ function ChatComponent({
 								viewId={tab.tabId}
 								initialAgentId={tab.agentId}
 								viewHost={view}
+								isActive={tab.tabId === activeTabId}
 								onRegisterCallbacks={(callbacks) => {
 									if (tab.tabId === activeTabId) {
 										activeCallbacksRef.current =

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -271,7 +271,11 @@ function ChatComponent({
 
 	const handleTabLabelChange = useCallback(
 		(tabId: string, label: string) => {
-			tabManager.setTabLabel(tabId, label);
+			if (label === "") {
+				tabManager.resetTab(tabId);
+			} else {
+				tabManager.setTabLabel(tabId, label);
+			}
 		},
 		[tabManager],
 	);

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -1,14 +1,15 @@
-import { ItemView, WorkspaceLeaf } from "obsidian";
+import { ItemView, WorkspaceLeaf, Menu, Notice, type MenuItem } from "obsidian";
 import type {
 	IChatViewContainer,
 	ChatViewType,
 } from "../services/view-registry";
 import * as React from "react";
-const { useState, useEffect, useMemo } = React;
+const { useEffect, useMemo, useCallback, useRef } = React;
 import { createRoot, Root } from "react-dom/client";
 
 import type AgentClientPlugin from "../plugin";
 import type { ChatInputState } from "../types/chat";
+import type { TabState } from "../types/tab";
 
 // Utility imports
 import { getLogger, Logger } from "../utils/logger";
@@ -18,11 +19,59 @@ import { ChatContextProvider } from "./ChatContext";
 
 // Component imports
 import { ChatPanel, type ChatPanelCallbacks } from "./ChatPanel";
+import { TabBar } from "./TabBar";
+import { TabErrorBoundary } from "./TabErrorBoundary";
+
+// Hook imports
+import { useTabManager } from "../hooks/useTabManager";
 
 // Service imports
 import { VaultService } from "../services/vault-service";
+import type { AcpClient } from "../acp/acp-client";
 
 export const VIEW_TYPE_CHAT = "agent-client-chat-view";
+
+// ============================================================================
+// TabPanel — per-tab wrapper that memoizes context value
+// ============================================================================
+
+/**
+ * Wrapper component for each tab that memoizes the ChatContextProvider value.
+ * Without this, every ChatComponent re-render creates a new context value object
+ * for every tab, causing all ChatPanel instances to re-render unnecessarily.
+ * This was the root cause of I7 (context note toggle stops working after first use).
+ */
+function TabPanel({
+	plugin,
+	acpClient,
+	vaultService,
+	children,
+}: {
+	plugin: AgentClientPlugin;
+	acpClient: AcpClient;
+	vaultService: VaultService;
+	children: React.ReactNode;
+}) {
+	const contextValue = useMemo(
+		() => ({
+			plugin,
+			acpClient,
+			vaultService,
+			settingsService: plugin.settingsService,
+		}),
+		[plugin, acpClient, vaultService],
+	);
+
+	return (
+		<ChatContextProvider value={contextValue}>
+			{children}
+		</ChatContextProvider>
+	);
+}
+
+// ============================================================================
+// ChatComponent — React root with tab management
+// ============================================================================
 
 function ChatComponent({
 	plugin,
@@ -33,91 +82,314 @@ function ChatComponent({
 	view: ChatView;
 	viewId: string;
 }) {
+	const initialAgentId =
+		view.getInitialAgentId() ??
+		plugin.settings.defaultAgentId;
+
+	const tabManager = useTabManager(initialAgentId);
+	const { tabs, activeTabId, activeTab } = tabManager;
+
 	// ============================================================
-	// Agent ID State (synced with Obsidian view state)
+	// Per-tab AcpClient management
 	// ============================================================
-	const [restoredAgentId, setRestoredAgentId] = useState<string | undefined>(
-		view.getInitialAgentId() ?? undefined,
+	const acpClientsRef = useRef<Map<string, AcpClient>>(new Map());
+
+	const getOrCreateClient = useCallback(
+		(tabId: string): AcpClient => {
+			let client = acpClientsRef.current.get(tabId);
+			if (!client) {
+				client = plugin.getOrCreateAcpClient(tabId);
+				acpClientsRef.current.set(tabId, client);
+			}
+			return client;
+		},
+		[plugin],
+	);
+
+	const removeClient = useCallback(
+		async (tabId: string) => {
+			await plugin.removeAcpClient(tabId);
+			acpClientsRef.current.delete(tabId);
+		},
+		[plugin],
+	);
+
+	// Cleanup all clients on unmount
+	useEffect(() => {
+		return () => {
+			for (const tabId of acpClientsRef.current.keys()) {
+				void plugin.removeAcpClient(tabId);
+			}
+			acpClientsRef.current.clear();
+		};
+	}, [plugin]);
+
+	// Shared VaultService (one per view, not per tab)
+	const vaultService = useMemo(
+		() => view.vaultService,
+		[view.vaultService],
 	);
 
 	// ============================================================
-	// Context Value
-	// ============================================================
-	const contextValue = useMemo(
-		() => ({
-			plugin,
-			acpClient: view.acpClient,
-			vaultService: view.vaultService,
-			settingsService: plugin.settingsService,
-		}),
-		[plugin, view.acpClient, view.vaultService],
-	);
-
-	// ============================================================
-	// Agent ID Restoration (ChatView-specific)
-	// Subscribe to agentId restoration from Obsidian's setState
+	// Agent ID restoration from Obsidian setState
 	// ============================================================
 	useEffect(() => {
 		const unsubscribe = view.onAgentIdRestored((agentId) => {
-			setRestoredAgentId(agentId);
+			// Update the active tab's agent
+			tabManager.addTab(agentId);
 		});
 		return unsubscribe;
+	}, [view, tabManager.addTab]);
+
+	// ============================================================
+	// Tab callbacks
+	// ============================================================
+	const handleAddTab = useCallback(() => {
+		const maxTabs = plugin.settings.maxSessionTabs ?? 10;
+		if (tabs.length >= maxTabs) {
+			new Notice(
+				`[Agent Client] Maximum ${maxTabs} tabs reached`,
+			);
+			return;
+		}
+		tabManager.addTab(activeTab.agentId);
+	}, [tabManager, activeTab.agentId, tabs.length, plugin.settings]);
+
+	const handleCloseTab = useCallback(
+		(tabId: string) => {
+			if (tabs.length <= 1) return; // Don't close last tab
+			void removeClient(tabId);
+			tabManager.removeTab(tabId);
+		},
+		[tabs.length, removeClient, tabManager],
+	);
+
+	const handleCloseOtherTabs = useCallback(
+		(tabId: string) => {
+			for (const tab of tabs) {
+				if (tab.tabId !== tabId) {
+					void removeClient(tab.tabId);
+				}
+			}
+			tabManager.removeOtherTabs(tabId);
+		},
+		[tabs, removeClient, tabManager],
+	);
+
+	const handleCloseTabsToRight = useCallback(
+		(tabId: string) => {
+			const idx = tabs.findIndex((t) => t.tabId === tabId);
+			for (let i = idx + 1; i < tabs.length; i++) {
+				void removeClient(tabs[i].tabId);
+			}
+			tabManager.removeTabsToRight(tabId);
+		},
+		[tabs, removeClient, tabManager],
+	);
+
+	const handleRenameTab = useCallback(
+		(tabId: string) => {
+			// TODO: Replace with Obsidian Modal for rename
+			new Notice("[Agent Client] Tab rename coming soon");
+		},
+		[],
+	);
+
+	const handleAddTabWithAgent = useCallback(
+		(e: React.MouseEvent) => {
+			e.preventDefault();
+			const maxTabs = plugin.settings.maxSessionTabs ?? 10;
+			if (tabs.length >= maxTabs) {
+				new Notice(
+					`[Agent Client] Maximum ${maxTabs} tabs reached`,
+				);
+				return;
+			}
+			const menu = new Menu();
+			const agents = plugin.getAvailableAgents();
+			for (const agent of agents) {
+				menu.addItem((item: MenuItem) => {
+					item.setTitle(agent.displayName).onClick(() => {
+						tabManager.addTab(agent.id);
+					});
+				});
+			}
+			menu.showAtMouseEvent(e.nativeEvent);
+		},
+		[plugin, tabs.length, tabManager],
+	);
+
+	// ============================================================
+	// State change callback for tab icons
+	// ============================================================
+	const handleTabStateChange = useCallback(
+		(tabId: string, state: TabState) => {
+			tabManager.setTabState(tabId, state);
+		},
+		[tabManager],
+	);
+
+	const handleTabLabelChange = useCallback(
+		(tabId: string, label: string) => {
+			tabManager.setTabLabel(tabId, label);
+		},
+		[tabManager],
+	);
+
+	// ============================================================
+	// Register callbacks for IChatViewContainer (active tab only)
+	// ============================================================
+	const activeCallbacksRef = useRef<ChatPanelCallbacks | null>(null);
+
+	useEffect(() => {
+		view.setCallbacks({
+			getDisplayName: () =>
+				activeCallbacksRef.current?.getDisplayName() ?? "Chat",
+			getInputState: () =>
+				activeCallbacksRef.current?.getInputState() ?? null,
+			setInputState: (state) =>
+				activeCallbacksRef.current?.setInputState(state),
+			canSend: () =>
+				activeCallbacksRef.current?.canSend() ?? false,
+			sendMessage: async () =>
+				(await activeCallbacksRef.current?.sendMessage()) ??
+				false,
+			cancelOperation: async () =>
+				activeCallbacksRef.current?.cancelOperation(),
+		});
 	}, [view]);
+
+	// ============================================================
+	// Persist agent ID when active tab changes
+	// ============================================================
+	useEffect(() => {
+		view.setAgentId(activeTab.agentId);
+	}, [view, activeTab.agentId]);
+
+	// Expose tabManager to the view class for commands
+	useEffect(() => {
+		view.setTabManager(tabManager);
+	}, [view, tabManager]);
 
 	// ============================================================
 	// Render
 	// ============================================================
 	return (
-		<ChatContextProvider value={contextValue}>
-			<ChatPanel
-				variant="sidebar"
-				viewId={viewId}
-				initialAgentId={restoredAgentId}
-				viewHost={view}
-				onRegisterCallbacks={(callbacks) =>
-					view.setCallbacks(callbacks)
-				}
-				onAgentIdChanged={(agentId) => view.setAgentId(agentId)}
+		<div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+			<TabBar
+				tabs={tabs}
+				activeTabId={activeTabId}
+				onSelectTab={tabManager.setActiveTab}
+				onAddTab={handleAddTab}
+				onCloseTab={handleCloseTab}
+				onCloseOtherTabs={handleCloseOtherTabs}
+				onCloseTabsToRight={handleCloseTabsToRight}
+				onRenameTab={handleRenameTab}
+				onMoveTab={tabManager.moveTab}
+				onAddTabWithAgent={handleAddTabWithAgent}
 			/>
-		</ChatContextProvider>
+			{tabs.map((tab) => (
+				<div
+					key={tab.tabId}
+					className="agent-client-tab-panel"
+					style={{
+						display:
+							tab.tabId === activeTabId
+								? "flex"
+								: "none",
+						flexDirection: "column" as const,
+						flex: 1,
+						minHeight: 0,
+					}}
+				>
+					<TabErrorBoundary
+						tabId={tab.tabId}
+						onError={(tabId) =>
+							handleTabStateChange(tabId, "error")
+						}
+					>
+						<TabPanel
+							plugin={plugin}
+							acpClient={getOrCreateClient(tab.tabId)}
+							vaultService={vaultService}
+						>
+							<ChatPanel
+								variant="sidebar"
+								viewId={tab.tabId}
+								initialAgentId={tab.agentId}
+								viewHost={view}
+								onRegisterCallbacks={(callbacks) => {
+									if (tab.tabId === activeTabId) {
+										activeCallbacksRef.current =
+											callbacks;
+									}
+								}}
+								onAgentIdChanged={(agentId) =>
+									view.setAgentId(agentId)
+								}
+								onStateChange={(state) =>
+									handleTabStateChange(
+										tab.tabId,
+										state,
+									)
+								}
+								onLabelChange={(label) =>
+									handleTabLabelChange(
+										tab.tabId,
+										label,
+									)
+								}
+							/>
+						</TabPanel>
+					</TabErrorBoundary>
+				</div>
+			))}
+		</div>
 	);
 }
+
+// ============================================================================
+// ChatView State
+// ============================================================================
 
 /** State stored for view persistence */
 interface ChatViewState extends Record<string, unknown> {
 	initialAgentId?: string;
 }
 
+// ============================================================================
+// ChatView Class
+// ============================================================================
+
 export class ChatView extends ItemView implements IChatViewContainer {
 	private root: Root | null = null;
 	private plugin: AgentClientPlugin;
 	private logger: Logger;
-	/** Unique identifier for this view instance (for multi-session support) */
+	/** Unique identifier for this view instance */
 	readonly viewId: string;
 	/** View type for IChatViewContainer */
 	readonly viewType: ChatViewType = "sidebar";
-	/** Initial agent ID passed via state (for openNewChatViewWithAgent) */
+	/** Initial agent ID passed via state */
 	private initialAgentId: string | null = null;
-	/** Callbacks to notify React when agentId is restored from workspace state */
+	/** Callbacks to notify React when agentId is restored */
 	private agentIdRestoredCallbacks: Set<(agentId: string) => void> =
 		new Set();
 
-	// Services owned by this class (lifecycle managed here)
-	/** @internal Exposed to ChatComponent for context creation */
-	acpClient!: ReturnType<AgentClientPlugin["getOrCreateAcpClient"]>;
+	// Services owned by this class
 	/** @internal Exposed to ChatComponent for context creation */
 	vaultService!: VaultService;
 
 	// Callbacks from ChatPanel for IChatViewContainer delegation
 	private callbacks: ChatPanelCallbacks | null = null;
 
+	// Tab manager reference (set by React component)
+	private tabManagerRef: ReturnType<typeof useTabManager> | null = null;
+
 	constructor(leaf: WorkspaceLeaf, plugin: AgentClientPlugin) {
 		super(leaf);
 		this.plugin = plugin;
 		this.logger = getLogger();
-		// Static sidebar view (not navigable) — hides .view-header
 		this.navigation = false;
-		// Use leaf.id if available, otherwise generate UUID
 		this.viewId = (leaf as { id?: string }).id ?? crypto.randomUUID();
 	}
 
@@ -133,19 +405,12 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		return "bot-message-square";
 	}
 
-	/**
-	 * Get the view state for persistence.
-	 */
 	getState(): ChatViewState {
 		return {
 			initialAgentId: this.initialAgentId ?? undefined,
 		};
 	}
 
-	/**
-	 * Restore the view state from persistence.
-	 * Notifies React when agentId is restored so it can re-create the session.
-	 */
 	async setState(
 		state: ChatViewState,
 		result: { history: boolean },
@@ -154,7 +419,6 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		this.initialAgentId = state.initialAgentId ?? null;
 		await super.setState(state, result);
 
-		// Notify React when agentId is restored and differs from previous value
 		if (this.initialAgentId && this.initialAgentId !== previousAgentId) {
 			this.agentIdRestoredCallbacks.forEach((cb) =>
 				cb(this.initialAgentId!),
@@ -162,29 +426,15 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		}
 	}
 
-	/**
-	 * Get the initial agent ID for this view.
-	 * Used by ChatComponent to determine which agent to initialize.
-	 */
 	getInitialAgentId(): string | null {
 		return this.initialAgentId;
 	}
 
-	/**
-	 * Set the agent ID for this view.
-	 * Called when agent is switched to persist the change.
-	 */
 	setAgentId(agentId: string): void {
 		this.initialAgentId = agentId;
-		// Request workspace to save the updated state
 		this.app.workspace.requestSaveLayout();
 	}
 
-	/**
-	 * Register a callback to be notified when agentId is restored from workspace state.
-	 * Used by React components to sync with Obsidian's setState lifecycle.
-	 * @returns Unsubscribe function
-	 */
 	onAgentIdRestored(callback: (agentId: string) => void): () => void {
 		this.agentIdRestoredCallbacks.add(callback);
 		return () => {
@@ -193,12 +443,47 @@ export class ChatView extends ItemView implements IChatViewContainer {
 	}
 
 	// ============================================================
+	// Tab Manager (set by React component)
+	// ============================================================
+
+	setTabManager(
+		manager: ReturnType<typeof useTabManager> | null,
+	): void {
+		this.tabManagerRef = manager;
+	}
+
+	/** Add a new tab (for Obsidian commands) */
+	addTab(agentId?: string): void {
+		if (this.tabManagerRef) {
+			this.tabManagerRef.addTab(
+				agentId ?? this.plugin.settings.defaultAgentId,
+			);
+		}
+	}
+
+	/** Close the active tab (for Obsidian commands) */
+	closeActiveTab(): void {
+		if (this.tabManagerRef) {
+			this.tabManagerRef.removeTab(
+				this.tabManagerRef.activeTabId,
+			);
+		}
+	}
+
+	/** Switch to next tab (for Obsidian commands) */
+	nextTab(): void {
+		this.tabManagerRef?.nextTab();
+	}
+
+	/** Switch to previous tab (for Obsidian commands) */
+	prevTab(): void {
+		this.tabManagerRef?.prevTab();
+	}
+
+	// ============================================================
 	// Callbacks from ChatPanel
 	// ============================================================
 
-	/**
-	 * Register callbacks from ChatPanel for IChatViewContainer delegation.
-	 */
 	setCallbacks(callbacks: ChatPanelCallbacks): void {
 		this.callbacks = callbacks;
 	}
@@ -207,38 +492,22 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		return this.callbacks?.getDisplayName() ?? "Chat";
 	}
 
-	/**
-	 * Get current input state (text + images).
-	 * Returns null if React component not mounted.
-	 */
 	getInputState(): ChatInputState | null {
 		return this.callbacks?.getInputState() ?? null;
 	}
 
-	/**
-	 * Set input state (text + images).
-	 */
 	setInputState(state: ChatInputState): void {
 		this.callbacks?.setInputState(state);
 	}
 
-	/**
-	 * Trigger send message. Returns true if message was sent.
-	 */
 	async sendMessage(): Promise<boolean> {
 		return (await this.callbacks?.sendMessage()) ?? false;
 	}
 
-	/**
-	 * Check if this view can send a message.
-	 */
 	canSend(): boolean {
 		return this.callbacks?.canSend() ?? false;
 	}
 
-	/**
-	 * Cancel current operation.
-	 */
 	async cancelOperation(): Promise<void> {
 		await this.callbacks?.cancelOperation();
 	}
@@ -247,25 +516,14 @@ export class ChatView extends ItemView implements IChatViewContainer {
 	// IChatViewContainer Implementation
 	// ============================================================
 
-	/**
-	 * Called when this view becomes the active/focused view.
-	 */
 	onActivate(): void {
 		this.logger.log(`[ChatView] Activated: ${this.viewId}`);
 	}
 
-	/**
-	 * Called when this view loses active/focused status.
-	 */
 	onDeactivate(): void {
 		this.logger.log(`[ChatView] Deactivated: ${this.viewId}`);
 	}
 
-	/**
-	 * Programmatically focus this view's input.
-	 * Reveals the leaf first so that Obsidian switches to this tab
-	 * before focusing the textarea (required for sidebar tabs).
-	 */
 	focus(): void {
 		void this.app.workspace.revealLeaf(this.leaf).then(() => {
 			const textarea = this.containerEl.querySelector(
@@ -277,28 +535,18 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		});
 	}
 
-	/**
-	 * Check if this view currently has focus.
-	 */
 	hasFocus(): boolean {
 		return this.containerEl.contains(document.activeElement);
 	}
 
-	/**
-	 * Expand the view if it's in a collapsed state.
-	 * Sidebar views don't have expand/collapse state - no-op.
-	 */
 	expand(): void {
-		// Sidebar views don't have expand/collapse state - no-op
+		// Sidebar views don't have expand/collapse state
 	}
 
 	collapse(): void {
-		// Sidebar views don't have expand/collapse state - no-op
+		// Sidebar views don't have expand/collapse state
 	}
 
-	/**
-	 * Get the DOM container element for this view.
-	 */
 	getContainerEl(): HTMLElement {
 		return this.containerEl;
 	}
@@ -307,8 +555,7 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		const container = this.containerEl.children[1];
 		container.empty();
 
-		// Create services owned by this class
-		this.acpClient = this.plugin.getOrCreateAcpClient(this.viewId);
+		// VaultService is shared across all tabs in this view
 		this.vaultService = new VaultService(this.plugin);
 
 		this.root = createRoot(container);
@@ -320,29 +567,22 @@ export class ChatView extends ItemView implements IChatViewContainer {
 			/>,
 		);
 
-		// Register with plugin's view registry
 		this.plugin.viewRegistry.register(this);
-
 		return Promise.resolve();
 	}
 
 	async onClose(): Promise<void> {
 		this.logger.log("[ChatView] onClose() called");
 
-		// Unregister from plugin's view registry
 		this.plugin.viewRegistry.unregister(this.viewId);
 
-		// Cleanup is handled by React useEffect cleanup in ChatPanel
-		// which performs auto-export and closeSession
+		// React cleanup handles per-tab AcpClient disconnection
 		if (this.root) {
 			this.root.unmount();
 			this.root = null;
 		}
 
-		// Cleanup services owned by this class
 		this.vaultService?.destroy();
-
-		// Remove adapter for this view (disconnect process)
-		await this.plugin.removeAcpClient(this.viewId);
+		this.tabManagerRef = null;
 	}
 }

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -21,6 +21,7 @@ import { ChatContextProvider } from "./ChatContext";
 import { ChatPanel, type ChatPanelCallbacks } from "./ChatPanel";
 import { TabBar } from "./TabBar";
 import { TabErrorBoundary } from "./TabErrorBoundary";
+import { EditTitleModal } from "./SessionHistoryModal";
 
 // Hook imports
 import { useTabManager } from "../hooks/useTabManager";
@@ -94,6 +95,9 @@ function ChatComponent({
 	// ============================================================
 	const acpClientsRef = useRef<Map<string, AcpClient>>(new Map());
 
+	// Per-tab session ID tracking (for rename persistence to session history)
+	const tabSessionIdsRef = useRef<Map<string, string | null>>(new Map());
+
 	const getOrCreateClient = useCallback(
 		(tabId: string): AcpClient => {
 			let client = acpClientsRef.current.get(tabId);
@@ -110,6 +114,7 @@ function ChatComponent({
 		async (tabId: string) => {
 			await plugin.removeAcpClient(tabId);
 			acpClientsRef.current.delete(tabId);
+			tabSessionIdsRef.current.delete(tabId);
 		},
 		[plugin],
 	);
@@ -189,10 +194,34 @@ function ChatComponent({
 
 	const handleRenameTab = useCallback(
 		(tabId: string) => {
-			// TODO: Replace with Obsidian Modal for rename
-			new Notice("[Agent Client] Tab rename coming soon");
+			const tab = tabs.find((t) => t.tabId === tabId);
+			if (!tab) return;
+
+			const modal = new EditTitleModal(
+				plugin.app,
+				tab.label,
+				async (newTitle) => {
+					tabManager.setTabLabel(tabId, newTitle);
+
+					// Persist to session history if this tab has a session
+					const sessionId = tabSessionIdsRef.current.get(tabId);
+					if (sessionId) {
+						const saved = plugin.settingsService
+							.getSavedSessions()
+							.find((s) => s.sessionId === sessionId);
+						if (saved) {
+							await plugin.settingsService.saveSession({
+								...saved,
+								title: newTitle,
+								updatedAt: new Date().toISOString(),
+							});
+						}
+					}
+				},
+			);
+			modal.open();
 		},
-		[],
+		[tabs, plugin, tabManager],
 	);
 
 	const handleAddTabWithAgent = useCallback(
@@ -234,6 +263,13 @@ function ChatComponent({
 			tabManager.setTabLabel(tabId, label);
 		},
 		[tabManager],
+	);
+
+	const handleSessionIdChange = useCallback(
+		(tabId: string, sessionId: string | null) => {
+			tabSessionIdsRef.current.set(tabId, sessionId);
+		},
+		[],
 	);
 
 	// ============================================================
@@ -338,6 +374,12 @@ function ChatComponent({
 									handleTabLabelChange(
 										tab.tabId,
 										label,
+									)
+								}
+								onSessionIdChange={(sessionId) =>
+									handleSessionIdChange(
+										tab.tabId,
+										sessionId,
 									)
 								}
 							/>

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -283,6 +283,20 @@ function ChatComponent({
 		[],
 	);
 
+	/** Find a tab that owns the given session ID (for I20: avoid restoring an already-open session) */
+	const findTabBySessionId = useCallback(
+		(sessionId: string): { tabId: string; label: string } | null => {
+			for (const [tabId, sid] of tabSessionIdsRef.current) {
+				if (sid === sessionId) {
+					const tab = tabs.find((t) => t.tabId === tabId);
+					if (tab) return { tabId: tab.tabId, label: tab.label };
+				}
+			}
+			return null;
+		},
+		[tabs],
+	);
+
 	// ============================================================
 	// Register callbacks for IChatViewContainer (active tab only)
 	// ============================================================
@@ -394,6 +408,8 @@ function ChatComponent({
 										sessionId,
 									)
 								}
+								findTabBySessionId={findTabBySessionId}
+								onSwitchToTab={tabManager.setActiveTab}
 							/>
 						</TabPanel>
 					</TabErrorBoundary>

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -1,14 +1,15 @@
-import { ItemView, WorkspaceLeaf } from "obsidian";
+import { ItemView, WorkspaceLeaf, Menu, Notice, type MenuItem } from "obsidian";
 import type {
 	IChatViewContainer,
 	ChatViewType,
 } from "../services/view-registry";
 import * as React from "react";
-const { useState, useEffect, useMemo } = React;
+const { useEffect, useMemo, useCallback, useRef } = React;
 import { createRoot, Root } from "react-dom/client";
 
 import type AgentClientPlugin from "../plugin";
 import type { ChatInputState } from "../types/chat";
+import type { TabState } from "../types/tab";
 
 // Utility imports
 import { getLogger, Logger } from "../utils/logger";
@@ -18,11 +19,59 @@ import { ChatContextProvider } from "./ChatContext";
 
 // Component imports
 import { ChatPanel, type ChatPanelCallbacks } from "./ChatPanel";
+import { TabBar } from "./TabBar";
+import { TabErrorBoundary } from "./TabErrorBoundary";
+
+// Hook imports
+import { useTabManager } from "../hooks/useTabManager";
 
 // Service imports
 import { VaultService } from "../services/vault-service";
+import type { AcpClient } from "../acp/acp-client";
 
 export const VIEW_TYPE_CHAT = "agent-client-chat-view";
+
+// ============================================================================
+// TabPanel — per-tab wrapper that memoizes context value
+// ============================================================================
+
+/**
+ * Wrapper component for each tab that memoizes the ChatContextProvider value.
+ * Without this, every ChatComponent re-render creates a new context value object
+ * for every tab, causing all ChatPanel instances to re-render unnecessarily.
+ * This was the root cause of I7 (context note toggle stops working after first use).
+ */
+function TabPanel({
+	plugin,
+	acpClient,
+	vaultService,
+	children,
+}: {
+	plugin: AgentClientPlugin;
+	acpClient: AcpClient;
+	vaultService: VaultService;
+	children: React.ReactNode;
+}) {
+	const contextValue = useMemo(
+		() => ({
+			plugin,
+			acpClient,
+			vaultService,
+			settingsService: plugin.settingsService,
+		}),
+		[plugin, acpClient, vaultService],
+	);
+
+	return (
+		<ChatContextProvider value={contextValue}>
+			{children}
+		</ChatContextProvider>
+	);
+}
+
+// ============================================================================
+// ChatComponent — React root with tab management
+// ============================================================================
 
 function ChatComponent({
 	plugin,
@@ -33,91 +82,314 @@ function ChatComponent({
 	view: ChatView;
 	viewId: string;
 }) {
+	const initialAgentId =
+		view.getInitialAgentId() ??
+		plugin.settings.defaultAgentId;
+
+	const tabManager = useTabManager(initialAgentId);
+	const { tabs, activeTabId, activeTab } = tabManager;
+
 	// ============================================================
-	// Agent ID State (synced with Obsidian view state)
+	// Per-tab AcpClient management
 	// ============================================================
-	const [restoredAgentId, setRestoredAgentId] = useState<string | undefined>(
-		view.getInitialAgentId() ?? undefined,
+	const acpClientsRef = useRef<Map<string, AcpClient>>(new Map());
+
+	const getOrCreateClient = useCallback(
+		(tabId: string): AcpClient => {
+			let client = acpClientsRef.current.get(tabId);
+			if (!client) {
+				client = plugin.getOrCreateAcpClient(tabId);
+				acpClientsRef.current.set(tabId, client);
+			}
+			return client;
+		},
+		[plugin],
+	);
+
+	const removeClient = useCallback(
+		async (tabId: string) => {
+			await plugin.removeAcpClient(tabId);
+			acpClientsRef.current.delete(tabId);
+		},
+		[plugin],
+	);
+
+	// Cleanup all clients on unmount
+	useEffect(() => {
+		return () => {
+			for (const tabId of acpClientsRef.current.keys()) {
+				void plugin.removeAcpClient(tabId);
+			}
+			acpClientsRef.current.clear();
+		};
+	}, [plugin]);
+
+	// Shared VaultService (one per view, not per tab)
+	const vaultService = useMemo(
+		() => view.vaultService,
+		[view.vaultService],
 	);
 
 	// ============================================================
-	// Context Value
-	// ============================================================
-	const contextValue = useMemo(
-		() => ({
-			plugin,
-			acpClient: view.acpClient,
-			vaultService: view.vaultService,
-			settingsService: plugin.settingsService,
-		}),
-		[plugin, view.acpClient, view.vaultService],
-	);
-
-	// ============================================================
-	// Agent ID Restoration (ChatView-specific)
-	// Subscribe to agentId restoration from Obsidian's setState
+	// Agent ID restoration from Obsidian setState
 	// ============================================================
 	useEffect(() => {
 		const unsubscribe = view.onAgentIdRestored((agentId) => {
-			setRestoredAgentId(agentId);
+			// Update the active tab's agent
+			tabManager.addTab(agentId);
 		});
 		return unsubscribe;
+	}, [view, tabManager.addTab]);
+
+	// ============================================================
+	// Tab callbacks
+	// ============================================================
+	const handleAddTab = useCallback(() => {
+		const maxTabs = plugin.settings.maxSessionTabs ?? 10;
+		if (tabs.length >= maxTabs) {
+			new Notice(
+				`[Agent Client] Maximum ${maxTabs} tabs reached`,
+			);
+			return;
+		}
+		tabManager.addTab(activeTab.agentId);
+	}, [tabManager, activeTab.agentId, tabs.length, plugin.settings]);
+
+	const handleCloseTab = useCallback(
+		(tabId: string) => {
+			if (tabs.length <= 1) return; // Don't close last tab
+			void removeClient(tabId);
+			tabManager.removeTab(tabId);
+		},
+		[tabs.length, removeClient, tabManager],
+	);
+
+	const handleCloseOtherTabs = useCallback(
+		(tabId: string) => {
+			for (const tab of tabs) {
+				if (tab.tabId !== tabId) {
+					void removeClient(tab.tabId);
+				}
+			}
+			tabManager.removeOtherTabs(tabId);
+		},
+		[tabs, removeClient, tabManager],
+	);
+
+	const handleCloseTabsToRight = useCallback(
+		(tabId: string) => {
+			const idx = tabs.findIndex((t) => t.tabId === tabId);
+			for (let i = idx + 1; i < tabs.length; i++) {
+				void removeClient(tabs[i].tabId);
+			}
+			tabManager.removeTabsToRight(tabId);
+		},
+		[tabs, removeClient, tabManager],
+	);
+
+	const handleRenameTab = useCallback(
+		(tabId: string) => {
+			// TODO: Replace with Obsidian Modal for rename
+			new Notice("[Agent Client] Tab rename coming soon");
+		},
+		[],
+	);
+
+	const handleAddTabWithAgent = useCallback(
+		(e: React.MouseEvent) => {
+			e.preventDefault();
+			const maxTabs = plugin.settings.maxSessionTabs ?? 10;
+			if (tabs.length >= maxTabs) {
+				new Notice(
+					`[Agent Client] Maximum ${maxTabs} tabs reached`,
+				);
+				return;
+			}
+			const menu = new Menu();
+			const agents = plugin.getAvailableAgents();
+			for (const agent of agents) {
+				menu.addItem((item: MenuItem) => {
+					item.setTitle(agent.displayName).onClick(() => {
+						tabManager.addTab(agent.id);
+					});
+				});
+			}
+			menu.showAtMouseEvent(e.nativeEvent);
+		},
+		[plugin, tabs.length, tabManager],
+	);
+
+	// ============================================================
+	// State change callback for tab icons
+	// ============================================================
+	const handleTabStateChange = useCallback(
+		(tabId: string, state: TabState) => {
+			tabManager.setTabState(tabId, state);
+		},
+		[tabManager],
+	);
+
+	const handleTabLabelChange = useCallback(
+		(tabId: string, label: string) => {
+			tabManager.setTabLabel(tabId, label);
+		},
+		[tabManager],
+	);
+
+	// ============================================================
+	// Register callbacks for IChatViewContainer (active tab only)
+	// ============================================================
+	const activeCallbacksRef = useRef<ChatPanelCallbacks | null>(null);
+
+	useEffect(() => {
+		view.setCallbacks({
+			getDisplayName: () =>
+				activeCallbacksRef.current?.getDisplayName() ?? "Chat",
+			getInputState: () =>
+				activeCallbacksRef.current?.getInputState() ?? null,
+			setInputState: (state) =>
+				activeCallbacksRef.current?.setInputState(state),
+			canSend: () =>
+				activeCallbacksRef.current?.canSend() ?? false,
+			sendMessage: async () =>
+				(await activeCallbacksRef.current?.sendMessage()) ??
+				false,
+			cancelOperation: async () =>
+				activeCallbacksRef.current?.cancelOperation(),
+		});
 	}, [view]);
+
+	// ============================================================
+	// Persist agent ID when active tab changes
+	// ============================================================
+	useEffect(() => {
+		view.setAgentId(activeTab.agentId);
+	}, [view, activeTab.agentId]);
+
+	// Expose tabManager to the view class for commands
+	useEffect(() => {
+		view.setTabManager(tabManager);
+	}, [view, tabManager]);
 
 	// ============================================================
 	// Render
 	// ============================================================
 	return (
-		<ChatContextProvider value={contextValue}>
-			<ChatPanel
-				variant="sidebar"
-				viewId={viewId}
-				initialAgentId={restoredAgentId}
-				viewHost={view}
-				onRegisterCallbacks={(callbacks) =>
-					view.setCallbacks(callbacks)
-				}
-				onAgentIdChanged={(agentId) => view.setAgentId(agentId)}
+		<div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+			<TabBar
+				tabs={tabs}
+				activeTabId={activeTabId}
+				onSelectTab={tabManager.setActiveTab}
+				onAddTab={handleAddTab}
+				onCloseTab={handleCloseTab}
+				onCloseOtherTabs={handleCloseOtherTabs}
+				onCloseTabsToRight={handleCloseTabsToRight}
+				onRenameTab={handleRenameTab}
+				onMoveTab={tabManager.moveTab}
+				onAddTabWithAgent={handleAddTabWithAgent}
 			/>
-		</ChatContextProvider>
+			{tabs.map((tab) => (
+				<div
+					key={tab.tabId}
+					className="agent-client-tab-panel"
+					style={{
+						display:
+							tab.tabId === activeTabId
+								? "flex"
+								: "none",
+						flexDirection: "column" as const,
+						flex: 1,
+						minHeight: 0,
+					}}
+				>
+					<TabErrorBoundary
+						tabId={tab.tabId}
+						onError={(tabId) =>
+							handleTabStateChange(tabId, "error")
+						}
+					>
+						<TabPanel
+							plugin={plugin}
+							acpClient={getOrCreateClient(tab.tabId)}
+							vaultService={vaultService}
+						>
+							<ChatPanel
+								variant="sidebar"
+								viewId={tab.tabId}
+								initialAgentId={tab.agentId}
+								viewHost={view}
+								onRegisterCallbacks={(callbacks) => {
+									if (tab.tabId === activeTabId) {
+										activeCallbacksRef.current =
+											callbacks;
+									}
+								}}
+								onAgentIdChanged={(agentId) =>
+									view.setAgentId(agentId)
+								}
+								onStateChange={(state) =>
+									handleTabStateChange(
+										tab.tabId,
+										state,
+									)
+								}
+								onLabelChange={(label) =>
+									handleTabLabelChange(
+										tab.tabId,
+										label,
+									)
+								}
+							/>
+						</TabPanel>
+					</TabErrorBoundary>
+				</div>
+			))}
+		</div>
 	);
 }
+
+// ============================================================================
+// ChatView State
+// ============================================================================
 
 /** State stored for view persistence */
 interface ChatViewState extends Record<string, unknown> {
 	initialAgentId?: string;
 }
 
+// ============================================================================
+// ChatView Class
+// ============================================================================
+
 export class ChatView extends ItemView implements IChatViewContainer {
 	private root: Root | null = null;
 	private plugin: AgentClientPlugin;
 	private logger: Logger;
-	/** Unique identifier for this view instance (for multi-session support) */
+	/** Unique identifier for this view instance */
 	readonly viewId: string;
 	/** View type for IChatViewContainer */
 	readonly viewType: ChatViewType = "sidebar";
-	/** Initial agent ID passed via state (for openNewChatViewWithAgent) */
+	/** Initial agent ID passed via state */
 	private initialAgentId: string | null = null;
-	/** Callbacks to notify React when agentId is restored from workspace state */
+	/** Callbacks to notify React when agentId is restored */
 	private agentIdRestoredCallbacks: Set<(agentId: string) => void> =
 		new Set();
 
-	// Services owned by this class (lifecycle managed here)
-	/** @internal Exposed to ChatComponent for context creation */
-	acpClient!: ReturnType<AgentClientPlugin["getOrCreateAcpClient"]>;
+	// Services owned by this class
 	/** @internal Exposed to ChatComponent for context creation */
 	vaultService!: VaultService;
 
 	// Callbacks from ChatPanel for IChatViewContainer delegation
 	private callbacks: ChatPanelCallbacks | null = null;
 
+	// Tab manager reference (set by React component)
+	private tabManagerRef: ReturnType<typeof useTabManager> | null = null;
+
 	constructor(leaf: WorkspaceLeaf, plugin: AgentClientPlugin) {
 		super(leaf);
 		this.plugin = plugin;
 		this.logger = getLogger();
-		// Static sidebar view (not navigable) — hides .view-header
 		this.navigation = false;
-		// Use leaf.id if available, otherwise generate UUID
 		this.viewId = (leaf as { id?: string }).id ?? crypto.randomUUID();
 	}
 
@@ -133,19 +405,12 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		return "bot-message-square";
 	}
 
-	/**
-	 * Get the view state for persistence.
-	 */
 	getState(): ChatViewState {
 		return {
 			initialAgentId: this.initialAgentId ?? undefined,
 		};
 	}
 
-	/**
-	 * Restore the view state from persistence.
-	 * Notifies React when agentId is restored so it can re-create the session.
-	 */
 	async setState(
 		state: ChatViewState,
 		result: { history: boolean },
@@ -154,7 +419,6 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		this.initialAgentId = state.initialAgentId ?? null;
 		await super.setState(state, result);
 
-		// Notify React when agentId is restored and differs from previous value
 		if (this.initialAgentId && this.initialAgentId !== previousAgentId) {
 			this.agentIdRestoredCallbacks.forEach((cb) =>
 				cb(this.initialAgentId!),
@@ -162,29 +426,15 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		}
 	}
 
-	/**
-	 * Get the initial agent ID for this view.
-	 * Used by ChatComponent to determine which agent to initialize.
-	 */
 	getInitialAgentId(): string | null {
 		return this.initialAgentId;
 	}
 
-	/**
-	 * Set the agent ID for this view.
-	 * Called when agent is switched to persist the change.
-	 */
 	setAgentId(agentId: string): void {
 		this.initialAgentId = agentId;
-		// Request workspace to save the updated state
 		this.app.workspace.requestSaveLayout();
 	}
 
-	/**
-	 * Register a callback to be notified when agentId is restored from workspace state.
-	 * Used by React components to sync with Obsidian's setState lifecycle.
-	 * @returns Unsubscribe function
-	 */
 	onAgentIdRestored(callback: (agentId: string) => void): () => void {
 		this.agentIdRestoredCallbacks.add(callback);
 		return () => {
@@ -193,12 +443,47 @@ export class ChatView extends ItemView implements IChatViewContainer {
 	}
 
 	// ============================================================
+	// Tab Manager (set by React component)
+	// ============================================================
+
+	setTabManager(
+		manager: ReturnType<typeof useTabManager> | null,
+	): void {
+		this.tabManagerRef = manager;
+	}
+
+	/** Add a new tab (for Obsidian commands) */
+	addTab(agentId?: string): void {
+		if (this.tabManagerRef) {
+			this.tabManagerRef.addTab(
+				agentId ?? this.plugin.settings.defaultAgentId,
+			);
+		}
+	}
+
+	/** Close the active tab (for Obsidian commands) */
+	closeActiveTab(): void {
+		if (this.tabManagerRef) {
+			this.tabManagerRef.removeTab(
+				this.tabManagerRef.activeTabId,
+			);
+		}
+	}
+
+	/** Switch to next tab (for Obsidian commands) */
+	nextTab(): void {
+		this.tabManagerRef?.nextTab();
+	}
+
+	/** Switch to previous tab (for Obsidian commands) */
+	prevTab(): void {
+		this.tabManagerRef?.prevTab();
+	}
+
+	// ============================================================
 	// Callbacks from ChatPanel
 	// ============================================================
 
-	/**
-	 * Register callbacks from ChatPanel for IChatViewContainer delegation.
-	 */
 	setCallbacks(callbacks: ChatPanelCallbacks): void {
 		this.callbacks = callbacks;
 	}
@@ -207,38 +492,22 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		return this.callbacks?.getDisplayName() ?? "Chat";
 	}
 
-	/**
-	 * Get current input state (text + images).
-	 * Returns null if React component not mounted.
-	 */
 	getInputState(): ChatInputState | null {
 		return this.callbacks?.getInputState() ?? null;
 	}
 
-	/**
-	 * Set input state (text + images).
-	 */
 	setInputState(state: ChatInputState): void {
 		this.callbacks?.setInputState(state);
 	}
 
-	/**
-	 * Trigger send message. Returns true if message was sent.
-	 */
 	async sendMessage(): Promise<boolean> {
 		return (await this.callbacks?.sendMessage()) ?? false;
 	}
 
-	/**
-	 * Check if this view can send a message.
-	 */
 	canSend(): boolean {
 		return this.callbacks?.canSend() ?? false;
 	}
 
-	/**
-	 * Cancel current operation.
-	 */
 	async cancelOperation(): Promise<void> {
 		await this.callbacks?.cancelOperation();
 	}
@@ -247,25 +516,14 @@ export class ChatView extends ItemView implements IChatViewContainer {
 	// IChatViewContainer Implementation
 	// ============================================================
 
-	/**
-	 * Called when this view becomes the active/focused view.
-	 */
 	onActivate(): void {
 		this.logger.log(`[ChatView] Activated: ${this.viewId}`);
 	}
 
-	/**
-	 * Called when this view loses active/focused status.
-	 */
 	onDeactivate(): void {
 		this.logger.log(`[ChatView] Deactivated: ${this.viewId}`);
 	}
 
-	/**
-	 * Programmatically focus this view's input.
-	 * Reveals the leaf first so that Obsidian switches to this tab
-	 * before focusing the textarea (required for sidebar tabs).
-	 */
 	focus(): void {
 		void this.app.workspace.revealLeaf(this.leaf).then(() => {
 			const textarea = this.containerEl.querySelector(
@@ -277,28 +535,18 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		});
 	}
 
-	/**
-	 * Check if this view currently has focus.
-	 */
 	hasFocus(): boolean {
 		return this.containerEl.contains(activeDocument.activeElement);
 	}
 
-	/**
-	 * Expand the view if it's in a collapsed state.
-	 * Sidebar views don't have expand/collapse state - no-op.
-	 */
 	expand(): void {
-		// Sidebar views don't have expand/collapse state - no-op
+		// Sidebar views don't have expand/collapse state
 	}
 
 	collapse(): void {
-		// Sidebar views don't have expand/collapse state - no-op
+		// Sidebar views don't have expand/collapse state
 	}
 
-	/**
-	 * Get the DOM container element for this view.
-	 */
 	getContainerEl(): HTMLElement {
 		return this.containerEl;
 	}
@@ -307,8 +555,7 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		const container = this.containerEl.children[1];
 		container.empty();
 
-		// Create services owned by this class
-		this.acpClient = this.plugin.getOrCreateAcpClient(this.viewId);
+		// VaultService is shared across all tabs in this view
 		this.vaultService = new VaultService(this.plugin);
 
 		this.root = createRoot(container);
@@ -320,29 +567,22 @@ export class ChatView extends ItemView implements IChatViewContainer {
 			/>,
 		);
 
-		// Register with plugin's view registry
 		this.plugin.viewRegistry.register(this);
-
 		return Promise.resolve();
 	}
 
 	async onClose(): Promise<void> {
 		this.logger.log("[ChatView] onClose() called");
 
-		// Unregister from plugin's view registry
 		this.plugin.viewRegistry.unregister(this.viewId);
 
-		// Cleanup is handled by React useEffect cleanup in ChatPanel
-		// which performs auto-export and closeSession
+		// React cleanup handles per-tab AcpClient disconnection
 		if (this.root) {
 			this.root.unmount();
 			this.root = null;
 		}
 
-		// Cleanup services owned by this class
 		this.vaultService?.destroy();
-
-		// Remove adapter for this view (disconnect process)
-		await this.plugin.removeAcpClient(this.viewId);
+		this.tabManagerRef = null;
 	}
 }

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -245,6 +245,8 @@ export interface InputAreaProps {
 	onClearAgentUpdate: () => void;
 	/** Messages array for input history navigation */
 	messages: ChatMessage[];
+	/** Whether this tab is the currently active tab (focuses textarea on activation) */
+	isActive?: boolean;
 }
 
 /**
@@ -295,6 +297,7 @@ export function InputArea({
 	onClearAgentUpdate,
 	// Input history
 	messages,
+	isActive,
 }: InputAreaProps) {
 	const { mentions, commands: slashCommands } = suggestions;
 	const logger = getLogger();
@@ -934,6 +937,19 @@ export function InputArea({
 			}
 		}, 0);
 	}, []);
+
+	// Focus textarea when this tab becomes active (I19)
+	// Tabs are kept mounted and hidden via display:none; without this, hotkey-
+	// driven tab switches leave focus on the previously active tab's textarea.
+	useEffect(() => {
+		if (isActive) {
+			window.setTimeout(() => {
+				if (textareaRef.current) {
+					textareaRef.current.focus();
+				}
+			}, 0);
+		}
+	}, [isActive]);
 
 	// Restore message when provided (e.g., after cancellation)
 	// Only restore if input is empty to avoid overwriting user's new input

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -320,12 +320,28 @@ export function InputArea({
 
 	// Refs
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const autoMentionToggleRef = useRef<HTMLButtonElement | null>(null);
 	const dragCounterRef = useRef(0);
+
+	// Stable callback ref for auto-mention toggle button — sets icon on mount
+	const autoMentionToggleCallbackRef = useCallback((el: HTMLButtonElement | null) => {
+		autoMentionToggleRef.current = el;
+		if (el) {
+			setIcon(el, "x"); // default: auto-mention enabled → show × to disable
+		}
+	}, []);
 
 	// Clear attached files when agent changes
 	useEffect(() => {
 		onAttachedFilesChange([]);
 	}, [agentId, onAttachedFilesChange]);
+
+	// Sync auto-mention toggle icon when disabled state changes
+	useEffect(() => {
+		if (autoMentionToggleRef.current) {
+			setIcon(autoMentionToggleRef.current, mentions.isAutoMentionDisabled ? "plus" : "x");
+		}
+	}, [mentions.isAutoMentionDisabled]);
 
 	/**
 	 * Add multiple attachments at once with limit enforcement.
@@ -1018,29 +1034,17 @@ export function InputArea({
 						</span>
 						<button
 							className="agent-client-auto-mention-toggle-btn"
-							onClick={(e) => {
-								const newDisabledState =
-									!mentions.isAutoMentionDisabled;
-								mentions.toggleAutoMention(newDisabledState);
-								const iconName = newDisabledState
-									? "x"
-									: "plus";
-								setIcon(e.currentTarget, iconName);
+							onClick={() => {
+								mentions.toggleAutoMention(
+									!mentions.isAutoMentionDisabled,
+								);
 							}}
 							title={
 								mentions.isAutoMentionDisabled
 									? "Enable auto-mention"
 									: "Temporarily disable auto-mention"
 							}
-							ref={(el) => {
-								if (el) {
-									const iconName =
-										mentions.isAutoMentionDisabled
-											? "plus"
-											: "x";
-									setIcon(el, iconName);
-								}
-							}}
+							ref={autoMentionToggleCallbackRef}
 						/>
 					</div>
 				)}

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -951,6 +951,30 @@ export function InputArea({
 		}
 	}, [isActive]);
 
+	// Focus textarea when the ACP panel regains visibility from another
+	// Obsidian pane. The isActive effect above only fires on tab switches
+	// within ACP, not on leaf-level focus changes. (I26)
+	const panelWasVisibleRef = useRef(true);
+	useEffect(() => {
+		const textarea = textareaRef.current;
+		if (!textarea) return;
+
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				const visible = entry.isIntersecting;
+				if (visible && !panelWasVisibleRef.current && isActive) {
+					window.setTimeout(() => {
+						textareaRef.current?.focus();
+					}, 0);
+				}
+				panelWasVisibleRef.current = visible;
+			},
+			{ threshold: 0.1 },
+		);
+		observer.observe(textarea);
+		return () => observer.disconnect();
+	}, [isActive]);
+
 	// Restore message when provided (e.g., after cancellation)
 	// Only restore if input is empty to avoid overwriting user's new input
 	useEffect(() => {

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -932,6 +932,30 @@ export function InputArea({
 		}
 	}, [isActive]);
 
+	// Focus textarea when the ACP panel regains visibility from another
+	// Obsidian pane. The isActive effect above only fires on tab switches
+	// within ACP, not on leaf-level focus changes. (I26)
+	const panelWasVisibleRef = useRef(true);
+	useEffect(() => {
+		const textarea = textareaRef.current;
+		if (!textarea) return;
+
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				const visible = entry.isIntersecting;
+				if (visible && !panelWasVisibleRef.current && isActive) {
+					window.setTimeout(() => {
+						textareaRef.current?.focus();
+					}, 0);
+				}
+				panelWasVisibleRef.current = visible;
+			},
+			{ threshold: 0.1 },
+		);
+		observer.observe(textarea);
+		return () => observer.disconnect();
+	}, [isActive]);
+
 	// Restore message when provided (e.g., after cancellation)
 	// Only restore if input is empty to avoid overwriting user's new input
 	useEffect(() => {

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -245,6 +245,8 @@ export interface InputAreaProps {
 	onClearAgentUpdate: () => void;
 	/** Messages array for input history navigation */
 	messages: ChatMessage[];
+	/** Whether this tab is the currently active tab (focuses textarea on activation) */
+	isActive?: boolean;
 }
 
 /**
@@ -295,6 +297,7 @@ export function InputArea({
 	onClearAgentUpdate,
 	// Input history
 	messages,
+	isActive,
 }: InputAreaProps) {
 	const { mentions, commands: slashCommands } = suggestions;
 	const logger = getLogger();
@@ -915,6 +918,19 @@ export function InputArea({
 			}
 		}, 0);
 	}, []);
+
+	// Focus textarea when this tab becomes active (I19)
+	// Tabs are kept mounted and hidden via display:none; without this, hotkey-
+	// driven tab switches leave focus on the previously active tab's textarea.
+	useEffect(() => {
+		if (isActive) {
+			window.setTimeout(() => {
+				if (textareaRef.current) {
+					textareaRef.current.focus();
+				}
+			}, 0);
+		}
+	}, [isActive]);
 
 	// Restore message when provided (e.g., after cancellation)
 	// Only restore if input is empty to avoid overwriting user's new input

--- a/src/ui/MessageList.tsx
+++ b/src/ui/MessageList.tsx
@@ -141,6 +141,34 @@ export function MessageList({
 		checkIfAtBottom();
 	}, [view, checkIfAtBottom]);
 
+	// Scroll to bottom when the panel becomes visible again (e.g. user
+	// clicked away to another Obsidian pane and came back). The tab-switch
+	// logic (wasInactive) doesn't cover this because isActive tracks which
+	// tab is selected, not whether the leaf is on-screen. (I25)
+	const wasVisibleRef = useRef(true);
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				const visible = entry.isIntersecting;
+				if (visible && !wasVisibleRef.current && isActive && messages.length > 0) {
+					requestAnimationFrame(() => {
+						virtualizerRef.current.scrollToIndex(
+							messages.length - 1,
+							{ align: "end" },
+						);
+					});
+				}
+				wasVisibleRef.current = visible;
+			},
+			{ threshold: 0.1 },
+		);
+		observer.observe(container);
+		return () => observer.disconnect();
+	}, [isActive, messages.length]);
+
 	// Scroll to bottom on new messages and on tab switch.
 	// Streaming scroll is handled by shouldAdjustScrollPositionOnItemSizeChange.
 	useEffect(() => {

--- a/src/ui/MessageList.tsx
+++ b/src/ui/MessageList.tsx
@@ -36,6 +36,8 @@ export interface MessageListProps {
 	) => Promise<void>;
 	/** Whether a permission request is currently pending */
 	hasActivePermission: boolean;
+	/** Whether this tab is currently active (visible) */
+	isActive?: boolean;
 }
 
 /**
@@ -61,6 +63,7 @@ export function MessageList({
 	terminalClient,
 	onApprovePermission,
 	hasActivePermission,
+	isActive = true,
 }: MessageListProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [isAtBottom, setIsAtBottom] = useState(true);
@@ -77,14 +80,12 @@ export function MessageList({
 		overscan: 5,
 	});
 
-	// Suppress scroll position correction when user has scrolled up.
-	// By default, the virtualizer adjusts scrollTop when an item before
-	// the scroll offset changes size (to keep visible content stable).
-	// During streaming, this causes the viewport to creep down as the
-	// last message grows. Our auto-scroll effect handles following new
-	// content when isAtBottom, so corrections are only needed there.
+	// Suppress scroll position correction on hidden tabs and when user
+	// has scrolled up. Without the isActive check, the virtualizer
+	// adjusts its internal offset during measurement of collapsed
+	// containers, corrupting the saved position.
 	virtualizer.shouldAdjustScrollPositionOnItemSizeChange = () =>
-		isAtBottomRef.current;
+		isActive && isAtBottomRef.current;
 
 	// ============================================================
 	// Scroll management
@@ -92,6 +93,9 @@ export function MessageList({
 
 	/**
 	 * Check if the scroll position is near the bottom.
+	 * Skips when the container is collapsed (display:none) to avoid
+	 * corrupting isAtBottomRef — a zero-height container always
+	 * satisfies the "near bottom" check (0 + 0 >= 0 - threshold).
 	 */
 	const checkIfAtBottom = useCallback(() => {
 		const container = containerRef.current;
@@ -124,87 +128,59 @@ export function MessageList({
 		prevIsSendingRef.current = isSending;
 	}, [isSending]);
 
-	// Auto-scroll to bottom when new messages arrive or content changes
-	useEffect(() => {
-		if (messages.length === 0) return;
+	// Ref for virtualizer — avoids putting the virtualizer object
+	// (new every render) in effect dependency arrays.
+	const virtualizerRef = useRef(virtualizer);
+	virtualizerRef.current = virtualizer;
 
+	const prevIsActiveRef = useRef(isActive);
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+		view.registerDomEvent(container, "scroll", checkIfAtBottom);
+		checkIfAtBottom();
+	}, [view, checkIfAtBottom]);
+
+	// Scroll to bottom on new messages and on tab switch.
+	// Streaming scroll is handled by shouldAdjustScrollPositionOnItemSizeChange.
+	useEffect(() => {
+		const wasInactive = !prevIsActiveRef.current;
+		prevIsActiveRef.current = isActive;
+
+		if (!isActive || messages.length === 0) return;
+
+		if (wasInactive) {
+			// Tab became active — always go to bottom
+			requestAnimationFrame(() => {
+				virtualizerRef.current.scrollToIndex(
+					messages.length - 1,
+					{ align: "end" },
+				);
+			});
+			return;
+		}
+
+		// New message: auto-scroll if pinned to bottom
 		if (scrollSmoothRef.current) {
-			// User sent a message — smooth scroll regardless of isAtBottom
 			scrollSmoothRef.current = false;
 			requestAnimationFrame(() => {
-				virtualizer.scrollToIndex(messages.length - 1, {
-					align: "end",
-					behavior: "smooth",
-				});
+				virtualizerRef.current.scrollToIndex(
+					messages.length - 1,
+					{ align: "end", behavior: "smooth" },
+				);
 			});
 			return;
 		}
 
 		if (isAtBottomRef.current) {
-			// Use requestAnimationFrame to ensure virtualizer has measured
 			requestAnimationFrame(() => {
-				virtualizer.scrollToIndex(messages.length - 1, {
-					align: "end",
-				});
+				virtualizerRef.current.scrollToIndex(
+					messages.length - 1,
+					{ align: "end" },
+				);
 			});
 		}
-	}, [messages, virtualizer]);
-
-	// Set up scroll event listener for isAtBottom detection
-	useEffect(() => {
-		const container = containerRef.current;
-		if (!container) return;
-
-		const handleScroll = () => {
-			checkIfAtBottom();
-		};
-
-		view.registerDomEvent(container, "scroll", handleScroll);
-
-		// Initial check
-		checkIfAtBottom();
-	}, [view, checkIfAtBottom]);
-
-	// Scroll to bottom when tab becomes visible (display:none → display:flex).
-	// The tab panel sets display:none on inactive tabs, which collapses the
-	// container to zero height. When the tab becomes active again, the
-	// ResizeObserver fires and we scroll to the latest content.
-	const wasHiddenRef = useRef(false);
-	const savedScrollTopRef = useRef<number | null>(null);
-	useEffect(() => {
-		const container = containerRef.current;
-		if (!container) return;
-
-		const observer = new ResizeObserver((entries) => {
-			const entry = entries[0];
-			if (!entry) return;
-			const height = entry.contentRect.height;
-			if (height === 0) {
-				// Tab becoming hidden — save scroll position
-				savedScrollTopRef.current = container.scrollTop;
-				wasHiddenRef.current = true;
-			} else if (wasHiddenRef.current) {
-				wasHiddenRef.current = false;
-				if (messages.length > 0) {
-					if (isAtBottomRef.current) {
-						// Was at bottom — scroll to latest content
-						virtualizer.scrollToIndex(messages.length - 1, {
-							align: "end",
-						});
-					} else if (savedScrollTopRef.current !== null) {
-						// Was manually scrolled up — restore position
-						requestAnimationFrame(() => {
-							container.scrollTop = savedScrollTopRef.current!;
-						});
-					}
-				}
-				savedScrollTopRef.current = null;
-			}
-		});
-
-		observer.observe(container);
-		return () => observer.disconnect();
-	}, [messages.length, virtualizer]);
+	}, [messages, messages.length, isActive]);
 
 	// ============================================================
 	// Render

--- a/src/ui/MessageList.tsx
+++ b/src/ui/MessageList.tsx
@@ -170,6 +170,7 @@ export function MessageList({
 	// container to zero height. When the tab becomes active again, the
 	// ResizeObserver fires and we scroll to the latest content.
 	const wasHiddenRef = useRef(false);
+	const savedScrollTopRef = useRef<number | null>(null);
 	useEffect(() => {
 		const container = containerRef.current;
 		if (!container) return;
@@ -179,15 +180,25 @@ export function MessageList({
 			if (!entry) return;
 			const height = entry.contentRect.height;
 			if (height === 0) {
+				// Tab becoming hidden — save scroll position
+				savedScrollTopRef.current = container.scrollTop;
 				wasHiddenRef.current = true;
 			} else if (wasHiddenRef.current) {
 				wasHiddenRef.current = false;
-				// Tab just became visible — scroll to bottom
 				if (messages.length > 0) {
-					virtualizer.scrollToIndex(messages.length - 1, {
-						align: "end",
-					});
+					if (isAtBottomRef.current) {
+						// Was at bottom — scroll to latest content
+						virtualizer.scrollToIndex(messages.length - 1, {
+							align: "end",
+						});
+					} else if (savedScrollTopRef.current !== null) {
+						// Was manually scrolled up — restore position
+						requestAnimationFrame(() => {
+							container.scrollTop = savedScrollTopRef.current!;
+						});
+					}
 				}
+				savedScrollTopRef.current = null;
 			}
 		});
 

--- a/src/ui/MessageList.tsx
+++ b/src/ui/MessageList.tsx
@@ -165,6 +165,36 @@ export function MessageList({
 		checkIfAtBottom();
 	}, [view, checkIfAtBottom]);
 
+	// Scroll to bottom when tab becomes visible (display:none → display:flex).
+	// The tab panel sets display:none on inactive tabs, which collapses the
+	// container to zero height. When the tab becomes active again, the
+	// ResizeObserver fires and we scroll to the latest content.
+	const wasHiddenRef = useRef(false);
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+
+		const observer = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (!entry) return;
+			const height = entry.contentRect.height;
+			if (height === 0) {
+				wasHiddenRef.current = true;
+			} else if (wasHiddenRef.current) {
+				wasHiddenRef.current = false;
+				// Tab just became visible — scroll to bottom
+				if (messages.length > 0) {
+					virtualizer.scrollToIndex(messages.length - 1, {
+						align: "end",
+					});
+				}
+			}
+		});
+
+		observer.observe(container);
+		return () => observer.disconnect();
+	}, [messages.length, virtualizer]);
+
 	// ============================================================
 	// Render
 	// ============================================================
@@ -246,20 +276,40 @@ export function MessageList({
 			</div>
 
 			{/* Scroll to bottom button */}
-			{!isAtBottom && (
-				<button
-					className="agent-client-scroll-to-bottom"
-					onClick={() => {
-						virtualizer.scrollToIndex(messages.length - 1, {
-							align: "end",
-							behavior: "smooth",
-						});
-					}}
-					ref={(el) => {
-						if (el) setIcon(el, "chevron-down");
-					}}
-				/>
-			)}
+			{!isAtBottom && <ScrollToBottomButton virtualizer={virtualizer} messageCount={messages.length} />}
 		</div>
+	);
+}
+
+/**
+ * Extracted scroll-to-bottom button with a stable ref for setIcon.
+ * Avoids the inline callback ref cycling that swallows click events (same fix as I7).
+ */
+function ScrollToBottomButton({
+	virtualizer,
+	messageCount,
+}: {
+	virtualizer: ReturnType<typeof useVirtualizer>;
+	messageCount: number;
+}) {
+	const btnRef = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		if (btnRef.current) {
+			setIcon(btnRef.current, "chevron-down");
+		}
+	}, []);
+
+	return (
+		<button
+			ref={btnRef}
+			className="agent-client-scroll-to-bottom"
+			onClick={() => {
+				virtualizer.scrollToIndex(messageCount - 1, {
+					align: "end",
+					behavior: "smooth",
+				});
+			}}
+		/>
 	);
 }

--- a/src/ui/MessageList.tsx
+++ b/src/ui/MessageList.tsx
@@ -36,6 +36,8 @@ export interface MessageListProps {
 	) => Promise<void>;
 	/** Whether a permission request is currently pending */
 	hasActivePermission: boolean;
+	/** Whether this tab is currently active (visible) */
+	isActive?: boolean;
 }
 
 /**
@@ -61,6 +63,7 @@ export function MessageList({
 	terminalClient,
 	onApprovePermission,
 	hasActivePermission,
+	isActive = true,
 }: MessageListProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [isAtBottom, setIsAtBottom] = useState(true);
@@ -77,14 +80,12 @@ export function MessageList({
 		overscan: 5,
 	});
 
-	// Suppress scroll position correction when user has scrolled up.
-	// By default, the virtualizer adjusts scrollTop when an item before
-	// the scroll offset changes size (to keep visible content stable).
-	// During streaming, this causes the viewport to creep down as the
-	// last message grows. Our auto-scroll effect handles following new
-	// content when isAtBottom, so corrections are only needed there.
+	// Suppress scroll position correction on hidden tabs and when user
+	// has scrolled up. Without the isActive check, the virtualizer
+	// adjusts its internal offset during measurement of collapsed
+	// containers, corrupting the saved position.
 	virtualizer.shouldAdjustScrollPositionOnItemSizeChange = () =>
-		isAtBottomRef.current;
+		isActive && isAtBottomRef.current;
 
 	// ============================================================
 	// Scroll management
@@ -92,6 +93,9 @@ export function MessageList({
 
 	/**
 	 * Check if the scroll position is near the bottom.
+	 * Skips when the container is collapsed (display:none) to avoid
+	 * corrupting isAtBottomRef — a zero-height container always
+	 * satisfies the "near bottom" check (0 + 0 >= 0 - threshold).
 	 */
 	const checkIfAtBottom = useCallback(() => {
 		const container = containerRef.current;
@@ -124,87 +128,59 @@ export function MessageList({
 		prevIsSendingRef.current = isSending;
 	}, [isSending]);
 
-	// Auto-scroll to bottom when new messages arrive or content changes
-	useEffect(() => {
-		if (messages.length === 0) return;
+	// Ref for virtualizer — avoids putting the virtualizer object
+	// (new every render) in effect dependency arrays.
+	const virtualizerRef = useRef(virtualizer);
+	virtualizerRef.current = virtualizer;
 
+	const prevIsActiveRef = useRef(isActive);
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+		view.registerDomEvent(container, "scroll", checkIfAtBottom);
+		checkIfAtBottom();
+	}, [view, checkIfAtBottom]);
+
+	// Scroll to bottom on new messages and on tab switch.
+	// Streaming scroll is handled by shouldAdjustScrollPositionOnItemSizeChange.
+	useEffect(() => {
+		const wasInactive = !prevIsActiveRef.current;
+		prevIsActiveRef.current = isActive;
+
+		if (!isActive || messages.length === 0) return;
+
+		if (wasInactive) {
+			// Tab became active — always go to bottom
+			window.requestAnimationFrame(() => {
+				virtualizerRef.current.scrollToIndex(
+					messages.length - 1,
+					{ align: "end" },
+				);
+			});
+			return;
+		}
+
+		// New message: auto-scroll if pinned to bottom
 		if (scrollSmoothRef.current) {
-			// User sent a message — smooth scroll regardless of isAtBottom
 			scrollSmoothRef.current = false;
 			window.requestAnimationFrame(() => {
-				virtualizer.scrollToIndex(messages.length - 1, {
-					align: "end",
-					behavior: "smooth",
-				});
+				virtualizerRef.current.scrollToIndex(
+					messages.length - 1,
+					{ align: "end", behavior: "smooth" },
+				);
 			});
 			return;
 		}
 
 		if (isAtBottomRef.current) {
-			// Use requestAnimationFrame to ensure virtualizer has measured
 			window.requestAnimationFrame(() => {
-				virtualizer.scrollToIndex(messages.length - 1, {
-					align: "end",
-				});
+				virtualizerRef.current.scrollToIndex(
+					messages.length - 1,
+					{ align: "end" },
+				);
 			});
 		}
-	}, [messages, virtualizer]);
-
-	// Set up scroll event listener for isAtBottom detection
-	useEffect(() => {
-		const container = containerRef.current;
-		if (!container) return;
-
-		const handleScroll = () => {
-			checkIfAtBottom();
-		};
-
-		view.registerDomEvent(container, "scroll", handleScroll);
-
-		// Initial check
-		checkIfAtBottom();
-	}, [view, checkIfAtBottom]);
-
-	// Scroll to bottom when tab becomes visible (display:none → display:flex).
-	// The tab panel sets display:none on inactive tabs, which collapses the
-	// container to zero height. When the tab becomes active again, the
-	// ResizeObserver fires and we scroll to the latest content.
-	const wasHiddenRef = useRef(false);
-	const savedScrollTopRef = useRef<number | null>(null);
-	useEffect(() => {
-		const container = containerRef.current;
-		if (!container) return;
-
-		const observer = new ResizeObserver((entries) => {
-			const entry = entries[0];
-			if (!entry) return;
-			const height = entry.contentRect.height;
-			if (height === 0) {
-				// Tab becoming hidden — save scroll position
-				savedScrollTopRef.current = container.scrollTop;
-				wasHiddenRef.current = true;
-			} else if (wasHiddenRef.current) {
-				wasHiddenRef.current = false;
-				if (messages.length > 0) {
-					if (isAtBottomRef.current) {
-						// Was at bottom — scroll to latest content
-						virtualizer.scrollToIndex(messages.length - 1, {
-							align: "end",
-						});
-					} else if (savedScrollTopRef.current !== null) {
-						// Was manually scrolled up — restore position
-						requestAnimationFrame(() => {
-							container.scrollTop = savedScrollTopRef.current!;
-						});
-					}
-				}
-				savedScrollTopRef.current = null;
-			}
-		});
-
-		observer.observe(container);
-		return () => observer.disconnect();
-	}, [messages.length, virtualizer]);
+	}, [messages, messages.length, isActive]);
 
 	// ============================================================
 	// Render

--- a/src/ui/SessionHistoryModal.tsx
+++ b/src/ui/SessionHistoryModal.tsx
@@ -579,17 +579,8 @@ function SessionHistoryContent({
 		return sessions.filter((s) => localSessionIds.has(s.sessionId));
 	}, [sessions, isUsingLocalSessions, hideNonLocalSessions, localSessionIds]);
 
-	// Show preparing message if agent is not ready
-	if (!isAgentReady) {
-		return (
-			<div className="agent-client-session-history-loading">
-				<p>Preparing agent...</p>
-			</div>
-		);
-	}
-
-	// Check if any session operation is available
-	const canPerformAnyOperation = canRestore || canFork;
+	// Check if any session operation is available (requires agent connection)
+	const canPerformAnyOperation = isAgentReady && (canRestore || canFork);
 
 	// Show local sessions list (always show for delete functionality)
 	// - If agent supports list: use agent's session/list
@@ -609,10 +600,13 @@ function SessionHistoryContent({
 				/>
 			)}
 
-			{/* Warning banner for agents that don't support restoration */}
+			{/* Warning banner for agents that don't support restoration or aren't connected */}
 			{!canPerformAnyOperation && (
 				<div className="agent-client-session-history-warning-banner">
-					<p>This agent does not support session restoration.</p>
+					<p>{!isAgentReady
+						? "Connect to an agent to restore or fork sessions."
+						: "This agent does not support session restoration."
+					}</p>
 				</div>
 			)}
 
@@ -702,8 +696,8 @@ function SessionHistoryContent({
 								<SessionItem
 									key={session.sessionId}
 									session={session}
-									canRestore={canRestore}
-									canFork={canFork}
+									canRestore={isAgentReady && canRestore}
+									canFork={isAgentReady && canFork}
 									currentCwd={currentCwd}
 									onRestoreSession={onRestoreSession}
 									onForkSession={onForkSession}
@@ -757,10 +751,12 @@ export type SessionHistoryModalProps = Omit<
 export class SessionHistoryModal extends Modal {
 	private root: Root | null = null;
 	private props: SessionHistoryModalProps;
+	private onModalClose?: () => void;
 
-	constructor(app: App, props: SessionHistoryModalProps) {
+	constructor(app: App, props: SessionHistoryModalProps, onModalClose?: () => void) {
 		super(app);
 		this.props = props;
+		this.onModalClose = onModalClose;
 	}
 
 	/**
@@ -817,5 +813,6 @@ export class SessionHistoryModal extends Modal {
 		}
 		const { contentEl } = this;
 		contentEl.empty();
+		this.onModalClose?.();
 	}
 }

--- a/src/ui/SessionHistoryModal.tsx
+++ b/src/ui/SessionHistoryModal.tsx
@@ -94,7 +94,7 @@ class ConfirmDeleteModal extends Modal {
  * Displays a text input pre-filled with the current title.
  * Calls onSave callback with the new title when user clicks Save.
  */
-class EditTitleModal extends Modal {
+export class EditTitleModal extends Modal {
 	private currentTitle: string;
 	private onSave: (newTitle: string) => void | Promise<void>;
 

--- a/src/ui/TabBar.tsx
+++ b/src/ui/TabBar.tsx
@@ -1,0 +1,315 @@
+/**
+ * Tab bar component for multi-session support.
+ *
+ * Follows Obsidian's native tab bar conventions:
+ * - Close button visible on active tab, hover-to-reveal on others
+ * - `+` button at the end of the tab strip
+ * - `˅` chevron for overflow tab list
+ * - Right-click context menu (Close, Close others, Close to the right)
+ * - Active tab background blends with content area
+ * - Drag to reorder (no tear-off)
+ */
+
+import * as React from "react";
+const { useRef, useEffect, useCallback } = React;
+import { Menu, setIcon, type MenuItem } from "obsidian";
+import type { TabInfo, TabState } from "../types/tab";
+
+// ============================================================================
+// Props
+// ============================================================================
+
+export interface TabBarProps {
+	tabs: TabInfo[];
+	activeTabId: string;
+	onSelectTab: (tabId: string) => void;
+	onAddTab: () => void;
+	onCloseTab: (tabId: string) => void;
+	onCloseOtherTabs: (tabId: string) => void;
+	onCloseTabsToRight: (tabId: string) => void;
+	onRenameTab: (tabId: string) => void;
+	onMoveTab: (fromIndex: number, toIndex: number) => void;
+	/** Right-click on + button — show agent picker */
+	onAddTabWithAgent?: (e: React.MouseEvent) => void;
+}
+
+// ============================================================================
+// State Icon Component (Colorblind-Safe)
+// ============================================================================
+
+/**
+ * Renders a tab state icon using shape + color + animation.
+ * No red/green contrast dependency.
+ */
+function TabStateIcon({ state }: { state: TabState }) {
+	const className = `agent-client-tab-state-icon agent-client-tab-state-${state}`;
+
+	switch (state) {
+		case "ready":
+			return <span className={className}>●</span>;
+		case "busy":
+			return <span className={className}>◐</span>;
+		case "permission":
+			return <span className={className}>△</span>;
+		case "error":
+			return <span className={className}>✕</span>;
+		case "disconnected":
+			return <span className={className}>○</span>;
+	}
+}
+
+// ============================================================================
+// Single Tab Component
+// ============================================================================
+
+interface TabItemProps {
+	tab: TabInfo;
+	isActive: boolean;
+	onSelect: () => void;
+	onClose: () => void;
+	onContextMenu: (e: React.MouseEvent) => void;
+	onMiddleClick: () => void;
+	onDragStart: (e: React.DragEvent) => void;
+	onDragOver: (e: React.DragEvent) => void;
+	onDrop: (e: React.DragEvent) => void;
+}
+
+function TabItem({
+	tab,
+	isActive,
+	onSelect,
+	onClose,
+	onContextMenu,
+	onMiddleClick,
+	onDragStart,
+	onDragOver,
+	onDrop,
+}: TabItemProps) {
+	const closeRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (closeRef.current) {
+			setIcon(closeRef.current, "x");
+		}
+	}, []);
+
+	const handleMouseDown = useCallback(
+		(e: React.MouseEvent) => {
+			// Middle-click to close
+			if (e.button === 1) {
+				e.preventDefault();
+				onMiddleClick();
+			}
+		},
+		[onMiddleClick],
+	);
+
+	return (
+		<div
+			className={`agent-client-tab${isActive ? " agent-client-tab-active" : ""}`}
+			onClick={onSelect}
+			onContextMenu={onContextMenu}
+			onMouseDown={handleMouseDown}
+			draggable
+			onDragStart={onDragStart}
+			onDragOver={onDragOver}
+			onDrop={onDrop}
+		>
+			<TabStateIcon state={tab.state} />
+			<span className="agent-client-tab-label">{tab.label}</span>
+			<div
+				ref={closeRef}
+				className="agent-client-tab-close clickable-icon"
+				onClick={(e) => {
+					e.stopPropagation();
+					onClose();
+				}}
+				aria-label="Close tab"
+			/>
+		</div>
+	);
+}
+
+// ============================================================================
+// Tab Bar Component
+// ============================================================================
+
+export function TabBar({
+	tabs,
+	activeTabId,
+	onSelectTab,
+	onAddTab,
+	onCloseTab,
+	onCloseOtherTabs,
+	onCloseTabsToRight,
+	onRenameTab,
+	onMoveTab,
+	onAddTabWithAgent,
+}: TabBarProps) {
+	const addBtnRef = useRef<HTMLDivElement>(null);
+	const chevronRef = useRef<HTMLDivElement>(null);
+	const scrollRef = useRef<HTMLDivElement>(null);
+	const dragIndexRef = useRef<number>(-1);
+
+	useEffect(() => {
+		if (addBtnRef.current) setIcon(addBtnRef.current, "plus");
+		if (chevronRef.current)
+			setIcon(chevronRef.current, "chevron-down");
+	}, []);
+
+	// Scroll active tab into view
+	useEffect(() => {
+		const container = scrollRef.current;
+		if (!container) return;
+		const activeEl = container.querySelector(
+			".agent-client-tab-active",
+		);
+		if (activeEl) {
+			activeEl.scrollIntoView({
+				behavior: "smooth",
+				block: "nearest",
+				inline: "nearest",
+			});
+		}
+	}, [activeTabId]);
+
+	// Right-click context menu on a tab (Obsidian Menu API)
+	const handleTabContextMenu = useCallback(
+		(e: React.MouseEvent, tab: TabInfo) => {
+			e.preventDefault();
+			const menu = new Menu();
+
+			menu.addItem((item: MenuItem) => {
+				item.setTitle("Rename").setIcon("pencil").onClick(() => {
+					onRenameTab(tab.tabId);
+				});
+			});
+
+			menu.addSeparator();
+
+			menu.addItem((item: MenuItem) => {
+				item.setTitle("Close").setIcon("x").onClick(() => {
+					onCloseTab(tab.tabId);
+				});
+			});
+
+			if (tabs.length > 1) {
+				menu.addItem((item: MenuItem) => {
+					item.setTitle("Close others").onClick(() => {
+						onCloseOtherTabs(tab.tabId);
+					});
+				});
+
+				const tabIdx = tabs.findIndex(
+					(t) => t.tabId === tab.tabId,
+				);
+				if (tabIdx < tabs.length - 1) {
+					menu.addItem((item: MenuItem) => {
+						item.setTitle("Close to the right").onClick(
+							() => {
+								onCloseTabsToRight(tab.tabId);
+							},
+						);
+					});
+				}
+			}
+
+			menu.showAtMouseEvent(e.nativeEvent);
+		},
+		[tabs, onCloseTab, onCloseOtherTabs, onCloseTabsToRight, onRenameTab],
+	);
+
+	// Chevron dropdown — list all tabs
+	const handleChevronClick = useCallback(
+		(e: React.MouseEvent) => {
+			const menu = new Menu();
+			for (const tab of tabs) {
+				menu.addItem((item: MenuItem) => {
+					item.setTitle(tab.label)
+						.setChecked(tab.tabId === activeTabId)
+						.onClick(() => {
+							onSelectTab(tab.tabId);
+						});
+				});
+			}
+			menu.showAtMouseEvent(e.nativeEvent);
+		},
+		[tabs, activeTabId, onSelectTab],
+	);
+
+	// Drag handlers
+	const handleDragStart = useCallback(
+		(index: number) => (e: React.DragEvent) => {
+			dragIndexRef.current = index;
+			e.dataTransfer.effectAllowed = "move";
+		},
+		[],
+	);
+
+	const handleDragOver = useCallback(
+		(e: React.DragEvent) => {
+			e.preventDefault();
+			e.dataTransfer.dropEffect = "move";
+		},
+		[],
+	);
+
+	const handleDrop = useCallback(
+		(toIndex: number) => (e: React.DragEvent) => {
+			e.preventDefault();
+			const fromIndex = dragIndexRef.current;
+			if (fromIndex !== -1 && fromIndex !== toIndex) {
+				onMoveTab(fromIndex, toIndex);
+			}
+			dragIndexRef.current = -1;
+		},
+		[onMoveTab],
+	);
+
+	// Horizontal scroll on wheel
+	const handleWheel = useCallback((e: React.WheelEvent) => {
+		if (scrollRef.current) {
+			scrollRef.current.scrollLeft += e.deltaY;
+		}
+	}, []);
+
+	return (
+		<div className="agent-client-tab-bar">
+			<div
+				className="agent-client-tab-bar-scroll"
+				ref={scrollRef}
+				onWheel={handleWheel}
+			>
+				{tabs.map((tab, index) => (
+					<TabItem
+						key={tab.tabId}
+						tab={tab}
+						isActive={tab.tabId === activeTabId}
+						onSelect={() => onSelectTab(tab.tabId)}
+						onClose={() => onCloseTab(tab.tabId)}
+						onContextMenu={(e) =>
+							handleTabContextMenu(e, tab)
+						}
+						onMiddleClick={() => onCloseTab(tab.tabId)}
+						onDragStart={handleDragStart(index)}
+						onDragOver={handleDragOver}
+						onDrop={handleDrop(index)}
+					/>
+				))}
+			</div>
+			<div
+				ref={addBtnRef}
+				className="clickable-icon agent-client-tab-bar-add"
+				aria-label="New session tab"
+				onClick={onAddTab}
+				onContextMenu={onAddTabWithAgent}
+			/>
+			<div
+				ref={chevronRef}
+				className="clickable-icon agent-client-tab-bar-chevron"
+				aria-label="Tab list"
+				onClick={handleChevronClick}
+			/>
+		</div>
+	);
+}

--- a/src/ui/TabBar.tsx
+++ b/src/ui/TabBar.tsx
@@ -185,15 +185,15 @@ export function TabBar({
 				});
 			});
 
-			menu.addSeparator();
-
-			menu.addItem((item: MenuItem) => {
-				item.setTitle("Close").setIcon("x").onClick(() => {
-					onCloseTab(tab.tabId);
-				});
-			});
-
 			if (tabs.length > 1) {
+				menu.addSeparator();
+
+				menu.addItem((item: MenuItem) => {
+					item.setTitle("Close").setIcon("x").onClick(() => {
+						onCloseTab(tab.tabId);
+					});
+				});
+
 				menu.addItem((item: MenuItem) => {
 					item.setTitle("Close others").onClick(() => {
 						onCloseOtherTabs(tab.tabId);

--- a/src/ui/TabErrorBoundary.tsx
+++ b/src/ui/TabErrorBoundary.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 interface Props {
 	tabId: string;
 	onError?: (tabId: string) => void;
+	onRetry?: (tabId: string) => void;
 	children: React.ReactNode;
 }
 
@@ -32,6 +33,7 @@ export class TabErrorBoundary extends React.Component<Props, State> {
 	}
 
 	private handleRetry = () => {
+		this.props.onRetry?.(this.props.tabId);
 		this.setState({ hasError: false, error: null });
 	};
 

--- a/src/ui/TabErrorBoundary.tsx
+++ b/src/ui/TabErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+
+interface Props {
+	tabId: string;
+	onError?: (tabId: string) => void;
+	children: React.ReactNode;
+}
+
+interface State {
+	hasError: boolean;
+	error: Error | null;
+}
+
+/**
+ * Error boundary that wraps each tab's ChatContextProvider + ChatPanel.
+ * Catches render errors in a single tab without crashing the entire view.
+ */
+export class TabErrorBoundary extends React.Component<Props, State> {
+	state: State = { hasError: false, error: null };
+
+	static getDerivedStateFromError(error: Error): State {
+		return { hasError: true, error };
+	}
+
+	componentDidCatch(error: Error, info: React.ErrorInfo) {
+		console.error(
+			`[Agent Client] Tab ${this.props.tabId} crashed:`,
+			error,
+			info.componentStack,
+		);
+		this.props.onError?.(this.props.tabId);
+	}
+
+	private handleRetry = () => {
+		this.setState({ hasError: false, error: null });
+	};
+
+	render() {
+		if (this.state.hasError) {
+			return (
+				<div className="agent-client-tab-error">
+					<div className="agent-client-tab-error-icon">⚠</div>
+					<div className="agent-client-tab-error-title">
+						This tab encountered an error
+					</div>
+					<div className="agent-client-tab-error-message">
+						{this.state.error?.message ?? "Unknown error"}
+					</div>
+					<button
+						className="agent-client-tab-error-retry"
+						onClick={this.handleRetry}
+					>
+						Retry
+					</button>
+				</div>
+			);
+		}
+		return this.props.children;
+	}
+}

--- a/src/ui/view-host.ts
+++ b/src/ui/view-host.ts
@@ -26,6 +26,15 @@ export interface IChatViewHost {
 	app: App;
 
 	/**
+	 * Registry-recognized container ID. For sidebar (ChatView) this is
+	 * the workspace leaf.id. For floating (FloatingChatView shim) this is
+	 * the floating-chat-N viewId. Used by ChatPanel's focus tracking to
+	 * write the value that ViewRegistry.setFocused() accepts (it rejects
+	 * unknown viewIds, so writing tab.tabId would silently no-op).
+	 */
+	readonly viewId: string;
+
+	/**
 	 * Register a DOM event listener that will be cleaned up when the view closes.
 	 *
 	 * In sidebar ChatView, this delegates to Obsidian's Component.registerDomEvent.

--- a/styles.css
+++ b/styles.css
@@ -398,6 +398,8 @@ If your plugin does not need CSS, delete this file.
 .agent-client-chat-view-container {
 	--ac-chat-font-size: var(--font-text-size);
 	height: 100%;
+	flex: 1;
+	min-height: 0;
 	display: flex;
 	flex-direction: column;
 	padding: 0;
@@ -2187,4 +2189,189 @@ If your plugin does not need CSS, delete this file.
 .agent-client-agent-label {
 	color: var(--text-normal);
 	font-size: 12px;
+}
+
+/* ===== Tab Bar (Multi-Session) ===== */
+
+.agent-client-tab-bar {
+	display: flex;
+	align-items: center;
+	border-bottom: 1px solid var(--background-modifier-border);
+	background-color: var(--background-secondary);
+	min-height: 32px;
+	flex-shrink: 0;
+}
+
+.agent-client-tab-bar-scroll {
+	display: flex;
+	flex: 1;
+	overflow-x: auto;
+	overflow-y: hidden;
+	scrollbar-width: none; /* Firefox */
+	min-width: 0;
+}
+
+.agent-client-tab-bar-scroll::-webkit-scrollbar {
+	display: none;
+}
+
+/* Single tab */
+.agent-client-tab {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 8px;
+	cursor: pointer;
+	white-space: nowrap;
+	font-size: var(--font-ui-small);
+	color: var(--text-muted);
+	border-right: 1px solid var(--background-modifier-border);
+	flex-shrink: 0;
+	user-select: none;
+	transition: background-color 0.1s ease;
+}
+
+.agent-client-tab:hover {
+	background-color: var(--background-modifier-hover);
+}
+
+/* Active tab — blends with content area (Obsidian convention) */
+.agent-client-tab-active {
+	background-color: var(--background-primary);
+	color: var(--text-normal);
+}
+
+/* Tab label */
+.agent-client-tab-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 160px;
+}
+
+/* Tab close button — Obsidian convention: visible on active, hover on others */
+.agent-client-tab-close {
+	display: none;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	flex-shrink: 0;
+	border-radius: var(--radius-s);
+}
+
+.agent-client-tab-close:hover {
+	background-color: var(--background-modifier-hover);
+}
+
+.agent-client-tab-close svg {
+	width: 16px;
+	height: 16px;
+}
+
+.agent-client-tab-active .agent-client-tab-close {
+	display: flex;
+}
+
+.agent-client-tab:hover .agent-client-tab-close {
+	display: flex;
+}
+
+/* + button and chevron */
+.agent-client-tab-bar-add,
+.agent-client-tab-bar-chevron {
+	flex-shrink: 0;
+	width: 28px;
+	height: 28px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.agent-client-tab-bar-add svg,
+.agent-client-tab-bar-chevron svg {
+	width: 14px;
+	height: 14px;
+}
+
+/* ===== Tab State Icons (Colorblind-Safe) ===== */
+
+.agent-client-tab-state-icon {
+	flex-shrink: 0;
+	font-size: 10px;
+	line-height: 1;
+	width: 14px;
+	text-align: center;
+}
+
+.agent-client-tab-state-ready {
+	color: var(--interactive-accent);
+}
+
+.agent-client-tab-state-busy {
+	color: var(--interactive-accent);
+	animation: agent-client-spin 1s linear infinite;
+}
+
+.agent-client-tab-state-permission {
+	color: var(--color-orange);
+	animation: agent-client-pulse 1.5s ease-in-out infinite;
+}
+
+.agent-client-tab-state-error {
+	color: var(--color-red);
+}
+
+.agent-client-tab-state-disconnected {
+	color: var(--text-faint);
+}
+
+@keyframes agent-client-spin {
+	from { transform: rotate(0deg); }
+	to { transform: rotate(360deg); }
+}
+
+@keyframes agent-client-pulse {
+	0%, 100% { opacity: 1; }
+	50% { opacity: 0.4; }
+}
+
+/* Drag feedback */
+.agent-client-tab[draggable="true"]:active {
+	opacity: 0.6;
+}
+
+/* ===== Tab Error Boundary ===== */
+
+.agent-client-tab-error {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	flex: 1;
+	gap: 8px;
+	padding: 24px;
+	color: var(--text-muted);
+}
+
+.agent-client-tab-error-icon {
+	font-size: 32px;
+	opacity: 0.6;
+}
+
+.agent-client-tab-error-title {
+	font-size: var(--font-ui-medium);
+	font-weight: var(--font-semibold);
+	color: var(--text-normal);
+}
+
+.agent-client-tab-error-message {
+	font-size: var(--font-ui-small);
+	color: var(--text-muted);
+	max-width: 300px;
+	text-align: center;
+	word-break: break-word;
+}
+
+.agent-client-tab-error-retry {
+	margin-top: 8px;
 }

--- a/styles.css
+++ b/styles.css
@@ -398,6 +398,8 @@ If your plugin does not need CSS, delete this file.
 .agent-client-chat-view-container {
 	--ac-chat-font-size: var(--font-text-size);
 	height: 100%;
+	flex: 1;
+	min-height: 0;
 	display: flex;
 	flex-direction: column;
 	padding: 0;
@@ -2180,4 +2182,189 @@ If your plugin does not need CSS, delete this file.
 .agent-client-agent-label {
 	color: var(--text-normal);
 	font-size: 12px;
+}
+
+/* ===== Tab Bar (Multi-Session) ===== */
+
+.agent-client-tab-bar {
+	display: flex;
+	align-items: center;
+	border-bottom: 1px solid var(--background-modifier-border);
+	background-color: var(--background-secondary);
+	min-height: 32px;
+	flex-shrink: 0;
+}
+
+.agent-client-tab-bar-scroll {
+	display: flex;
+	flex: 1;
+	overflow-x: auto;
+	overflow-y: hidden;
+	scrollbar-width: none; /* Firefox */
+	min-width: 0;
+}
+
+.agent-client-tab-bar-scroll::-webkit-scrollbar {
+	display: none;
+}
+
+/* Single tab */
+.agent-client-tab {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 8px;
+	cursor: pointer;
+	white-space: nowrap;
+	font-size: var(--font-ui-small);
+	color: var(--text-muted);
+	border-right: 1px solid var(--background-modifier-border);
+	flex-shrink: 0;
+	user-select: none;
+	transition: background-color 0.1s ease;
+}
+
+.agent-client-tab:hover {
+	background-color: var(--background-modifier-hover);
+}
+
+/* Active tab — blends with content area (Obsidian convention) */
+.agent-client-tab-active {
+	background-color: var(--background-primary);
+	color: var(--text-normal);
+}
+
+/* Tab label */
+.agent-client-tab-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 160px;
+}
+
+/* Tab close button — Obsidian convention: visible on active, hover on others */
+.agent-client-tab-close {
+	display: none;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	flex-shrink: 0;
+	border-radius: var(--radius-s);
+}
+
+.agent-client-tab-close:hover {
+	background-color: var(--background-modifier-hover);
+}
+
+.agent-client-tab-close svg {
+	width: 16px;
+	height: 16px;
+}
+
+.agent-client-tab-active .agent-client-tab-close {
+	display: flex;
+}
+
+.agent-client-tab:hover .agent-client-tab-close {
+	display: flex;
+}
+
+/* + button and chevron */
+.agent-client-tab-bar-add,
+.agent-client-tab-bar-chevron {
+	flex-shrink: 0;
+	width: 28px;
+	height: 28px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.agent-client-tab-bar-add svg,
+.agent-client-tab-bar-chevron svg {
+	width: 14px;
+	height: 14px;
+}
+
+/* ===== Tab State Icons (Colorblind-Safe) ===== */
+
+.agent-client-tab-state-icon {
+	flex-shrink: 0;
+	font-size: 10px;
+	line-height: 1;
+	width: 14px;
+	text-align: center;
+}
+
+.agent-client-tab-state-ready {
+	color: var(--interactive-accent);
+}
+
+.agent-client-tab-state-busy {
+	color: var(--interactive-accent);
+	animation: agent-client-spin 1s linear infinite;
+}
+
+.agent-client-tab-state-permission {
+	color: var(--color-orange);
+	animation: agent-client-pulse 1.5s ease-in-out infinite;
+}
+
+.agent-client-tab-state-error {
+	color: var(--color-red);
+}
+
+.agent-client-tab-state-disconnected {
+	color: var(--text-faint);
+}
+
+@keyframes agent-client-spin {
+	from { transform: rotate(0deg); }
+	to { transform: rotate(360deg); }
+}
+
+@keyframes agent-client-pulse {
+	0%, 100% { opacity: 1; }
+	50% { opacity: 0.4; }
+}
+
+/* Drag feedback */
+.agent-client-tab[draggable="true"]:active {
+	opacity: 0.6;
+}
+
+/* ===== Tab Error Boundary ===== */
+
+.agent-client-tab-error {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	flex: 1;
+	gap: 8px;
+	padding: 24px;
+	color: var(--text-muted);
+}
+
+.agent-client-tab-error-icon {
+	font-size: 32px;
+	opacity: 0.6;
+}
+
+.agent-client-tab-error-title {
+	font-size: var(--font-ui-medium);
+	font-weight: var(--font-semibold);
+	color: var(--text-normal);
+}
+
+.agent-client-tab-error-message {
+	font-size: var(--font-ui-small);
+	color: var(--text-muted);
+	max-width: 300px;
+	text-align: center;
+	word-break: break-word;
+}
+
+.agent-client-tab-error-retry {
+	margin-top: 8px;
 }


### PR DESCRIPTION
## Description

Adds an internal tab bar to the plugin view, allowing users to run multiple independent agent sessions within a single Obsidian leaf. Replaces the current "Open new view" workflow (2 clicks, creates a new Obsidian leaf) with a one-click `+` button.

### What it does

- **Tab bar** inside the plugin view with `+` (new tab), `˅` (overflow list), and per-tab close buttons
- **Tab state icons** using shape + color + animation (colorblind-safe: ● ready, ◐ busy, △ permission, ✕ error, ○ disconnected)
- **Auto-generated tab labels** from session title → first user message → agent+timestamp
- **Tab rename** via right-click context menu, synced bidirectionally with session history
- **Keyboard commands** registered as Obsidian commands (user-bindable): new/close/next/previous tab
- **Error boundary per tab** – a render crash in one tab doesn't take down the view
- **Full backward compatibility** – "Open new view" still works, floating chat unaffected, existing commands work across all tabs

### Design principle

**Model Obsidian's tab behavior, not Chrome's.** Close button visible on active tab only (hover for others), no bottom accent border, `˅` chevron for overflow, commands as user-bindable hotkeys.

### Architecture

Each tab is an independent `AcpClient` + `ChatPanel` – the same unit as a `ChatView` leaf today. The `TabBar` multiplexes which one is visible.

| New file | Purpose |
|----------|---------|
| `hooks/useTabManager.ts` | Tab state management (list, active, metadata, reorder) |
| `types/tab.ts` | `TabInfo`, `TabState` type definitions |
| `ui/TabBar.tsx` | Tab strip with state icons, labels, close buttons, context menu |
| `ui/TabErrorBoundary.tsx` | React error boundary per tab |

Key modified files: `ChatView.tsx` (renders TabBar + active tab's ChatPanel), `ChatPanel.tsx` (accepts tabId, reports state changes), `plugin.ts` (tab commands, view registry updates), `styles.css` (+187 lines using Obsidian CSS variables).

### Bug fixes included in this branch

This branch also includes fixes for issues discovered during development. Pre-existing bugs that affect `upstream/dev` independently have **separate PRs** filed from standalone fix branches:

- #244 – registerView race on plugin reload
- #245 – hotkey focus steal by floating chat
- #246 – attachment remove button broken
- #247 – debug mode toggle ineffective
- #248 – auto-allow permissions not propagated
- #249 – cancel() crash after disconnect

The feature branch cherry-picks these fixes so the tabbed sessions code works correctly end-to-end. The standalone PRs can be merged independently.

Feature-scoped fixes (only relevant with tabs):
- Session history modal infinite re-render crash (I11, I12)
- Tab label sync with session history rename (I14)
- Scroll position on tab switch (I8)
- Chatbox focus on hotkey tab switch (I19)
- Error boundary retry resets tab state (I16)
- Duplicate tab name rejection (I22)
- Already-open session detection on restore (I20)
- Context menu hides close when single tab (I23)
- Panel refocus scroll/textarea (I25, I26)
- Event-dispatched command routing to active tab (I29)
- Infinite re-render loop in tab state reporting (I31)

### What's NOT included

- Tab persistence across Obsidian restarts (future enhancement)
- Tab drag reorder (future enhancement)
- AI-generated session rename (future enhancement)

## Related issue

Closes #232

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Kiro
- OS: macOS

## Screenshots

N/A – will add screenshots in a follow-up comment if helpful.