### PR TITLE
fix: bump session updatedAt on turn end (#257)

### DIFF
--- a/src/hooks/useSessionHistory.ts
+++ b/src/hooks/useSessionHistory.ts
@@ -796,6 +796,10 @@ export function useSessionHistory(
 	 * Save session messages locally.
 	 * Called when a turn ends (agent response complete).
 	 * Fire-and-forget (does not block UI).
+	 *
+	 * Also bumps the session's `updatedAt` metadata so that
+	 * `getSavedSessions()` (sorted by updatedAt desc) reflects actual
+	 * activity rather than just session-creation time (#257).
 	 */
 	const saveSessionMessages = useCallback(
 		(
@@ -804,12 +808,27 @@ export function useSessionHistory(
 		) => {
 			if (!session.agentId || messages.length === 0) return;
 
-			// Fire-and-forget
+			// Persist message content (fire-and-forget)
 			void settingsAccess.saveSessionMessages(
 				sessionId,
 				session.agentId,
 				messages,
 			);
+
+			// Bump updatedAt on session metadata so "last used" ordering
+			// reflects real activity. Read live snapshot (not React state)
+			// to avoid races with rapid fork/rename. Skip if the metadata
+			// entry hasn't landed yet — saveSessionLocally will create it
+			// on the first-message path.
+			const existing = settingsAccess
+				.getSavedSessions()
+				.find((s) => s.sessionId === sessionId);
+			if (existing) {
+				void settingsAccess.saveSession({
+					...existing,
+					updatedAt: new Date().toISOString(),
+				});
+			}
 		},
 		[session.agentId, settingsAccess],
 	);


### PR DESCRIPTION
Session metadata's `updatedAt` field was only written in three paths: session creation (`saveSessionLocally`), fork, and title rename. Turn completion (`saveSessionMessages`) persisted message content but never touched the `savedSessions[]` entry, so `updatedAt` stayed frozen at session-creation time for the entire lifetime of the session.

This meant "sort by `updatedAt` desc" (the existing behavior of `getSavedSessions`) returned stale ordering: a session actively used every day would sort below a session started yesterday and never touched.

## Fix

After persisting message content in `saveSessionMessages`, read the live `savedSessions` snapshot via `settingsAccess.getSavedSessions()`, find the entry by `sessionId`, and fire-and-forget `saveSession({ ...existing, updatedAt: now })`. The `if (existing)` guard handles the first-message race window where `saveSessionLocally` hasn't landed yet (that path sets `updatedAt` correctly on its own).

No layer changes; the fix stays in the hook layer. Storage layer unchanged.

Fixes #257
