### PR TITLE
Feature/wikilink

### DIFF
--- a/src/hooks/useAgent.ts
+++ b/src/hooks/useAgent.ts
@@ -14,6 +14,8 @@ import type { IVaultAccess } from "../services/vault-service";
 import type { ISettingsAccess } from "../services/settings-service";
 import type { ErrorInfo } from "../types/errors";
 import type { IMentionService } from "../utils/mention-parser";
+import type { IWikilinkResolver } from "../utils/wikilink-resolver";
+import type { IAgentWorkspace } from "../services/agent-workspace";
 import { useAgentSession } from "./useAgentSession";
 import { useAgentMessages, type SendMessageOptions } from "./useAgentMessages";
 
@@ -114,9 +116,10 @@ export interface UseAgentReturn {
 export function useAgent(
 	agentClient: AcpClient,
 	settingsAccess: ISettingsAccess,
-	vaultAccess: IVaultAccess & IMentionService,
+	vaultAccess: IVaultAccess & IMentionService & IWikilinkResolver,
 	workingDirectory: string,
 	initialAgentId?: string,
+	agentWorkspace: IAgentWorkspace | null = null,
 ): UseAgentReturn {
 	// ============================================================
 	// Shared Error State
@@ -142,6 +145,8 @@ export function useAgent(
 		vaultAccess,
 		agentSession.session,
 		setErrorInfo,
+		agentWorkspace,
+		agentSession.setWorkspaceSnapshot,
 	);
 
 	// ============================================================

--- a/src/hooks/useAgentMessages.ts
+++ b/src/hooks/useAgentMessages.ts
@@ -15,12 +15,18 @@ import type {
 	ImagePromptContent,
 	ResourceLinkPromptContent,
 } from "../types/chat";
-import type { ChatSession, SessionUpdate } from "../types/session";
+import type {
+	ChatSession,
+	SessionUpdate,
+	WorkspaceSnapshot,
+} from "../types/session";
 import type { AcpClient } from "../acp/acp-client";
 import type { IVaultAccess, NoteMetadata } from "../services/vault-service";
+import type { IWikilinkResolver } from "../utils/wikilink-resolver";
 import type { ISettingsAccess } from "../services/settings-service";
 import type { ErrorInfo } from "../types/errors";
 import type { IMentionService } from "../utils/mention-parser";
+import type { IAgentWorkspace } from "../services/agent-workspace";
 import { preparePrompt, sendPreparedPrompt } from "../services/message-sender";
 import { Platform } from "obsidian";
 import {
@@ -91,9 +97,11 @@ export interface UseAgentMessagesReturn {
 export function useAgentMessages(
 	agentClient: AcpClient,
 	settingsAccess: ISettingsAccess,
-	vaultAccess: IVaultAccess & IMentionService,
+	vaultAccess: IVaultAccess & IMentionService & IWikilinkResolver,
 	session: ChatSession,
 	setErrorInfo: (error: ErrorInfo | null) => void,
+	agentWorkspace: IAgentWorkspace | null,
+	setWorkspaceSnapshot: (snapshot: WorkspaceSnapshot | null) => void,
 ): UseAgentMessagesReturn {
 	// ============================================================
 	// Message State
@@ -233,6 +241,14 @@ export function useAgentMessages(
 
 			const settings = settingsAccess.getSnapshot();
 
+			const workspaceInput =
+				agentWorkspace && agentWorkspace.isEnabled()
+					? {
+							service: agentWorkspace,
+							snapshot: session.workspaceSnapshot ?? null,
+						}
+					: undefined;
+
 			const prepared = await preparePrompt(
 				{
 					message: content,
@@ -247,6 +263,9 @@ export function useAgentMessages(
 					maxNoteLength: settings.displaySettings.maxNoteLength,
 					maxSelectionLength:
 						settings.displaySettings.maxSelectionLength,
+					expandWikilinkContext: settings.expandWikilinkContext,
+					wikilinkResolver: vaultAccess,
+					agentWorkspace: workspaceInput,
 				},
 				vaultAccess,
 				vaultAccess, // IMentionService (same object)
@@ -314,6 +333,28 @@ export function useAgentMessages(
 				if (result.success) {
 					setIsSending(false);
 					setLastUserMessage(null);
+
+					// Commit post-turn workspace snapshot — recompute from disk
+					// so that any agent-self-edits during the turn are folded
+					// in and not re-shipped on the next prompt.
+					if (workspaceInput) {
+						try {
+							const next =
+								await agentWorkspace!.postTurnSnapshot();
+							setWorkspaceSnapshot(next);
+						} catch (error) {
+							console.warn(
+								"[useAgentMessages] postTurnSnapshot failed:",
+								error,
+							);
+							// Fall back to the pending snapshot computed pre-send.
+							if (prepared.pendingWorkspaceSnapshot) {
+								setWorkspaceSnapshot(
+									prepared.pendingWorkspaceSnapshot,
+								);
+							}
+						}
+					}
 				} else {
 					setIsSending(false);
 					setErrorInfo(
@@ -344,6 +385,9 @@ export function useAgentMessages(
 			session.sessionId,
 			session.authMethods,
 			session.promptCapabilities,
+			session.workspaceSnapshot,
+			agentWorkspace,
+			setWorkspaceSnapshot,
 			shouldConvertToWsl,
 			addMessage,
 			setErrorInfo,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -19,6 +19,7 @@ import {
 } from "./services/settings-service";
 import { AgentClientSettingTab } from "./ui/SettingsTab";
 import { AcpClient } from "./acp/acp-client";
+import { AgentWorkspace } from "./services/agent-workspace";
 import {
 	sanitizeArgs,
 	normalizeEnvVars,
@@ -32,6 +33,7 @@ import {
 	obj,
 	strRecord,
 	xyPoint,
+	normalizeWorkspacePath,
 } from "./services/settings-normalizer";
 import {
 	AgentEnvVar,
@@ -75,6 +77,17 @@ export interface AgentClientPluginSettings {
 	defaultAgentId: string;
 	autoAllowPermissions: boolean;
 	autoMentionActiveNote: boolean;
+	/** Surface `[[wikilinks]]` inside note content as resolved metadata so the agent can decide which links to follow */
+	expandWikilinkContext: boolean;
+	/** Agent Workspace — opinionated /Agent-Client/ folder with seed-then-delta context shipping */
+	agentWorkspace: {
+		enabled: boolean;
+		path: string;
+		emitInstructions: boolean;
+		agentAssistedFocusUpdate: boolean;
+		resourcesMaxEntries: number;
+		resourcesMaxDepth: number;
+	};
 	/** Show OS system notifications on response completion and permission requests */
 	enableSystemNotifications: boolean;
 	debugMode: boolean;
@@ -149,6 +162,15 @@ const DEFAULT_SETTINGS: AgentClientPluginSettings = {
 	defaultAgentId: "claude-code-acp",
 	autoAllowPermissions: false,
 	autoMentionActiveNote: true,
+	expandWikilinkContext: true,
+	agentWorkspace: {
+		enabled: true,
+		path: "Agent-Client",
+		emitInstructions: true,
+		agentAssistedFocusUpdate: false,
+		resourcesMaxEntries: 200,
+		resourcesMaxDepth: 3,
+	},
 	enableSystemNotifications: true,
 	debugMode: false,
 	nodePath: "",
@@ -188,6 +210,7 @@ const DEFAULT_SETTINGS: AgentClientPluginSettings = {
 export default class AgentClientPlugin extends Plugin {
 	settings: AgentClientPluginSettings;
 	settingsService!: SettingsService;
+	agentWorkspace!: AgentWorkspace;
 
 	/** Registry for all chat view containers (sidebar + floating) */
 	viewRegistry = new ChatViewRegistry();
@@ -206,6 +229,10 @@ export default class AgentClientPlugin extends Plugin {
 
 		// Initialize settings store
 		this.settingsService = createSettingsService(this.settings, this);
+
+		// Initialize Agent Workspace (folder bootstrap is async; fire and forget)
+		this.agentWorkspace = new AgentWorkspace(this, this.settingsService);
+		void this.agentWorkspace.ensureBootstrapped();
 
 		this.registerView(VIEW_TYPE_CHAT, (leaf) => new ChatView(leaf, this));
 
@@ -346,6 +373,9 @@ export default class AgentClientPlugin extends Plugin {
 	}
 
 	onunload() {
+		// Tear down Agent Workspace (unsubscribe vault events)
+		this.agentWorkspace?.destroy();
+
 		// Unmount floating button
 		this.floatingButton?.unmount();
 		this.floatingButton = null;
@@ -837,6 +867,7 @@ export default class AgentClientPlugin extends Plugin {
 		const rg = obj(raw.gemini) ?? {};
 		const re = obj(raw.exportSettings) ?? {};
 		const rd = obj(raw.displaySettings) ?? {};
+		const rw = obj(raw.agentWorkspace) ?? {};
 
 		// Normalize custom agents
 		const customAgents = Array.isArray(raw.customAgents)
@@ -907,6 +938,32 @@ export default class AgentClientPlugin extends Plugin {
 				raw.autoMentionActiveNote,
 				D.autoMentionActiveNote,
 			),
+			expandWikilinkContext: bool(
+				raw.expandWikilinkContext,
+				D.expandWikilinkContext,
+			),
+			agentWorkspace: {
+				enabled: bool(rw.enabled, D.agentWorkspace.enabled),
+				path: normalizeWorkspacePath(rw.path, D.agentWorkspace.path),
+				emitInstructions: bool(
+					rw.emitInstructions,
+					D.agentWorkspace.emitInstructions,
+				),
+				agentAssistedFocusUpdate: bool(
+					rw.agentAssistedFocusUpdate,
+					D.agentWorkspace.agentAssistedFocusUpdate,
+				),
+				resourcesMaxEntries: num(
+					rw.resourcesMaxEntries,
+					D.agentWorkspace.resourcesMaxEntries,
+					1,
+				),
+				resourcesMaxDepth: num(
+					rw.resourcesMaxDepth,
+					D.agentWorkspace.resourcesMaxDepth,
+					0,
+				),
+			},
 			enableSystemNotifications: bool(
 				raw.enableSystemNotifications,
 				D.enableSystemNotifications,
@@ -1099,6 +1156,16 @@ export default class AgentClientPlugin extends Plugin {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Re-bootstrap the Agent Workspace after settings changes
+	 * (path or enable toggle). Discards in-memory manifest and snapshots.
+	 */
+	refreshAgentWorkspace(): void {
+		this.agentWorkspace?.destroy();
+		this.agentWorkspace = new AgentWorkspace(this, this.settingsService);
+		void this.agentWorkspace.ensureBootstrapped();
 	}
 
 	ensureDefaultAgentId(): void {

--- a/src/services/message-sender.ts
+++ b/src/services/message-sender.ts
@@ -37,6 +37,15 @@ import {
 } from "../utils/mention-parser";
 import { convertWindowsPathToWsl } from "../utils/platform";
 import { buildFileUri } from "../utils/paths";
+import {
+	type IWikilinkResolver,
+	type BasenameIndex,
+} from "../utils/wikilink-resolver";
+import { formatLinkedNotesPrelude } from "../utils/wikilink-formatter";
+import type {
+	IAgentWorkspace,
+	WorkspaceSnapshot,
+} from "./agent-workspace";
 
 // ============================================================================
 // Types
@@ -75,6 +84,23 @@ export interface PreparePromptInput {
 
 	/** Maximum characters for selection (default: 10000) */
 	maxSelectionLength?: number;
+
+	/** Whether to enrich note content with wikilink metadata (default: false) */
+	expandWikilinkContext?: boolean;
+
+	/** Resolver for `[[wikilinks]]` inside note content; required when expandWikilinkContext=true */
+	wikilinkResolver?: IWikilinkResolver | null;
+
+	/**
+	 * Agent Workspace integration. When provided, a `<obsidian_workspace>` seed
+	 * (or `<obsidian_workspace_update>` delta) is prepended to the prompt.
+	 * `snapshot=null` triggers a seed; otherwise the service computes a delta
+	 * relative to the snapshot.
+	 */
+	agentWorkspace?: {
+		service: IAgentWorkspace;
+		snapshot: WorkspaceSnapshot | null;
+	};
 }
 
 /**
@@ -96,6 +122,12 @@ export interface PreparePromptResult {
 			toLine: number;
 		};
 	};
+
+	/**
+	 * Agent Workspace snapshot to commit on successful send. Always defined
+	 * when `input.agentWorkspace` was provided; otherwise omitted.
+	 */
+	pendingWorkspaceSnapshot?: WorkspaceSnapshot;
 }
 
 /**
@@ -286,6 +318,55 @@ function buildAutoMentionContext(
 }
 
 /**
+ * Per-prompt scan context: built once at the top of `preparePrompt`,
+ * threaded into helpers so the basename index isn't rebuilt per mention.
+ */
+interface WikilinkScanContext {
+	resolver: IWikilinkResolver;
+	basenameIndex: BasenameIndex;
+	vaultBasePath: string;
+	convertToWsl: boolean;
+}
+
+/**
+ * Build the wikilink scan context, or null when expansion is disabled
+ * or the resolver port wasn't provided.
+ */
+function buildWikilinkContext(
+	input: PreparePromptInput,
+): WikilinkScanContext | null {
+	if (!input.expandWikilinkContext || !input.wikilinkResolver) return null;
+	return {
+		resolver: input.wikilinkResolver,
+		basenameIndex: input.wikilinkResolver.buildBasenameIndex(),
+		vaultBasePath: input.vaultBasePath,
+		convertToWsl: input.convertToWsl ?? false,
+	};
+}
+
+/**
+ * Prepend the `<obsidian_metadata>` prelude to note content when wikilinks
+ * are present. No-op when ctx is null or the note has no resolvable links.
+ */
+function decorateWithLinkedNotes(
+	rawContent: string,
+	sourcePath: string,
+	ctx: WikilinkScanContext | null,
+): string {
+	if (!ctx) return rawContent;
+	const links = ctx.resolver.extractLinkedNoteMetadata(
+		rawContent,
+		sourcePath,
+		ctx.basenameIndex,
+	);
+	const prelude = formatLinkedNotesPrelude(links, {
+		vaultBasePath: ctx.vaultBasePath,
+		convertToWsl: ctx.convertToWsl,
+	});
+	return prelude + rawContent;
+}
+
+/**
  * Resolve absolute path with optional WSL conversion.
  */
 function resolveAbsolutePath(
@@ -325,15 +406,62 @@ export async function preparePrompt(
 	// Step 1: Extract all mentioned notes from the message
 	const mentionedNotes = extractMentionedNotes(input.message, mentionService);
 
-	// Step 2: Build context based on agent capabilities
-	if (input.supportsEmbeddedContext) {
-		return preparePromptWithEmbeddedContext(
-			input,
-			vaultAccess,
-			mentionedNotes,
+	// Step 2: Build the Agent Workspace prelude (seed or delta) up-front so
+	// both transport branches can prepend it to their first text block.
+	const workspace = await buildAgentWorkspacePrelude(input);
+
+	// Step 3: Build context based on agent capabilities
+	const result = input.supportsEmbeddedContext
+		? await preparePromptWithEmbeddedContext(
+				input,
+				vaultAccess,
+				mentionedNotes,
+				workspace.prelude,
+			)
+		: await preparePromptWithTextContext(
+				input,
+				vaultAccess,
+				mentionedNotes,
+				workspace.prelude,
+			);
+
+	if (workspace.pendingSnapshot) {
+		result.pendingWorkspaceSnapshot = workspace.pendingSnapshot;
+	}
+	return result;
+}
+
+/**
+ * Compute the Agent Workspace prelude string + the snapshot to commit on
+ * successful send. Returns empty prelude when the integration is not enabled.
+ */
+async function buildAgentWorkspacePrelude(
+	input: PreparePromptInput,
+): Promise<{
+	prelude: string;
+	pendingSnapshot: WorkspaceSnapshot | undefined;
+}> {
+	if (!input.agentWorkspace) {
+		return { prelude: "", pendingSnapshot: undefined };
+	}
+	try {
+		const result = await input.agentWorkspace.service.buildPrelude(
+			input.agentWorkspace.snapshot,
+			{
+				vaultBasePath: input.vaultBasePath,
+				convertToWsl: input.convertToWsl ?? false,
+				wikilinkResolver: input.wikilinkResolver ?? null,
+				expandWikilinkContext:
+					input.expandWikilinkContext ?? false,
+			},
 		);
-	} else {
-		return preparePromptWithTextContext(input, vaultAccess, mentionedNotes);
+		return {
+			prelude: result.prelude,
+			pendingSnapshot: result.pendingSnapshot,
+		};
+	} catch (error) {
+		console.error("[message-sender] Workspace prelude failed:", error);
+		return { prelude: "", pendingSnapshot: undefined };
 	}
 }
 
@@ -347,8 +475,10 @@ async function preparePromptWithEmbeddedContext(
 		noteTitle: string;
 		file: { path: string; stat: { mtime: number } } | undefined;
 	}>,
+	workspacePrelude: string,
 ): Promise<PreparePromptResult> {
 	const maxNoteLen = input.maxNoteLength ?? DEFAULT_MAX_NOTE_LENGTH;
+	const wikilinkCtx = buildWikilinkContext(input);
 	const resourceBlocks: ResourcePromptContent[] = [];
 
 	// Build Resource blocks for each mentioned note
@@ -364,10 +494,11 @@ async function preparePromptWithEmbeddedContext(
 		);
 		if (!note) continue;
 
-		const text = note.wasTruncated
+		const baseText = note.wasTruncated
 			? note.content +
 				`\n\n[Note: Truncated from ${note.originalLength} to ${maxNoteLen} characters]`
 			: note.content;
+		const text = decorateWithLinkedNotes(baseText, file.path, wikilinkCtx);
 
 		resourceBlocks.push({
 			type: "resource",
@@ -389,6 +520,7 @@ async function preparePromptWithEmbeddedContext(
 			vaultAccess,
 			input.convertToWsl ?? false,
 			input.maxSelectionLength ?? DEFAULT_MAX_SELECTION_LENGTH,
+			wikilinkCtx,
 		);
 		autoMentionBlocks.push(...autoMentionResource);
 	}
@@ -398,14 +530,18 @@ async function preparePromptWithEmbeddedContext(
 		input.isAutoMentionDisabled,
 	);
 
+	const messageText = autoMentionPrefix + input.message;
+	const includeTextBlock =
+		messageText.length > 0 || workspacePrelude.length > 0;
+
 	const agentContent: PromptContent[] = [
 		...resourceBlocks,
 		...autoMentionBlocks,
-		...(input.message || autoMentionPrefix
+		...(includeTextBlock
 			? [
 					{
 						type: "text" as const,
-						text: autoMentionPrefix + input.message,
+						text: workspacePrelude + messageText,
 					},
 				]
 			: []),
@@ -433,8 +569,10 @@ async function preparePromptWithTextContext(
 		noteTitle: string;
 		file: { path: string; stat: { mtime: number } } | undefined;
 	}>,
+	workspacePrelude: string,
 ): Promise<PreparePromptResult> {
 	const maxNoteLen = input.maxNoteLength ?? DEFAULT_MAX_NOTE_LENGTH;
+	const wikilinkCtx = buildWikilinkContext(input);
 	const contextBlocks: string[] = [];
 
 	// Build XML context blocks for each mentioned note
@@ -454,8 +592,14 @@ async function preparePromptWithTextContext(
 			? `\n\n[Note: This note was truncated. Original length: ${note.originalLength} characters, showing first ${maxNoteLen} characters]`
 			: "";
 
+		const decoratedBody = decorateWithLinkedNotes(
+			note.content,
+			file.path,
+			wikilinkCtx,
+		);
+
 		contextBlocks.push(
-			`<obsidian_mentioned_note ref="${note.absolutePath}">\n${note.content}${truncationNote}\n</obsidian_mentioned_note>`,
+			`<obsidian_mentioned_note ref="${note.absolutePath}">\n${decoratedBody}${truncationNote}\n</obsidian_mentioned_note>`,
 		);
 	}
 
@@ -468,6 +612,7 @@ async function preparePromptWithTextContext(
 			input.convertToWsl ?? false,
 			input.activeNote.selection,
 			input.maxSelectionLength ?? DEFAULT_MAX_SELECTION_LENGTH,
+			wikilinkCtx,
 		);
 		contextBlocks.push(autoMentionContextBlock);
 	}
@@ -477,14 +622,15 @@ async function preparePromptWithTextContext(
 		input.isAutoMentionDisabled,
 	);
 
-	// Build agent message text (context blocks + auto-mention prefix + original message)
-	const agentMessageText =
+	// Build agent message text (workspace prelude + context blocks + auto-mention prefix + original message)
+	const baseText =
 		contextBlocks.length > 0
 			? contextBlocks.join("\n") +
 				"\n\n" +
 				autoMentionPrefix +
 				input.message
 			: autoMentionPrefix + input.message;
+	const agentMessageText = workspacePrelude + baseText;
 
 	const agentContent: PromptContent[] = [
 		...(agentMessageText
@@ -513,6 +659,7 @@ async function buildAutoMentionResource(
 	vaultAccess: IVaultAccess,
 	convertToWsl: boolean,
 	maxSelectionLength: number,
+	wikilinkCtx: WikilinkScanContext | null,
 ): Promise<PromptContent[]> {
 	const absolutePath = resolveAbsolutePath(
 		activeNote.path,
@@ -540,10 +687,15 @@ async function buildAutoMentionResource(
 			];
 		}
 
-		const text = sel.wasTruncated
+		const baseText = sel.wasTruncated
 			? sel.text +
 				`\n\n[Note: Truncated from ${sel.originalLength} to ${maxSelectionLength} characters]`
 			: sel.text;
+		const text = decorateWithLinkedNotes(
+			baseText,
+			activeNote.path,
+			wikilinkCtx,
+		);
 
 		return [
 			{
@@ -580,6 +732,7 @@ async function buildAutoMentionTextContext(
 	convertToWsl: boolean,
 	selection: { from: EditorPosition; to: EditorPosition } | undefined,
 	maxSelectionLength: number,
+	wikilinkCtx: WikilinkScanContext | null,
 ): Promise<string> {
 	const absolutePath = resolveAbsolutePath(notePath, vaultPath, convertToWsl);
 
@@ -601,10 +754,16 @@ async function buildAutoMentionTextContext(
 			? `\n\n[Note: The selection was truncated. Original length: ${sel.originalLength} characters, showing first ${maxSelectionLength} characters]`
 			: "";
 
+		const decoratedSelection = decorateWithLinkedNotes(
+			sel.text,
+			notePath,
+			wikilinkCtx,
+		);
+
 		return `<obsidian_opened_note selection="lines ${fromLine}-${toLine}">
 The user opened the note ${absolutePath} in Obsidian and selected the following text (lines ${fromLine}-${toLine}):
 
-${sel.text}${truncationNote}
+${decoratedSelection}${truncationNote}
 
 This is what the user is currently focusing on.
 </obsidian_opened_note>`;

--- a/src/services/vault-service.ts
+++ b/src/services/vault-service.ts
@@ -17,6 +17,13 @@ import {
 import { EditorView } from "@codemirror/view";
 import { Compartment, StateEffect } from "@codemirror/state";
 import { getLogger, Logger } from "../utils/logger";
+import {
+	buildBasenameIndex,
+	extractLinkedNoteMetadata,
+	type BasenameIndex,
+	type IWikilinkResolver,
+	type LinkedNoteMetadata,
+} from "../utils/wikilink-resolver";
 
 // ============================================================================
 // Port Types (from vault-access.port.ts)
@@ -116,7 +123,7 @@ export interface IVaultAccess {
  * providing built-in fuzzy search (formerly NoteMentionService),
  * and tracking editor selection state.
  */
-export class VaultService implements IVaultAccess {
+export class VaultService implements IVaultAccess, IWikilinkResolver {
 	private files: TFile[] = [];
 	private lastBuild = 0;
 	private logger: Logger;
@@ -295,6 +302,27 @@ export class VaultService implements IVaultAccess {
 	listNotes(): Promise<NoteMetadata[]> {
 		return Promise.resolve(
 			this.files.map((file) => this.convertToMetadata(file)),
+		);
+	}
+
+	// ========================================================================
+	// IWikilinkResolver Implementation
+	// ========================================================================
+
+	buildBasenameIndex(): BasenameIndex {
+		return buildBasenameIndex(this.plugin.app);
+	}
+
+	extractLinkedNoteMetadata(
+		content: string,
+		sourcePath: string,
+		basenameIndex: BasenameIndex,
+	): LinkedNoteMetadata[] {
+		return extractLinkedNoteMetadata(
+			content,
+			sourcePath,
+			basenameIndex,
+			this.plugin.app,
 		);
 	}
 

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -130,6 +130,20 @@ export class AgentClientSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName("Expand wikilink context")
+			.setDesc(
+				"Surface [[wikilinks]] inside mentioned notes as resolved file paths so the agent can choose which to read. Does not embed linked content.",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.expandWikilinkContext)
+					.onChange(async (value) => {
+						this.plugin.settings.expandWikilinkContext = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
 			.setName("Max note length")
 			.setDesc(
 				"Maximum characters per mentioned note. Notes longer than this will be truncated.",
@@ -171,6 +185,137 @@ export class AgentClientSettingTab extends PluginSettingTab {
 						if (!isNaN(num) && num >= 1) {
 							this.plugin.settings.displaySettings.maxSelectionLength =
 								num;
+							await this.plugin.saveSettings();
+						}
+					}),
+			);
+
+		// ─────────────────────────────────────────────────────────────────────
+		// Agent Workspace
+		// ─────────────────────────────────────────────────────────────────────
+
+		new Setting(containerEl).setName("Agent Workspace").setHeading();
+
+		new Setting(containerEl)
+			.setName("Enable agent workspace")
+			.setDesc(
+				"Maintain a dedicated /Agent-Client/ folder (Focus_Context.md, Resources/, Agent_Output/) and ship its structure to the agent on every session.",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.agentWorkspace.enabled)
+					.onChange(async (value) => {
+						this.plugin.settings.agentWorkspace.enabled = value;
+						await this.plugin.saveSettings();
+						this.plugin.refreshAgentWorkspace();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Workspace folder")
+			.setDesc(
+				"Vault-relative folder name. Existing content is preserved; missing structure is created on load.",
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder("Agent-Client")
+					.setValue(this.plugin.settings.agentWorkspace.path)
+					.onChange(async (value) => {
+						const trimmed = value
+							.trim()
+							.replace(/^\/+|\/+$/g, "");
+						if (!trimmed) return;
+						if (
+							trimmed
+								.split("/")
+								.some((seg) => !seg || seg === "..")
+						) {
+							return;
+						}
+						this.plugin.settings.agentWorkspace.path = trimmed;
+						await this.plugin.saveSettings();
+						this.plugin.refreshAgentWorkspace();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Emit instructions block")
+			.setDesc(
+				"Include a short instructions block in the seed prelude describing each zone's role.",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(
+						this.plugin.settings.agentWorkspace.emitInstructions,
+					)
+					.onChange(async (value) => {
+						this.plugin.settings.agentWorkspace.emitInstructions =
+							value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Agent-assisted Focus_Context updates")
+			.setDesc(
+				"Tell the agent to append a `[[link]]: summary` line to Focus_Context.md after creating each output note. Default off.",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(
+						this.plugin.settings.agentWorkspace
+							.agentAssistedFocusUpdate,
+					)
+					.onChange(async (value) => {
+						this.plugin.settings.agentWorkspace.agentAssistedFocusUpdate =
+							value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Resources max entries")
+			.setDesc(
+				"Cap the number of files listed in the Resources/ manifest. Older files are dropped first.",
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder("200")
+					.setValue(
+						String(
+							this.plugin.settings.agentWorkspace
+								.resourcesMaxEntries,
+						),
+					)
+					.onChange(async (value) => {
+						const n = parseInt(value, 10);
+						if (!isNaN(n) && n >= 1) {
+							this.plugin.settings.agentWorkspace.resourcesMaxEntries =
+								n;
+							await this.plugin.saveSettings();
+						}
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Resources max depth")
+			.setDesc(
+				"Maximum subdirectory depth to scan inside Resources/. 0 = top level only.",
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder("3")
+					.setValue(
+						String(
+							this.plugin.settings.agentWorkspace
+								.resourcesMaxDepth,
+						),
+					)
+					.onChange(async (value) => {
+						const n = parseInt(value, 10);
+						if (!isNaN(n) && n >= 0) {
+							this.plugin.settings.agentWorkspace.resourcesMaxDepth =
+								n;
 							await this.plugin.saveSettings();
 						}
 					}),

--- a/src/utils/wikilink-formatter.ts
+++ b/src/utils/wikilink-formatter.ts
@@ -1,0 +1,107 @@
+/**
+ * Wikilink metadata formatter
+ *
+ * Pure function: takes a `LinkedNoteMetadata[]` (vault-relative) plus the
+ * vault base path / WSL flag and produces the `<obsidian_metadata>` body
+ * string that gets prepended to the note body in both transports.
+ *
+ * Design ref: docs/design/wikilink-context.md §4.1
+ */
+
+import type { LinkedNoteMetadata } from "./wikilink-resolver";
+import { convertWindowsPathToWsl } from "./platform";
+import { buildFileUri } from "./paths";
+
+/** Hard cap on links per note (D9). Beyond this, emit `truncated="N"`. */
+const MAX_LINKS_PER_NOTE = 50;
+
+export interface FormatLinkedNotesOptions {
+	vaultBasePath: string;
+	convertToWsl: boolean;
+	/** Override the cap (tests). Defaults to MAX_LINKS_PER_NOTE. */
+	maxLinks?: number;
+}
+
+/**
+ * Build the `<obsidian_metadata>` prelude for a note.
+ *
+ * Returns an empty string when there are no links — the caller should not
+ * emit any wrapper in that case (D8: byte-identical to today's output for
+ * link-free notes).
+ */
+export function formatLinkedNotesPrelude(
+	links: LinkedNoteMetadata[],
+	options: FormatLinkedNotesOptions,
+): string {
+	if (links.length === 0) return "";
+
+	const cap = options.maxLinks ?? MAX_LINKS_PER_NOTE;
+	const truncated = links.length > cap;
+	const visibleLinks = truncated ? links.slice(0, cap) : links;
+
+	const linkLines = visibleLinks.map((link) =>
+		formatLink(link, options.vaultBasePath, options.convertToWsl),
+	);
+
+	const linksOpen = truncated
+		? `<links truncated="${links.length - cap}">`
+		: "<links>";
+
+	return `<obsidian_metadata>\n  ${linksOpen}\n${linkLines.join("\n")}\n  </links>\n</obsidian_metadata>\n`;
+}
+
+function formatLink(
+	link: LinkedNoteMetadata,
+	vaultBasePath: string,
+	convertToWsl: boolean,
+): string {
+	const attrs: string[] = [`text="${escapeAttr(link.linkText)}"`];
+	if (link.displayText) {
+		attrs.push(`displayText="${escapeAttr(link.displayText)}"`);
+	}
+	if (link.section) {
+		attrs.push(`section="${escapeAttr(link.section)}"`);
+	}
+
+	if (link.candidates.length === 0) {
+		attrs.push(`resolved="false"`);
+		return `    <link ${attrs.join(" ")} />`;
+	}
+
+	if (link.candidates.length === 1) {
+		const c = link.candidates[0];
+		const absolutePath = resolveAbsolute(c.path, vaultBasePath, convertToWsl);
+		attrs.push(`path="${escapeAttr(absolutePath)}"`);
+		attrs.push(`uri="${escapeAttr(buildFileUri(absolutePath))}"`);
+		attrs.push(`resolved="true"`);
+		return `    <link ${attrs.join(" ")} />`;
+	}
+
+	attrs.push(`resolved="ambiguous"`);
+	const candidateLines = link.candidates.map((c) => {
+		const absolutePath = resolveAbsolute(c.path, vaultBasePath, convertToWsl);
+		return `      <candidate path="${escapeAttr(absolutePath)}" uri="${escapeAttr(buildFileUri(absolutePath))}" />`;
+	});
+	return `    <link ${attrs.join(" ")}>\n${candidateLines.join("\n")}\n    </link>`;
+}
+
+function resolveAbsolute(
+	relativePath: string,
+	vaultBasePath: string,
+	convertToWsl: boolean,
+): string {
+	const absolutePath = vaultBasePath
+		? `${vaultBasePath}/${relativePath}`
+		: relativePath;
+	return convertToWsl ? convertWindowsPathToWsl(absolutePath) : absolutePath;
+}
+
+/** XML attribute-value escaping. Covers all five XML predefined entities. */
+function escapeAttr(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&apos;");
+}

--- a/src/utils/wikilink-resolver.ts
+++ b/src/utils/wikilink-resolver.ts
@@ -1,0 +1,161 @@
+/**
+ * Wikilink resolver
+ *
+ * Pure utilities for extracting `[[wikilinks]]` from note content and resolving
+ * them to vault files. Skips `![[embeds]]` (per design D6).
+ *
+ * The resolver returns vault-relative metadata; the formatter is responsible
+ * for converting `path` to absolute path / `file://` URI.
+ */
+
+import { TFile, type App } from "obsidian";
+
+export interface LinkedNoteCandidate {
+	/** Vault-relative path (e.g., "folder/Note.md") */
+	path: string;
+	/** File basename without extension (e.g., "Note") */
+	basename: string;
+}
+
+export interface LinkedNoteMetadata {
+	/** Target portion of the wikilink (`[[Foo]]` → "Foo", `[[Foo#Bar]]` → "Foo") */
+	linkText: string;
+	/** Alias (`[[Foo|bar]]` → "bar"); undefined when same as linkText */
+	displayText?: string;
+	/** Section anchor (`[[Foo#Bar]]` → "Bar"); undefined when no anchor */
+	section?: string;
+	/** Resolved file matches; empty = unresolved, single = resolved, multiple = ambiguous */
+	candidates: LinkedNoteCandidate[];
+}
+
+/**
+ * Index of vault files keyed by basename. Multiple files can share a basename
+ * (collision), which is what surfaces ambiguity in `extractLinkedNoteMetadata`.
+ *
+ * Build once per `preparePrompt` and reuse across multiple notes (perf).
+ */
+export type BasenameIndex = Map<string, TFile[]>;
+
+/**
+ * VaultService-implemented port. Lets `preparePrompt` request resolver work
+ * without taking an `App` dependency itself.
+ */
+export interface IWikilinkResolver {
+	buildBasenameIndex(): BasenameIndex;
+	extractLinkedNoteMetadata(
+		content: string,
+		sourcePath: string,
+		basenameIndex: BasenameIndex,
+	): LinkedNoteMetadata[];
+}
+
+/** Build a basename → files index from the vault's markdown files. */
+export function buildBasenameIndex(app: App): BasenameIndex {
+	const index: BasenameIndex = new Map();
+	const files = app.vault.getMarkdownFiles();
+	for (const file of files) {
+		const entries = index.get(file.basename) ?? [];
+		entries.push(file);
+		index.set(file.basename, entries);
+	}
+	return index;
+}
+
+/**
+ * Resolve a single wikilink target string to candidate files.
+ *
+ * Combines two sources:
+ *   1. `metadataCache.getFirstLinkpathDest(target, sourcePath)` — Obsidian's
+ *      own resolver, which respects relative paths and same-folder priority.
+ *   2. Basename collisions from the prebuilt index (only when target has no
+ *      extension), so ambiguous links surface multiple candidates.
+ *
+ * Map dedupes by file path; result preserves insertion order.
+ */
+function resolveWikiLinkTargets(
+	rawTarget: string,
+	sourcePath: string,
+	basenameIndex: BasenameIndex,
+	app: App,
+): TFile[] {
+	const target = rawTarget.trim();
+	if (!target) return [];
+
+	const results = new Map<string, TFile>();
+
+	const resolved = app.metadataCache.getFirstLinkpathDest(target, sourcePath);
+	if (resolved instanceof TFile) {
+		results.set(resolved.path, resolved);
+	}
+
+	if (!/\.[^./]+$/.test(target)) {
+		const basename = target.split("/").pop() ?? target;
+		const duplicates = basenameIndex.get(basename) ?? [];
+		for (const file of duplicates) {
+			results.set(file.path, file);
+		}
+	}
+
+	return Array.from(results.values());
+}
+
+/**
+ * Extract structured metadata for every `[[wikilink]]` in `content`.
+ *
+ * Skips `![[embeds]]` and in-document anchors (`[[#Heading]]`).
+ * Dedupes by composite key `target|alias|section` so the same link written
+ * multiple times produces one entry.
+ */
+export function extractLinkedNoteMetadata(
+	content: string,
+	sourcePath: string,
+	basenameIndex: BasenameIndex,
+	app: App,
+): LinkedNoteMetadata[] {
+	if (!content) return [];
+
+	const linkPattern = /\[\[([^\]]+)\]\]/g;
+	const matches = new Map<string, LinkedNoteMetadata>();
+
+	let match: RegExpExecArray | null;
+	while ((match = linkPattern.exec(content)) !== null) {
+		// Skip embeds: `![[Foo]]`
+		if (match.index > 0 && content[match.index - 1] === "!") continue;
+
+		const inner = match[1]?.trim();
+		if (!inner) continue;
+
+		const [targetPart, displayPart] = inner.split("|");
+		const [targetWithoutSection, sectionPart] = targetPart.split("#");
+		const linkText = targetWithoutSection?.trim();
+		if (!linkText) continue; // in-document anchor (`[[#Heading]]`) or whitespace-only
+
+		const aliasTrimmed = displayPart?.trim();
+		const sectionTrimmed = sectionPart?.trim();
+
+		const key = `${linkText}|${aliasTrimmed ?? ""}|${sectionTrimmed ?? ""}`;
+		if (matches.has(key)) continue;
+
+		const candidateFiles = resolveWikiLinkTargets(
+			linkText,
+			sourcePath,
+			basenameIndex,
+			app,
+		);
+
+		matches.set(key, {
+			linkText,
+			displayText:
+				aliasTrimmed && aliasTrimmed !== linkText
+					? aliasTrimmed
+					: undefined,
+			section: sectionTrimmed || undefined,
+			candidates: candidateFiles.map((file) => ({
+				path: file.path,
+				basename: file.basename,
+			})),
+		});
+	}
+
+	return Array.from(matches.values());
+}


### PR DESCRIPTION
## Description

Add a setting Expand wikilink context (default on) under Mentions in the plugin settings. When enabled, every mentioned note (and the auto-mention
active note) gets a leading <obsidian_metadata><links>...</links></obsidian_metadata>
block listing each [[link]] with:

text — the raw target as written
displayText — alias when present ([[Foo|bar]])
section — anchor when present ([[Foo#Bar]])
resolved — "true", "false", or "ambiguous"
path  — file:// URI for resolved single-candidate links
nested <candidate> entries for ambiguous matches
The agent always sees pointers, never embedded body content for linked
notes — that decision stays with the agent at read time.

## Related issue

#267 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: macOS

## Screenshots
- Settings (wikilink mode):
<img width="1096" height="674" alt="image" src="https://github.com/user-attachments/assets/383ddf43-0d4d-4e89-b958-1812a9f5206c" />

- Agent can see wikilink path
<img width="446" height="873" alt="image" src="https://github.com/user-attachments/assets/64062c3a-06ce-4c95-9816-9b657fa4d652" />


