### PR TITLE
fix: address Obsidian plugin review feedback

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
               run: npm run build
 
             - name: Attest build provenance
-              uses: actions/attest-build-provenance@v2
+              uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
               with:
                   subject-path: |
                       main.js

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,18 +10,28 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: write
+            id-token: write
+            attestations: write
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Use Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
-                  node-version: "18.x"
+                  node-version: "22.x"
+
+            - name: Install dependencies
+              run: npm ci
 
             - name: Build plugin
-              run: |
-                  npm install
-                  npm run build
+              run: npm run build
+
+            - name: Attest build provenance
+              uses: actions/attest-build-provenance@v2
+              with:
+                  subject-path: |
+                      main.js
+                      styles.css
 
             - name: Create release
               env:

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "agent-client",
 	"name": "Agent Client",
 	"version": "0.10.2",
-	"minAppVersion": "0.15.0",
+	"minAppVersion": "1.7.2",
 	"description": "Chat with AI agents via the Agent Client Protocol directly from your vault.",
 	"author": "RAIT-09",
 	"authorUrl": "https://github.com/RAIT-09",

--- a/src/acp/acp-client.ts
+++ b/src/acp/acp-client.ts
@@ -469,7 +469,7 @@ export class AcpClient {
 				promptResult.stopReason === "end_turn"
 			) {
 				// Allow pending stderr data events to flush before checking
-				await new Promise((r) => setTimeout(r, 100));
+				await new Promise((r) => activeWindow.setTimeout(r, 100));
 
 				const stderrHint = extractStderrErrorHint(this.recentStderr);
 				if (stderrHint) {

--- a/src/acp/acp-handler.ts
+++ b/src/acp/acp-handler.ts
@@ -182,11 +182,11 @@ export class AcpHandler {
 	// File System Stubs
 	// ====================================================================
 
-	readTextFile(params: acp.ReadTextFileRequest) {
+	readTextFile(_params: acp.ReadTextFileRequest) {
 		return Promise.resolve({ content: "" });
 	}
 
-	writeTextFile(params: acp.WriteTextFileRequest) {
+	writeTextFile(_params: acp.WriteTextFileRequest) {
 		return Promise.resolve({});
 	}
 

--- a/src/types/obsidian-internals.d.ts
+++ b/src/types/obsidian-internals.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Type augmentation for unofficial Obsidian APIs.
+ *
+ * These methods exist at runtime but are not in the public type definitions.
+ * Only add methods that are widely used by the plugin community and unlikely
+ * to be removed without notice.
+ */
+declare module "obsidian" {
+	interface Vault {
+		getConfig(key: string): unknown;
+	}
+}

--- a/src/types/obsidian-internals.d.ts
+++ b/src/types/obsidian-internals.d.ts
@@ -1,3 +1,5 @@
+export {};
+
 /**
  * Type augmentation for unofficial Obsidian APIs.
  *

--- a/src/ui/ChangeDirectoryModal.ts
+++ b/src/ui/ChangeDirectoryModal.ts
@@ -57,7 +57,7 @@ export class ChangeDirectoryModal extends Modal {
 		});
 
 		// Focus and select all text
-		setTimeout(() => {
+		activeWindow.setTimeout(() => {
 			inputEl.focus();
 			inputEl.select();
 		}, 10);

--- a/src/ui/ChangeDirectoryModal.ts
+++ b/src/ui/ChangeDirectoryModal.ts
@@ -93,7 +93,7 @@ export class ChangeDirectoryModal extends Modal {
 
 	private async openFolderPicker(): Promise<string | null> {
 		try {
-			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			// eslint-disable-next-line @typescript-eslint/no-require-imports -- electron is a runtime-only module provided by Obsidian's host environment
 			const { remote } = require("electron") as {
 				remote: {
 					dialog: {

--- a/src/ui/ChatHeader.tsx
+++ b/src/ui/ChatHeader.tsx
@@ -17,8 +17,6 @@ export interface SidebarHeaderProps {
 	agentLabel: string;
 	/** Whether a plugin update is available */
 	isUpdateAvailable: boolean;
-	/** Whether session history is supported (show History button) */
-	hasHistoryCapability?: boolean;
 	/** Callback to create a new chat session */
 	onNewChat: () => void;
 	/** Callback to export the chat */
@@ -105,7 +103,6 @@ function NavActionButton({
 function SidebarHeader({
 	agentLabel,
 	isUpdateAvailable,
-	hasHistoryCapability = false,
 	onNewChat,
 	onExportChat,
 	onShowMenu,

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -991,7 +991,6 @@ export function ChatPanel({
 				variant="sidebar"
 				agentLabel={activeAgentLabel}
 				isUpdateAvailable={isUpdateAvailable}
-				hasHistoryCapability={sessionHistory.canShowSessionHistory}
 				onNewChat={() => void handleNewChatWithPersist()}
 				onExportChat={() => void handleExportChat()}
 				onShowMenu={handleShowSidebarMenu}

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -702,7 +702,7 @@ export function ChatPanel({
 			);
 
 			// System notification on response completion
-			if (settings.enableSystemNotifications && !document.hasFocus()) {
+			if (settings.enableSystemNotifications && !activeDocument.hasFocus()) {
 				new Notification("Agent Client", {
 					body: `${activeAgentLabel} has completed the response.`,
 				});
@@ -732,7 +732,7 @@ export function ChatPanel({
 			!wasActive &&
 			agent.hasActivePermission &&
 			settings.enableSystemNotifications &&
-			!document.hasFocus()
+			!activeDocument.hasFocus()
 		) {
 			new Notification("Agent Client", {
 				body: `${activeAgentLabel} is requesting permission.`,

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -281,7 +281,7 @@ export class ChatView extends ItemView implements IChatViewContainer {
 	 * Check if this view currently has focus.
 	 */
 	hasFocus(): boolean {
-		return this.containerEl.contains(document.activeElement);
+		return this.containerEl.contains(activeDocument.activeElement);
 	}
 
 	/**

--- a/src/ui/ErrorBanner.tsx
+++ b/src/ui/ErrorBanner.tsx
@@ -46,7 +46,7 @@ export function ErrorBanner({
 			}
 		};
 
-		view.registerDomEvent(document, "keydown", handleKeyDown);
+		view.registerDomEvent(activeDocument, "keydown", handleKeyDown);
 	}, [onClose, view]);
 
 	return (

--- a/src/ui/FloatingButton.tsx
+++ b/src/ui/FloatingButton.tsx
@@ -34,7 +34,7 @@ export class FloatingButtonContainer {
 	private containerEl: HTMLElement;
 
 	constructor(private plugin: AgentClientPlugin) {
-		this.containerEl = document.body.createDiv({
+		this.containerEl = activeDocument.body.createDiv({
 			cls: "agent-client-floating-button-root",
 		});
 	}
@@ -195,7 +195,8 @@ function FloatingButtonComponent({ plugin }: FloatingButtonProps) {
 	// Save button position to settings (debounced)
 	useEffect(() => {
 		if (!position) return;
-		const timer = setTimeout(() => {
+		const win = activeWindow;
+		const timer = win.setTimeout(() => {
 			if (
 				!settings.floatingButtonPosition ||
 				position.x !== settings.floatingButtonPosition.x ||
@@ -207,7 +208,7 @@ function FloatingButtonComponent({ plugin }: FloatingButtonProps) {
 				});
 			}
 		}, 500);
-		return () => clearTimeout(timer);
+		return () => win.clearTimeout(timer);
 	}, [position, plugin, settings.floatingButtonPosition]);
 
 	// Button click handler
@@ -239,9 +240,10 @@ function FloatingButtonComponent({ plugin }: FloatingButtonProps) {
 			}
 		};
 
-		document.addEventListener("mousedown", handleClickOutside);
+		const doc = activeDocument;
+		doc.addEventListener("mousedown", handleClickOutside);
 		return () => {
-			document.removeEventListener("mousedown", handleClickOutside);
+			doc.removeEventListener("mousedown", handleClickOutside);
 		};
 	}, [showInstanceMenu]);
 

--- a/src/ui/FloatingChatView.tsx
+++ b/src/ui/FloatingChatView.tsx
@@ -62,7 +62,7 @@ export class FloatingViewContainer implements IChatViewContainer {
 		this.plugin = plugin;
 		// viewId format: "floating-chat-{instanceId}" to match adapter key
 		this.viewId = `floating-chat-${instanceId}`;
-		this.containerEl = document.body.createDiv({
+		this.containerEl = activeDocument.body.createDiv({
 			cls: "agent-client-floating-view-root",
 		});
 	}
@@ -149,7 +149,7 @@ export class FloatingViewContainer implements IChatViewContainer {
 	hasFocus(): boolean {
 		return (
 			this.isExpandedState &&
-			(this.containerRefEl?.contains(document.activeElement) ?? false)
+			(this.containerRefEl?.contains(activeDocument.activeElement) ?? false)
 		);
 	}
 
@@ -360,10 +360,11 @@ function FloatingChatComponent({
 			}
 		};
 
-		const timer = setTimeout(() => {
+		const win = activeWindow;
+		const timer = win.setTimeout(() => {
 			void saveSize();
-		}, 500); // Debounce save
-		return () => clearTimeout(timer);
+		}, 500);
+		return () => win.clearTimeout(timer);
 	}, [size, plugin, settings.floatingWindowSize]);
 
 	// Save position to settings
@@ -381,10 +382,11 @@ function FloatingChatComponent({
 			}
 		};
 
-		const timer = setTimeout(() => {
+		const win = activeWindow;
+		const timer = win.setTimeout(() => {
 			void savePosition();
-		}, 500); // Debounce save
-		return () => clearTimeout(timer);
+		}, 500);
+		return () => win.clearTimeout(timer);
 	}, [position, plugin, settings.floatingWindowPosition]);
 
 	// ============================================================

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -301,12 +301,9 @@ export function InputArea({
 	const settings = useSettings(plugin);
 	const showEmojis = plugin.settings.displaySettings.showEmojis;
 
-	// Unofficial Obsidian API: app.vault.getConfig() is not in the public type definitions
-	// but is widely used by the plugin community for accessing editor settings.
-	/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access */
-	const obsidianSpellcheck: boolean =
-		(plugin.app.vault as any).getConfig("spellcheck") ?? true;
-	/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access */
+	// Unofficial Obsidian API (see src/types/obsidian-internals.d.ts)
+	const obsidianSpellcheck =
+		(plugin.app.vault.getConfig("spellcheck") as boolean | undefined) ?? true;
 
 	// Local state (hint and command are still local - not needed for broadcast)
 	const [hintText, setHintText] = useState<string | null>(null);
@@ -418,7 +415,7 @@ export function InputArea({
 	const convertFilesToAttachments = useCallback(
 		(files: File[]): AttachedFile[] => {
 			// Get file path via Electron's webUtils API (File.path was removed in Electron 32)
-			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			// eslint-disable-next-line @typescript-eslint/no-require-imports -- electron is a runtime-only module provided by Obsidian's host environment
 			const { webUtils } = require("electron") as {
 				webUtils: { getPathForFile: (file: File) => string };
 			};

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -537,7 +537,7 @@ export function InputArea({
 	/**
 	 * Handle drag leave event to reset visual feedback.
 	 */
-	const handleDragLeave = useCallback((e: React.DragEvent) => {
+	const handleDragLeave = useCallback((_e: React.DragEvent) => {
 		dragCounterRef.current--;
 		if (dragCounterRef.current === 0) {
 			setIsDraggingOver(false);
@@ -970,8 +970,6 @@ export function InputArea({
 					selectedIndex={mentions.selectedIndex}
 					onSelect={selectMention}
 					onClose={mentions.close}
-					plugin={plugin}
-					view={view}
 				/>
 			)}
 
@@ -983,8 +981,6 @@ export function InputArea({
 					selectedIndex={slashCommands.selectedIndex}
 					onSelect={handleSelectSlashCommand}
 					onClose={slashCommands.close}
-					plugin={plugin}
-					view={view}
 				/>
 			)}
 

--- a/src/ui/MessageBubble.tsx
+++ b/src/ui/MessageBubble.tsx
@@ -318,7 +318,7 @@ function CopyButton({ contents }: { contents: MessageContent[] }) {
 			.writeText(text)
 			.then(() => {
 				setCopied(true);
-				setTimeout(() => setCopied(false), 2000);
+				activeWindow.setTimeout(() => setCopied(false), 2000);
 			})
 			.catch(() => {});
 	}, [contents]);

--- a/src/ui/MessageBubble.tsx
+++ b/src/ui/MessageBubble.tsx
@@ -152,7 +152,6 @@ function CollapsibleThought({ text, plugin }: CollapsibleThoughtProps) {
 interface ContentBlockProps {
 	content: MessageContent;
 	plugin: AgentClientPlugin;
-	messageId?: string;
 	messageRole?: "user" | "assistant";
 	terminalClient?: AcpClient;
 	/** Callback to approve a permission request */
@@ -165,7 +164,6 @@ interface ContentBlockProps {
 function ContentBlock({
 	content,
 	plugin,
-	messageId,
 	messageRole,
 	terminalClient,
 	onApprovePermission,
@@ -247,7 +245,6 @@ function ContentBlock({
 				<TerminalBlock
 					terminalId={content.terminalId}
 					terminalClient={terminalClient || null}
-					plugin={plugin}
 				/>
 			);
 
@@ -409,7 +406,6 @@ export const MessageBubble = React.memo(function MessageBubble({
 									key={imgIdx}
 									content={content}
 									plugin={plugin}
-									messageId={message.id}
 									messageRole={message.role}
 									terminalClient={terminalClient}
 									onApprovePermission={onApprovePermission}
@@ -424,7 +420,6 @@ export const MessageBubble = React.memo(function MessageBubble({
 							<ContentBlock
 								content={group.item}
 								plugin={plugin}
-								messageId={message.id}
 								messageRole={message.role}
 								terminalClient={terminalClient}
 								onApprovePermission={onApprovePermission}

--- a/src/ui/PermissionBanner.tsx
+++ b/src/ui/PermissionBanner.tsx
@@ -1,4 +1,3 @@
-import type AgentClientPlugin from "../plugin";
 import { getLogger } from "../utils/logger";
 import type { PermissionOption } from "../types/chat";
 
@@ -10,8 +9,6 @@ interface PermissionBannerProps {
 		isCancelled?: boolean;
 		isActive?: boolean;
 	};
-	toolCallId: string;
-	plugin: AgentClientPlugin;
 	/** Callback to approve a permission request */
 	onApprovePermission?: (
 		requestId: string,
@@ -22,8 +19,6 @@ interface PermissionBannerProps {
 
 export function PermissionBanner({
 	permissionRequest,
-	toolCallId,
-	plugin,
 	onApprovePermission,
 	onOptionSelected,
 }: PermissionBannerProps) {

--- a/src/ui/SessionHistoryModal.tsx
+++ b/src/ui/SessionHistoryModal.tsx
@@ -123,7 +123,7 @@ class EditTitleModal extends Modal {
 		inputEl.value = this.currentTitle;
 
 		// Focus and select all text for easy replacement
-		setTimeout(() => {
+		activeWindow.setTimeout(() => {
 			inputEl.focus();
 			inputEl.select();
 		}, 10);

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -1228,15 +1228,15 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	 */
 	private addInstallHint(containerEl: HTMLElement, npmPackage: string): void {
 		const command = `npm install -g ${npmPackage}@latest`;
-		const frag = document.createDocumentFragment();
-		frag.append("Not installed? Run in terminal: ");
-		frag.appendChild(document.createElement("code")).textContent = command;
+		const frag = createFragment();
+		frag.appendText("Not installed? Run in terminal: ");
+		frag.createEl("code", { text: command });
 		new Setting(containerEl).setDesc(frag).addButton((btn) => {
 			btn.setButtonText("Copy").onClick(() => {
 				void navigator.clipboard.writeText(command).then(
 					() => {
 						btn.setButtonText("Copied!");
-						setTimeout(() => {
+						activeWindow.setTimeout(() => {
 							btn.setButtonText("Copy");
 						}, 1500);
 					},
@@ -1279,14 +1279,14 @@ export class AgentClientSettingTab extends PluginSettingTab {
 							this.display();
 						} else {
 							btn.setButtonText("Not found");
-							setTimeout(() => {
+							activeWindow.setTimeout(() => {
 								btn.setButtonText("Auto-detect");
 								btn.setDisabled(false);
 							}, 2000);
 						}
 					} catch {
 						btn.setButtonText("Error");
-						setTimeout(() => {
+						activeWindow.setTimeout(() => {
 							btn.setButtonText("Auto-detect");
 							btn.setDisabled(false);
 						}, 2000);

--- a/src/ui/SuggestionPopup.tsx
+++ b/src/ui/SuggestionPopup.tsx
@@ -60,9 +60,10 @@ export function SuggestionPopup({
 			}
 		};
 
-		document.addEventListener("mousedown", handleClickOutside);
+		const doc = activeDocument;
+		doc.addEventListener("mousedown", handleClickOutside);
 		return () => {
-			document.removeEventListener("mousedown", handleClickOutside);
+			doc.removeEventListener("mousedown", handleClickOutside);
 		};
 	}, [onClose]);
 

--- a/src/ui/SuggestionPopup.tsx
+++ b/src/ui/SuggestionPopup.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
 const { useRef, useEffect } = React;
-import type AgentClientPlugin from "../plugin";
-import type { IChatViewHost } from "./view-host";
 import type { NoteMetadata } from "../services/vault-service";
 import type { SlashCommand } from "../types/session";
 
@@ -31,12 +29,6 @@ interface SuggestionPopupProps {
 
 	/** Callback to close the dropdown */
 	onClose: () => void;
-
-	/** Plugin instance for logging */
-	plugin: AgentClientPlugin;
-
-	/** View instance for event registration */
-	view: IChatViewHost;
 }
 
 /**
@@ -54,8 +46,6 @@ export function SuggestionPopup({
 	selectedIndex,
 	onSelect,
 	onClose,
-	plugin,
-	view,
 }: SuggestionPopupProps) {
 	const dropdownRef = useRef<HTMLDivElement>(null);
 

--- a/src/ui/TerminalBlock.tsx
+++ b/src/ui/TerminalBlock.tsx
@@ -2,17 +2,14 @@ import * as React from "react";
 const { useState, useRef, useEffect } = React;
 import type { AcpClient } from "../acp/acp-client";
 import { getLogger } from "../utils/logger";
-import type AgentClientPlugin from "../plugin";
 interface TerminalBlockProps {
 	terminalId: string;
 	terminalClient: AcpClient | null;
-	plugin: AgentClientPlugin;
 }
 
 export const TerminalBlock = React.memo(function TerminalBlock({
 	terminalId,
 	terminalClient,
-	plugin,
 }: TerminalBlockProps) {
 	const logger = getLogger();
 	const [output, setOutput] = useState("");

--- a/src/ui/TerminalBlock.tsx
+++ b/src/ui/TerminalBlock.tsx
@@ -29,6 +29,7 @@ export const TerminalBlock = React.memo(function TerminalBlock({
 			`[TerminalBlock] useEffect triggered for ${terminalId}, terminalClient: ${!!terminalClient}`,
 		);
 		if (!terminalId || !terminalClient) return;
+		const win = activeWindow;
 
 		const pollOutput = async () => {
 			try {
@@ -46,7 +47,7 @@ export const TerminalBlock = React.memo(function TerminalBlock({
 					});
 					setIsRunning(false);
 					if (intervalRef.current) {
-						window.clearInterval(intervalRef.current);
+						win.clearInterval(intervalRef.current);
 						intervalRef.current = null;
 					}
 				}
@@ -60,7 +61,7 @@ export const TerminalBlock = React.memo(function TerminalBlock({
 
 				setIsRunning(false);
 				if (intervalRef.current) {
-					window.clearInterval(intervalRef.current);
+					win.clearInterval(intervalRef.current);
 					intervalRef.current = null;
 				}
 			}
@@ -70,13 +71,13 @@ export const TerminalBlock = React.memo(function TerminalBlock({
 		void pollOutput();
 
 		// Set up polling interval with shorter interval to catch fast commands
-		intervalRef.current = window.setInterval(() => {
+		intervalRef.current = win.setInterval(() => {
 			void pollOutput();
 		}, 100);
 
 		return () => {
 			if (intervalRef.current) {
-				window.clearInterval(intervalRef.current);
+				win.clearInterval(intervalRef.current);
 				intervalRef.current = null;
 			}
 		};
@@ -85,7 +86,7 @@ export const TerminalBlock = React.memo(function TerminalBlock({
 	// Separate effect to stop polling when no longer running
 	useEffect(() => {
 		if (!isRunning && intervalRef.current) {
-			window.clearInterval(intervalRef.current);
+			activeWindow.clearInterval(intervalRef.current);
 			intervalRef.current = null;
 		}
 	}, [isRunning]);

--- a/src/ui/ToolCallBlock.tsx
+++ b/src/ui/ToolCallBlock.tsx
@@ -146,7 +146,6 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 								key={index}
 								terminalId={item.terminalId}
 								terminalClient={terminalClient || null}
-								plugin={plugin}
 							/>
 						);
 					}
@@ -177,8 +176,6 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 						...permissionRequest,
 						selectedOptionId: selectedOptionId,
 					}}
-					toolCallId={toolCallId}
-					plugin={plugin}
 					onApprovePermission={onApprovePermission}
 					onOptionSelected={setSelectedOptionId}
 				/>

--- a/src/ui/ToolCallBlock.tsx
+++ b/src/ui/ToolCallBlock.tsx
@@ -32,7 +32,6 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 		kind,
 		title,
 		status,
-		toolCallId,
 		permissionRequest,
 		locations,
 		rawInput,


### PR DESCRIPTION
## Description

Address all findings from the Obsidian official plugin review. The review flagged 23 errors, 38 warnings, and 2 recommendations across source code and release assets.

### Changes by category

**B. minAppVersion (18 errors)**
Bump `minAppVersion` from `0.15.0` to `1.7.2`. The codebase uses APIs up to `Workspace.revealLeaf()` (introduced in 1.7.2) but declared compatibility with 0.15.0.

**C. ESLint directives (5 errors)**
- Add module augmentation (`src/types/obsidian-internals.d.ts`) for the unofficial `Vault.getConfig()` API, eliminating the `as any` cast that violated `no-explicit-any`
- Add `-- reason` descriptions to `eslint-disable` directives for `require("electron")`

**D. Unused variables (10 warnings)**
- Remove 7 unused props (`hasHistoryCapability`, `messageId`, `toolCallId`, `plugin`×4, `view`) from component interfaces, destructures, and call sites
- Rename 3 interface-required parameters to `_params` / `_e`

**E. Popout window compatibility (28 warnings)**
- Replace `setTimeout`/`clearTimeout` with `activeWindow.setTimeout`/`activeWindow.clearTimeout`
- Replace `document` references with `activeDocument`
- Replace `document.createDocumentFragment()`/`document.createElement()` with Obsidian's `createFragment()`/`createEl()`
- Capture `activeWindow`/`activeDocument` in `useEffect` locals for paired add/remove patterns

**A. Artifact attestation (2 recommendations)**
- Add `actions/attest-build-provenance@v2` to the release workflow
- Modernize workflow: actions v3→v4, Node.js 18→22, `npm install`→`npm ci`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [ ] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: Linux (Ubuntu)