### PR TITLE
feat: make entire auto-mention badge row clickable

### DIFF
--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -1001,7 +1001,14 @@ export function InputArea({
 			>
 				{/* Auto-mention Badge */}
 				{autoMentionEnabled && mentions.activeNote && (
-					<div className="agent-client-auto-mention-inline">
+					<div
+						className="agent-client-auto-mention-inline"
+						onClick={() =>
+							mentions.toggleAutoMention(
+								!mentions.isAutoMentionDisabled,
+							)
+						}
+					>
 						<span
 							className={`agent-client-mention-badge ${mentions.isAutoMentionDisabled ? "agent-client-disabled" : ""}`}
 						>
@@ -1017,15 +1024,6 @@ export function InputArea({
 						</span>
 						<button
 							className="agent-client-auto-mention-toggle-btn"
-							onClick={(e) => {
-								const newDisabledState =
-									!mentions.isAutoMentionDisabled;
-								mentions.toggleAutoMention(newDisabledState);
-								const iconName = newDisabledState
-									? "x"
-									: "plus";
-								setIcon(e.currentTarget, iconName);
-							}}
 							title={
 								mentions.isAutoMentionDisabled
 									? "Enable auto-mention"

--- a/styles.css
+++ b/styles.css
@@ -694,6 +694,7 @@ If your plugin does not need CSS, delete this file.
 	justify-content: space-between;
 	gap: 4px;
 	padding: 6px 12px;
+	cursor: pointer;
 	background-color: transparent;
 }
 


### PR DESCRIPTION
## Description

Make the entire auto-mention badge row clickable to toggle the auto-mention state,
instead of only the × / + button. Clicking anywhere on the row — the @note name text — now triggers the same toggle.

- Moved `onClick` from the badge `<span>` to the container `<div>` in `InputArea.tsx`
- Removed the redundant `onClick` from the toggle button (icon still updates via ref callback on re-render)
- Added `cursor: pointer` to `.agent-client-auto-mention-inline` in `styles.css`


## Related issue

N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: Windows 11