### PR TITLE
fix: use window.* prefix for timer and animation frame APIs

### DIFF
--- a/src/acp/acp-client.ts
+++ b/src/acp/acp-client.ts
@@ -469,7 +469,7 @@ export class AcpClient {
 				promptResult.stopReason === "end_turn"
 			) {
 				// Allow pending stderr data events to flush before checking
-				await new Promise((r) => activeWindow.setTimeout(r, 100));
+				await new Promise((r) => window.setTimeout(r, 100));
 
 				const stderrHint = extractStderrErrorHint(this.recentStderr);
 				if (stderrHint) {

--- a/src/hooks/useAgentMessages.ts
+++ b/src/hooks/useAgentMessages.ts
@@ -153,7 +153,7 @@ export function useAgentMessages(
 			pendingUpdatesRef.current.push(update);
 			if (!flushScheduledRef.current) {
 				flushScheduledRef.current = true;
-				requestAnimationFrame(flushPendingUpdates);
+				window.requestAnimationFrame(flushPendingUpdates);
 			}
 		},
 		[flushPendingUpdates],

--- a/src/ui/ChangeDirectoryModal.ts
+++ b/src/ui/ChangeDirectoryModal.ts
@@ -57,7 +57,7 @@ export class ChangeDirectoryModal extends Modal {
 		});
 
 		// Focus and select all text
-		activeWindow.setTimeout(() => {
+		window.setTimeout(() => {
 			inputEl.focus();
 			inputEl.select();
 		}, 10);

--- a/src/ui/FloatingButton.tsx
+++ b/src/ui/FloatingButton.tsx
@@ -195,8 +195,7 @@ function FloatingButtonComponent({ plugin }: FloatingButtonProps) {
 	// Save button position to settings (debounced)
 	useEffect(() => {
 		if (!position) return;
-		const win = activeWindow;
-		const timer = win.setTimeout(() => {
+		const timer = window.setTimeout(() => {
 			if (
 				!settings.floatingButtonPosition ||
 				position.x !== settings.floatingButtonPosition.x ||
@@ -208,7 +207,7 @@ function FloatingButtonComponent({ plugin }: FloatingButtonProps) {
 				});
 			}
 		}, 500);
-		return () => win.clearTimeout(timer);
+		return () => window.clearTimeout(timer);
 	}, [position, plugin, settings.floatingButtonPosition]);
 
 	// Button click handler

--- a/src/ui/FloatingChatView.tsx
+++ b/src/ui/FloatingChatView.tsx
@@ -157,7 +157,7 @@ export class FloatingViewContainer implements IChatViewContainer {
 			this.setExpanded?.(true);
 		}
 		// Focus after next render (expansion may need a frame)
-		requestAnimationFrame(() => {
+		window.requestAnimationFrame(() => {
 			const textarea = this.containerRefEl?.querySelector(
 				"textarea.agent-client-chat-input-textarea",
 			);
@@ -411,11 +411,10 @@ function FloatingChatComponent({
 			}
 		};
 
-		const win = activeWindow;
-		const timer = win.setTimeout(() => {
+		const timer = window.setTimeout(() => {
 			void saveSize();
 		}, 500);
-		return () => win.clearTimeout(timer);
+		return () => window.clearTimeout(timer);
 	}, [size, plugin, settings.floatingWindowSize]);
 
 	// Save position to settings
@@ -433,11 +432,10 @@ function FloatingChatComponent({
 			}
 		};
 
-		const win = activeWindow;
-		const timer = win.setTimeout(() => {
+		const timer = window.setTimeout(() => {
 			void savePosition();
 		}, 500);
-		return () => win.clearTimeout(timer);
+		return () => window.clearTimeout(timer);
 	}, [position, plugin, settings.floatingWindowPosition]);
 
 	// ============================================================

--- a/src/ui/MessageBubble.tsx
+++ b/src/ui/MessageBubble.tsx
@@ -318,7 +318,7 @@ function CopyButton({ contents }: { contents: MessageContent[] }) {
 			.writeText(text)
 			.then(() => {
 				setCopied(true);
-				activeWindow.setTimeout(() => setCopied(false), 2000);
+				window.setTimeout(() => setCopied(false), 2000);
 			})
 			.catch(() => {});
 	}, [contents]);

--- a/src/ui/MessageList.tsx
+++ b/src/ui/MessageList.tsx
@@ -131,7 +131,7 @@ export function MessageList({
 		if (scrollSmoothRef.current) {
 			// User sent a message — smooth scroll regardless of isAtBottom
 			scrollSmoothRef.current = false;
-			requestAnimationFrame(() => {
+			window.requestAnimationFrame(() => {
 				virtualizer.scrollToIndex(messages.length - 1, {
 					align: "end",
 					behavior: "smooth",
@@ -142,7 +142,7 @@ export function MessageList({
 
 		if (isAtBottomRef.current) {
 			// Use requestAnimationFrame to ensure virtualizer has measured
-			requestAnimationFrame(() => {
+			window.requestAnimationFrame(() => {
 				virtualizer.scrollToIndex(messages.length - 1, {
 					align: "end",
 				});

--- a/src/ui/SessionHistoryModal.tsx
+++ b/src/ui/SessionHistoryModal.tsx
@@ -123,7 +123,7 @@ class EditTitleModal extends Modal {
 		inputEl.value = this.currentTitle;
 
 		// Focus and select all text for easy replacement
-		activeWindow.setTimeout(() => {
+		window.setTimeout(() => {
 			inputEl.focus();
 			inputEl.select();
 		}, 10);

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -1236,7 +1236,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 				void navigator.clipboard.writeText(command).then(
 					() => {
 						btn.setButtonText("Copied!");
-						activeWindow.setTimeout(() => {
+						window.setTimeout(() => {
 							btn.setButtonText("Copy");
 						}, 1500);
 					},
@@ -1279,14 +1279,14 @@ export class AgentClientSettingTab extends PluginSettingTab {
 							this.display();
 						} else {
 							btn.setButtonText("Not found");
-							activeWindow.setTimeout(() => {
+							window.setTimeout(() => {
 								btn.setButtonText("Auto-detect");
 								btn.setDisabled(false);
 							}, 2000);
 						}
 					} catch {
 						btn.setButtonText("Error");
-						activeWindow.setTimeout(() => {
+						window.setTimeout(() => {
 							btn.setButtonText("Auto-detect");
 							btn.setDisabled(false);
 						}, 2000);

--- a/src/ui/TerminalBlock.tsx
+++ b/src/ui/TerminalBlock.tsx
@@ -29,7 +29,6 @@ export const TerminalBlock = React.memo(function TerminalBlock({
 			`[TerminalBlock] useEffect triggered for ${terminalId}, terminalClient: ${!!terminalClient}`,
 		);
 		if (!terminalId || !terminalClient) return;
-		const win = activeWindow;
 
 		const pollOutput = async () => {
 			try {
@@ -47,7 +46,7 @@ export const TerminalBlock = React.memo(function TerminalBlock({
 					});
 					setIsRunning(false);
 					if (intervalRef.current) {
-						win.clearInterval(intervalRef.current);
+						window.clearInterval(intervalRef.current);
 						intervalRef.current = null;
 					}
 				}
@@ -61,7 +60,7 @@ export const TerminalBlock = React.memo(function TerminalBlock({
 
 				setIsRunning(false);
 				if (intervalRef.current) {
-					win.clearInterval(intervalRef.current);
+					window.clearInterval(intervalRef.current);
 					intervalRef.current = null;
 				}
 			}
@@ -71,13 +70,13 @@ export const TerminalBlock = React.memo(function TerminalBlock({
 		void pollOutput();
 
 		// Set up polling interval with shorter interval to catch fast commands
-		intervalRef.current = win.setInterval(() => {
+		intervalRef.current = window.setInterval(() => {
 			void pollOutput();
 		}, 100);
 
 		return () => {
 			if (intervalRef.current) {
-				win.clearInterval(intervalRef.current);
+				window.clearInterval(intervalRef.current);
 				intervalRef.current = null;
 			}
 		};
@@ -86,7 +85,7 @@ export const TerminalBlock = React.memo(function TerminalBlock({
 	// Separate effect to stop polling when no longer running
 	useEffect(() => {
 		if (!isRunning && intervalRef.current) {
-			activeWindow.clearInterval(intervalRef.current);
+			window.clearInterval(intervalRef.current);
 			intervalRef.current = null;
 		}
 	}, [isRunning]);


### PR DESCRIPTION
## Description

Address the second round of Obsidian plugin review feedback on timer APIs.

The previous review asked for `activeWindow.setTimeout` instead of bare `setTimeout`. The latest review reversed this, requesting explicit `window.setTimeout` instead. The review also newly flagged bare `requestAnimationFrame` calls, requesting `window.requestAnimationFrame`.

### Changes

- Replace `activeWindow.setTimeout` → `window.setTimeout` (7 sites)
- Replace `activeWindow.clearInterval` → `window.clearInterval` (1 site)
- Replace bare `requestAnimationFrame` → `window.requestAnimationFrame` (4 sites)
- Remove `const win = activeWindow` capture patterns that are no longer needed since `window` is a static reference (TerminalBlock, FloatingChatView, FloatingButton)

`activeDocument` usages are unchanged — they were not flagged by the review.

## Related issue

N/A — Obsidian plugin review feedback

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [ ] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: Linux (Ubuntu)