### PR TITLE
fix: restore saved mode/model before marking session ready (#266)

### DIFF
--- a/src/hooks/useAgentSession.ts
+++ b/src/hooks/useAgentSession.ts
@@ -223,27 +223,16 @@ export function useAgentSession(
 				const sessionResult =
 					await agentClient.newSession(effectiveCwd);
 
-				setSession((prev) => ({
-					...prev,
-					sessionId: sessionResult.sessionId,
-					state: "ready",
-					authMethods: initResult?.authMethods ?? [],
-					modes: sessionResult.modes,
-					models: sessionResult.models,
-					configOptions: sessionResult.configOptions,
-					promptCapabilities: initResult
-						? initResult.promptCapabilities
-						: prev.promptCapabilities,
-					agentCapabilities: initResult
-						? initResult.agentCapabilities
-						: prev.agentCapabilities,
-					agentInfo: initResult
-						? initResult.agentInfo
-						: prev.agentInfo,
-					lastActivityAt: new Date(),
-				}));
+				// Pre-compute restored modes/models/configOptions BEFORE
+				// marking state as "ready" to avoid a UI race: without this,
+				// the dropdowns briefly show the agent's default values and
+				// a message sent during the window hits the agent in the
+				// wrong mode. With this, the first render after session
+				// creation already shows the user's saved selection.
+				let finalModes = sessionResult.modes;
+				let finalModels = sessionResult.models;
+				let finalConfigOptions = sessionResult.configOptions;
 
-				// Restore last used config (model/mode)
 				if (sessionResult.configOptions && sessionResult.sessionId) {
 					let configOptions = sessionResult.configOptions;
 					configOptions = await tryRestoreConfigOption(
@@ -260,21 +249,37 @@ export function useAgentSession(
 						"mode",
 						settings.lastUsedModes[agentId],
 					);
-					if (configOptions !== sessionResult.configOptions) {
-						setSession((prev) => ({
-							...prev,
-							configOptions,
-						}));
-					}
+					finalConfigOptions = configOptions;
 				} else if (sessionResult.sessionId) {
-					await restoreLegacyConfig(
+					const restored = await restoreLegacyConfig(
 						agentClient,
 						sessionResult,
 						settings.lastUsedModels[agentId],
 						settings.lastUsedModes[agentId],
-						setSession,
 					);
+					finalModes = restored.modes;
+					finalModels = restored.models;
 				}
+
+				setSession((prev) => ({
+					...prev,
+					sessionId: sessionResult.sessionId,
+					state: "ready",
+					authMethods: initResult?.authMethods ?? [],
+					modes: finalModes,
+					models: finalModels,
+					configOptions: finalConfigOptions,
+					promptCapabilities: initResult
+						? initResult.promptCapabilities
+						: prev.promptCapabilities,
+					agentCapabilities: initResult
+						? initResult.agentCapabilities
+						: prev.agentCapabilities,
+					agentInfo: initResult
+						? initResult.agentInfo
+						: prev.agentInfo,
+					lastActivityAt: new Date(),
+				}));
 			} catch (error) {
 				setSession((prev) => ({ ...prev, state: "error" }));
 				setErrorInfo({
@@ -346,20 +351,17 @@ export function useAgentSession(
 			models?: SessionModelState,
 			configOptions?: SessionConfigOption[],
 		) => {
-			setSession((prev) => ({
-				...prev,
-				sessionId,
-				state: "ready",
-				modes: modes ?? prev.modes,
-				models: models ?? prev.models,
-				configOptions: configOptions ?? prev.configOptions,
-				lastActivityAt: new Date(),
-			}));
-
-			// Restore last used config (model/mode) — same logic as createSession
+			// Pre-compute restored config BEFORE marking ready to avoid a UI
+			// race where the dropdowns briefly show the agent's current values
+			// before the user's saved selection is re-applied. See the matching
+			// refactor in createSession for the rationale.
 			const s = sessionRef.current;
 			const settings = settingsAccess.getSnapshot();
 			const agentId = s.agentId;
+
+			let finalModes = modes;
+			let finalModels = models;
+			let finalConfigOptions = configOptions;
 
 			if (configOptions && sessionId) {
 				let restored = configOptions;
@@ -377,21 +379,27 @@ export function useAgentSession(
 					"mode",
 					settings.lastUsedModes[agentId],
 				);
-				if (restored !== configOptions) {
-					setSession((prev) => ({
-						...prev,
-						configOptions: restored,
-					}));
-				}
+				finalConfigOptions = restored;
 			} else if (sessionId && modes) {
-				await restoreLegacyConfig(
+				const restored = await restoreLegacyConfig(
 					agentClient,
 					{ sessionId, modes, models, configOptions: undefined },
 					settings.lastUsedModels[agentId],
 					settings.lastUsedModes[agentId],
-					setSession,
 				);
+				finalModes = restored.modes;
+				finalModels = restored.models;
 			}
+
+			setSession((prev) => ({
+				...prev,
+				sessionId,
+				state: "ready",
+				modes: finalModes ?? prev.modes,
+				models: finalModels ?? prev.models,
+				configOptions: finalConfigOptions ?? prev.configOptions,
+				lastActivityAt: new Date(),
+			}));
 		},
 		[agentClient, settingsAccess],
 	);
@@ -459,7 +467,9 @@ export function useAgentSession(
 		async (configId: string, value: string) => {
 			const s = sessionRef.current;
 			if (!s.sessionId) {
-				getLogger().debug("Cannot set config option: no active session");
+				getLogger().debug(
+					"Cannot set config option: no active session",
+				);
 				return;
 			}
 

--- a/src/services/session-state.ts
+++ b/src/services/session-state.ts
@@ -76,32 +76,41 @@ export async function tryRestoreConfigOption(
 /**
  * Restore last used mode/model via legacy APIs.
  * Only called when configOptions is not available.
+ *
+ * Returns the final modes/models state after restoration (or the originals
+ * if no restoration was needed or if the agent-side calls failed).
+ * The caller is responsible for applying these to session state.
+ * This function has no side effects on React state so callers can sequence
+ * the restore BEFORE marking the session as "ready", avoiding a UI race
+ * where the dropdown briefly shows the agent's default mode/model before
+ * the user's saved selection is re-applied.
  */
 export async function restoreLegacyConfig(
 	agentClient: AcpClient,
 	sessionResult: SessionResult,
 	savedModelId: string | undefined,
 	savedModeId: string | undefined,
-	setSession: (updater: (prev: ChatSession) => ChatSession) => void,
-): Promise<void> {
-	if (!sessionResult.sessionId) return;
+): Promise<{
+	modes: SessionResult["modes"];
+	models: SessionResult["models"];
+}> {
+	let modes = sessionResult.modes;
+	let models = sessionResult.models;
+
+	if (!sessionResult.sessionId) return { modes, models };
 
 	// Legacy model restore
-	if (sessionResult.models && savedModelId) {
+	if (models && savedModelId) {
 		if (
-			savedModelId !== sessionResult.models.currentModelId &&
-			sessionResult.models.availableModels.some(
-				(m) => m.modelId === savedModelId,
-			)
+			savedModelId !== models.currentModelId &&
+			models.availableModels.some((m) => m.modelId === savedModelId)
 		) {
 			try {
 				await agentClient.setSessionModel(
 					sessionResult.sessionId,
 					savedModelId,
 				);
-				setSession((prev) =>
-					applyLegacyValue(prev, "model", savedModelId),
-				);
+				models = { ...models, currentModelId: savedModelId };
 			} catch {
 				// Agent default is fine as fallback
 			}
@@ -109,22 +118,22 @@ export async function restoreLegacyConfig(
 	}
 
 	// Legacy mode restore
-	if (sessionResult.modes && savedModeId) {
+	if (modes && savedModeId) {
 		if (
-			savedModeId !== sessionResult.modes.currentModeId &&
-			sessionResult.modes.availableModes.some((m) => m.id === savedModeId)
+			savedModeId !== modes.currentModeId &&
+			modes.availableModes.some((m) => m.id === savedModeId)
 		) {
 			try {
 				await agentClient.setSessionMode(
 					sessionResult.sessionId,
 					savedModeId,
 				);
-				setSession((prev) =>
-					applyLegacyValue(prev, "mode", savedModeId),
-				);
+				modes = { ...modes, currentModeId: savedModeId };
 			} catch {
 				// Agent default is fine as fallback
 			}
 		}
 	}
+
+	return { modes, models };
 }


### PR DESCRIPTION
Closes #266.

## Summary

Race window during session creation: `restoreLegacyConfig` was applying the saved mode/model **after** the session transitioned to `ready` state, so the dropdowns flickered (default → saved value) and a fast user could send a message in the wrong mode before the restore fired.

This refactors `restoreLegacyConfig` in `src/services/session-state.ts` to return the resolved config object instead of mutating React state via a setter. `useAgentSession.ts` now calls it synchronously before the ready transition, so the restored mode/model is applied in the same render cycle the session becomes interactive.

## Files changed

- `src/services/session-state.ts` — `restoreLegacyConfig` returns `{mode, model}` instead of calling `setSessions`
- `src/hooks/useAgentSession.ts` — call `restoreLegacyConfig` synchronously before setting `state: "ready"`

## Testing

- Created several new sessions; saved mode/model applied without flicker on session reload
- Tested across agents (Kiro, Claude Code, Gemini CLI); correct values restored in each
- Sent message immediately after session ready transition; turn used the restored mode (no race)
- Build clean (`npm run build`); lint at baseline (no new errors)

Rebased on `upstream/dev` (`5f62dae`) at submission time.
