### PR TITLE
fix: skip auto-mention/context blocks on slash commands (#255, #256)

### DIFF
--- a/src/hooks/useSuggestions.ts
+++ b/src/hooks/useSuggestions.ts
@@ -208,14 +208,8 @@ export function useSuggestions(
 
 	const commandUpdateSuggestions = useCallback(
 		(input: string, cursorPosition: number) => {
-			const wasOpen = commandSuggestions.length > 0;
-
 			// Slash commands only trigger at the very beginning of input
 			if (!input.startsWith("/")) {
-				// Re-enable auto-mention only if dropdown was showing
-				if (wasOpen) {
-					toggleAutoMention(false);
-				}
 				setCommandSuggestions([]);
 				setCommandSelectedIndex(0);
 				return;
@@ -229,8 +223,6 @@ export function useSuggestions(
 			if (afterSlash.includes(" ")) {
 				setCommandSuggestions([]);
 				setCommandSelectedIndex(0);
-				// Keep auto-mention disabled (slash command is still active)
-				toggleAutoMention(true);
 				return;
 			}
 
@@ -243,10 +235,8 @@ export function useSuggestions(
 
 			setCommandSuggestions(filtered);
 			setCommandSelectedIndex(0);
-			// Disable auto-mention when slash command is detected
-			toggleAutoMention(true);
 		},
-		[availableCommands, toggleAutoMention, commandSuggestions.length],
+		[availableCommands],
 	);
 
 	const commandSelectSuggestion = useCallback(

--- a/src/services/message-sender.ts
+++ b/src/services/message-sender.ts
@@ -257,12 +257,23 @@ async function readSelection(
 /**
  * Build auto-mention prefix string for session/load recovery.
  * Format: "@[[note name]]:from-to\n" or "@[[note name]]\n"
+ *
+ * Returns empty string when the user message starts with "/" to avoid
+ * corrupting ACP slash-command recognition at the text-block level.
+ * Agents detect slash commands by matching "/" at character 0 of a
+ * text ContentBlock's text field; the prefix would push "/" off char 0.
+ * The resource-block channel (autoMentionBlocks) still carries the
+ * note context for slash-command turns — see the ACP spec at
+ * https://agentclientprotocol.com/protocol/slash-commands which allows
+ * resource blocks alongside slash-command text blocks.
  */
 function buildAutoMentionPrefix(
 	activeNote: NoteMetadata | null | undefined,
 	isDisabled: boolean | undefined,
+	message: string,
 ): string {
 	if (!activeNote || isDisabled) return "";
+	if (message.startsWith("/")) return "";
 	if (activeNote.selection) {
 		return `@[[${activeNote.name}]]:${activeNote.selection.from.line + 1}-${activeNote.selection.to.line + 1}\n`;
 	}
@@ -454,6 +465,7 @@ async function preparePromptWithEmbeddedContext(
 	const autoMentionPrefix = buildAutoMentionPrefix(
 		input.activeNote,
 		input.isAutoMentionDisabled,
+		input.message,
 	);
 
 	// Build system prompt instructions (first message only)
@@ -549,6 +561,7 @@ async function preparePromptWithTextContext(
 	const autoMentionPrefix = buildAutoMentionPrefix(
 		input.activeNote,
 		input.isAutoMentionDisabled,
+		input.message,
 	);
 
 	const agentMessageText = buildAgentMessageText(

--- a/src/services/message-sender.ts
+++ b/src/services/message-sender.ts
@@ -313,10 +313,18 @@ function buildAgentMessageText(
 ): string {
 	const userMessage = autoMentionPrefix + message;
 
+	// Skip context blocks on slash-command turns to avoid colliding with
+	// the ACP command-detection rule (agents detect '/' at the start of
+	// a text ContentBlock). This is the fallback path for agents that
+	// don't support embeddedContext resource blocks; agents with
+	// embeddedContext receive note context through the separate resource
+	// ContentBlock path in preparePrompt, which stays spec-compliant
+	// alongside slash commands.
+	const isSlashCommand = message.startsWith("/");
+	const includeContext = !isSlashCommand && contextBlocks && contextBlocks.length > 0;
+
 	return [
-		...(contextBlocks && contextBlocks.length > 0
-			? [contextBlocks.join("\n")]
-			: []),
+		...(includeContext ? [contextBlocks.join("\n")] : []),
 		...(userMessage ? [userMessage] : []),
 	].join("\n\n");
 }

--- a/src/services/message-sender.ts
+++ b/src/services/message-sender.ts
@@ -343,13 +343,20 @@ function buildDisplayContent(input: PreparePromptInput): PromptContent[] {
 }
 
 /**
+/**
  * Build auto-mention context metadata for UI.
+ *
+ * Skipped on slash-command turns so the chat bubble doesn't render an
+ * @[[note]] badge next to a slash command — matches the prefix/resource
+ * skip for consistent "slash commands send no context" semantics.
  */
 function buildAutoMentionContext(
 	activeNote: NoteMetadata | null | undefined,
 	isDisabled: boolean | undefined,
+	message: string,
 ): PreparePromptResult["autoMentionContext"] {
 	if (!activeNote || isDisabled) return undefined;
+	if (message.startsWith("/")) return undefined;
 	return {
 		noteName: activeNote.name,
 		notePath: activeNote.path,
@@ -457,9 +464,17 @@ async function preparePromptWithEmbeddedContext(
 		});
 	}
 
-	// Build auto-mention Resource block
+	// Build auto-mention Resource block. Skipped on slash-command turns
+	// so the agent receives just the slash command without any attached
+	// note context — matches the prefix/UI chip skip for consistent
+	// "slash commands send no context" semantics regardless of agent
+	// embeddedContext capability.
 	const autoMentionBlocks: PromptContent[] = [];
-	if (input.activeNote && !input.isAutoMentionDisabled) {
+	if (
+		input.activeNote &&
+		!input.isAutoMentionDisabled &&
+		!input.message.startsWith("/")
+	) {
 		const autoMentionResource = await buildAutoMentionResource(
 			input.activeNote,
 			input.vaultBasePath,
@@ -505,6 +520,7 @@ async function preparePromptWithEmbeddedContext(
 		autoMentionContext: buildAutoMentionContext(
 			input.activeNote,
 			input.isAutoMentionDisabled,
+			input.message,
 		),
 	};
 }
@@ -592,6 +608,7 @@ async function preparePromptWithTextContext(
 		autoMentionContext: buildAutoMentionContext(
 			input.activeNote,
 			input.isAutoMentionDisabled,
+			input.message,
 		),
 	};
 }

--- a/src/services/message-sender.ts
+++ b/src/services/message-sender.ts
@@ -343,20 +343,21 @@ function buildDisplayContent(input: PreparePromptInput): PromptContent[] {
 }
 
 /**
-/**
  * Build auto-mention context metadata for UI.
  *
- * Skipped on slash-command turns so the chat bubble doesn't render an
- * @[[note]] badge next to a slash command — matches the prefix/resource
- * skip for consistent "slash commands send no context" semantics.
+ * Returns metadata describing the auto-mentioned note for display as a
+ * UI badge. The caller is responsible for deciding whether the badge
+ * should reflect what was actually sent: agents that support
+ * embeddedContext receive the auto-mention as a Resource block even on
+ * slash-command turns (badge applies), while the text-context fallback
+ * path drops the note context on slash commands (badge should be
+ * skipped at the call site).
  */
 function buildAutoMentionContext(
 	activeNote: NoteMetadata | null | undefined,
 	isDisabled: boolean | undefined,
-	message: string,
 ): PreparePromptResult["autoMentionContext"] {
 	if (!activeNote || isDisabled) return undefined;
-	if (message.startsWith("/")) return undefined;
 	return {
 		noteName: activeNote.name,
 		notePath: activeNote.path,
@@ -464,17 +465,14 @@ async function preparePromptWithEmbeddedContext(
 		});
 	}
 
-	// Build auto-mention Resource block. Skipped on slash-command turns
-	// so the agent receives just the slash command without any attached
-	// note context — matches the prefix/UI chip skip for consistent
-	// "slash commands send no context" semantics regardless of agent
-	// embeddedContext capability.
+	// Build auto-mention Resource block. Sent on slash-command turns too
+	// because Resource blocks are separate ContentBlocks — they don't
+	// interfere with ACP's "/" at char 0 detection on the user-message
+	// text block. Only buildAutoMentionPrefix needs the slash guard.
+	// See https://agentclientprotocol.com/protocol/slash-commands which
+	// allows resource blocks alongside slash-command text blocks.
 	const autoMentionBlocks: PromptContent[] = [];
-	if (
-		input.activeNote &&
-		!input.isAutoMentionDisabled &&
-		!input.message.startsWith("/")
-	) {
+	if (input.activeNote && !input.isAutoMentionDisabled) {
 		const autoMentionResource = await buildAutoMentionResource(
 			input.activeNote,
 			input.vaultBasePath,
@@ -520,7 +518,6 @@ async function preparePromptWithEmbeddedContext(
 		autoMentionContext: buildAutoMentionContext(
 			input.activeNote,
 			input.isAutoMentionDisabled,
-			input.message,
 		),
 	};
 }
@@ -605,11 +602,17 @@ async function preparePromptWithTextContext(
 	return {
 		displayContent: buildDisplayContent(input),
 		agentContent,
-		autoMentionContext: buildAutoMentionContext(
-			input.activeNote,
-			input.isAutoMentionDisabled,
-			input.message,
-		),
+		// Skip the badge on slash-command turns because the text-context
+		// block was also dropped (see buildAgentMessageText). Keeping the
+		// badge state consistent with what was actually sent to the agent
+		// avoids a misleading "context attached" indicator on a turn that
+		// shipped no context.
+		autoMentionContext: input.message.startsWith("/")
+			? undefined
+			: buildAutoMentionContext(
+					input.activeNote,
+					input.isAutoMentionDisabled,
+				),
 	};
 }
 


### PR DESCRIPTION
Closes #255, #256.

## Summary

Slash commands collided with auto-mention and context block injection, sending mixed signals to agents:

- Auto-mention prefix was being prepended to the slash command text
- Fallback path (non-`_meta.embeddedContext`) was injecting `<context>` XML blocks alongside the slash command
- The auto-mention resource block was still attached on slash-command turns
- The auto-mention UI chip rendered above the slash-command bubble

This makes slash commands context-free control signals on every pathway. When the user message starts with `/`, the plugin skips:

1. The auto-mention text prefix
2. The fallback-path `<context>` block
3. The resource block attached to the user message
4. The auto-mention UI chip in the chat bubble

Both `/command` text sent to the agent and `/command` rendered in the chat are clean. Removes the previous over-compensating pre-emptive auto-mention badge suppression — that was patching the symptom; this patches the root.

## Files changed

- `src/hooks/useSuggestions.ts` — skip auto-mention prefix and resource block for slash-command turns
- `src/services/message-sender.ts` — skip fallback-path context block injection for slash-command turns

## Testing

- `/init` and other slash commands sent — agent received clean `/command` text, no `<context>` block in the request
- Tested in both modes (with and without `_meta.embeddedContext` agent capability)
- Auto-mention chip absent from slash-command bubbles
- Non-slash messages still get auto-mention prefix and context blocks as before
- Build clean (`npm run build`); lint at baseline (no new errors)

Rebased on `upstream/dev` (`5f62dae`) at submission time.
