### PR TITLE
fix: normalize WSL path on session restore to prevent cwd mismatch

### DIFF
--- a/src/hooks/useHistoryModal.ts
+++ b/src/hooks/useHistoryModal.ts
@@ -1,7 +1,8 @@
 import { useRef, useCallback, useEffect } from "react";
-import { Notice } from "obsidian";
+import { Notice, Platform } from "obsidian";
 import { SessionHistoryModal } from "../ui/SessionHistoryModal";
 import { getLogger } from "../utils/logger";
+import { convertWslPathToWindows } from "../utils/platform";
 import type AgentClientPlugin from "../plugin";
 import type { UseAgentReturn } from "./useAgent";
 import type { UseSessionHistoryReturn } from "./useSessionHistory";
@@ -39,7 +40,9 @@ export function useHistoryModal(
 				logger.log(`[ChatPanel] Restoring session: ${sessionId}`);
 				agent.clearMessages();
 				await sessionHistory.restoreSession(sessionId, cwd);
-				onAgentCwdChange?.(cwd);
+				onAgentCwdChange?.(
+					Platform.isWin ? convertWslPathToWindows(cwd) : cwd,
+				);
 				new Notice("[Agent Client] Session restored");
 			} catch (error) {
 				new Notice("[Agent Client] Failed to restore session");
@@ -60,7 +63,9 @@ export function useHistoryModal(
 				logger.log(`[ChatPanel] Forking session: ${sessionId}`);
 				agent.clearMessages();
 				await sessionHistory.forkSession(sessionId, cwd);
-				onAgentCwdChange?.(cwd);
+				onAgentCwdChange?.(
+					Platform.isWin ? convertWslPathToWindows(cwd) : cwd,
+				);
 				new Notice("[Agent Client] Session forked");
 			} catch (error) {
 				new Notice("[Agent Client] Failed to fork session");

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from "obsidian";
 
 import type { AttachedFile, ChatInputState } from "../types/chat";
+import { isSameDirectory } from "../utils/platform";
 import { useHistoryModal } from "../hooks/useHistoryModal";
 import { useChatActions } from "../hooks/useChatActions";
 import { ChangeDirectoryModal } from "./ChangeDirectoryModal";
@@ -1011,7 +1012,7 @@ export function ChatPanel({
 		);
 
 	const cwdBanner =
-		agentCwd !== vaultPath ? (
+		agentCwd !== vaultPath && !isSameDirectory(agentCwd, vaultPath) ? (
 			<div className="agent-client-cwd-banner" title={agentCwd}>
 				<span
 					className="agent-client-cwd-banner-icon"

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -215,6 +215,24 @@ export function convertWslPathToWindows(wslPath: string): string {
 }
 
 /**
+ * Check whether two paths refer to the same directory, accounting for
+ * Windows ↔ WSL path format differences.
+ *
+ * Normalizes both paths to forward-slash lowercase form before comparing,
+ * so "C:\Users\foo" and "/mnt/c/Users/foo" are recognized as equal.
+ */
+export function isSameDirectory(pathA: string, pathB: string): boolean {
+	if (pathA === pathB) return true;
+
+	const normalize = (p: string): string => {
+		const win = convertWslPathToWindows(p);
+		return win.replace(/\\/g, "/").toLowerCase();
+	};
+
+	return normalize(pathA) === normalize(pathB);
+}
+
+/**
  * Build a WSL shell wrapper that sources ~/.profile, detects the user's
  * $SHELL, and falls back to /bin/sh for non-POSIX shells (fish, elvish,
  * nushell, xonsh).

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -215,21 +215,20 @@ export function convertWslPathToWindows(wslPath: string): string {
 }
 
 /**
- * Check whether two paths refer to the same directory, accounting for
- * Windows ↔ WSL path format differences.
- *
- * Normalizes both paths to forward-slash lowercase form before comparing,
- * so "C:\Users\foo" and "/mnt/c/Users/foo" are recognized as equal.
+ * Compare two directory paths accounting for Windows ↔ WSL format differences.
  */
 export function isSameDirectory(pathA: string, pathB: string): boolean {
 	if (pathA === pathB) return true;
 
 	const normalize = (p: string): string => {
 		const win = convertWslPathToWindows(p);
-		return win.replace(/\\/g, "/").toLowerCase();
+		return win.replace(/\\/g, "/").replace(/\/+$/, "");
 	};
 
-	return normalize(pathA) === normalize(pathB);
+	const a = normalize(pathA);
+	const b = normalize(pathB);
+
+	return Platform.isWin ? a.toLowerCase() === b.toLowerCase() : a === b;
 }
 
 /**


### PR DESCRIPTION
## Description

In WSL mode, restoring a session from history causes the agent to lose context and displays an incorrect directory banner.

**Root cause:** Session metadata stores `cwd` in WSL format (`/mnt/c/...`) after conversion during save. On restore, this WSL path is set directly to `agentCwd` state, which is normally Windows format (`C:\...`). The mismatch triggers two issues:

1. `agentCwd` change causes `createSession`'s `useCallback` reference to update (it has `workingDirectory` in deps), which re-fires the initialization effect — creating a new empty session that overwrites the just-loaded one.
2. `agentCwd !== vaultPath` evaluates to `true` (different string formats for the same directory), showing the directory banner incorrectly.

**Fix:** Convert WSL paths back to Windows format before setting `agentCwd` in the restore/fork callbacks. Add a defensive `isSameDirectory()` helper for the banner comparison.

### Changes

- `src/utils/platform.ts` — Add `isSameDirectory()` that normalizes Windows/WSL paths before comparing
- `src/hooks/useHistoryModal.ts` — Convert restored session `cwd` from WSL to Windows format via `convertWslPathToWindows()` before passing to `setAgentCwd`
- `src/ui/ChatPanel.tsx` — Use `isSameDirectory()` as fallback in cwd banner comparison

## Related issue

N/A — reported directly by a user on Windows + WSL

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: Windows (WSL mode)