### PR TITLE
Update GitHub Actions versions and enhance CI security

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,10 @@ jobs:
   lint-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
           node-version: "22.x"
           cache: "npm"


### PR DESCRIPTION
## Overview
Updates `actions/checkout` and `actions/setup-node` in `.github/workflows/ci.yaml` to their latest versions and pins them by commit SHA for improved security and reproducibility.

## Changes
- `actions/checkout`: `v4` -> `v6.0.2` (Pinned to SHA: `de0fac2e4500dabe0009e67214ff5f5447ce83dd`)
- `actions/setup-node`: `v4` -> `v6.4.0` (Pinned to SHA: `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`)


https://github.com/actions/setup-node/releases/tag/v6.4.0
https://github.com/actions/checkout/releases/tag/v6.0.2

## Why
- **Security (Supply Chain Security)**: Following GitHub's security best practices by pinning actions to a full-length commit SHA. This mitigates risks from malicious tag moving or supply chain attacks.
- **Optimization**: Ensures better stability and compatibility with modern Node.js environments (currently using Node 22.x).

<img width="1332" height="165" alt="image" src="https://github.com/user-attachments/assets/fc9e3854-fb9d-4ddc-9ee9-84b2599e7806" />

## Meaning
- **Reproducibility**: SHA pinning guarantees the CI environment remains identical even if upstream tags are updated, preventing unexpected CI failures.
- **Maintainability**: Version numbers are kept in comments (e.g., `#v6.0.2`) to maintain human readability while utilizing secure SHA pins.

## Impact
- **Performance**: Potential minor CI speed improvements due to optimized caching and checkout logic in newer versions.
- **Workflow**: No impact on plugin functionality or local development environments.
