### PR TITLE
fix: downgrade React to 18 to pass Obsidian automated review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,14 @@
 				"@codemirror/view": "^6.35.0",
 				"@tanstack/react-virtual": "^3.13.23",
 				"diff": "^8.0.2",
-				"react": "^19.1.1",
-				"react-dom": "^19.1.1",
+				"react": "18.3.1",
+				"react-dom": "18.3.1",
 				"semver": "^7.7.3"
 			},
 			"devDependencies": {
 				"@types/node": "^16.11.6",
-				"@types/react": "^19.1.13",
-				"@types/react-dom": "^19.1.9",
+				"@types/react": "18.3.29",
+				"@types/react-dom": "18.3.7",
 				"@types/semver": "^7.7.1",
 				"@typescript-eslint/parser": "^8.0.0",
 				"@typescript-eslint/utils": "^8.0.0",
@@ -423,54 +423,6 @@
 				"search-insights": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@docsearch/js/node_modules/@types/react": {
-			"version": "18.3.29",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
-			"integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/prop-types": "*",
-				"csstype": "^3.2.2"
-			}
-		},
-		"node_modules/@docsearch/js/node_modules/react": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@docsearch/js/node_modules/react-dom": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"scheduler": "^0.23.2"
-			},
-			"peerDependencies": {
-				"react": "^18.3.1"
-			}
-		},
-		"node_modules/@docsearch/js/node_modules/scheduler": {
-			"version": "0.23.2",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.1.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -1840,27 +1792,28 @@
 			"version": "15.7.15",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
 			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-			"extraneous": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "19.2.15",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
-			"integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+			"version": "18.3.29",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
+			"integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "19.2.3",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
-				"@types/react": "^19.2.0"
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@types/semver": {
@@ -5025,7 +4978,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
@@ -5213,7 +5165,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
@@ -5879,24 +5830,28 @@
 			}
 		},
 		"node_modules/react": {
-			"version": "19.2.6",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-			"integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			},
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "19.2.6",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-			"integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"license": "MIT",
 			"dependencies": {
-				"scheduler": "^0.27.0"
+				"loose-envify": "^1.1.0",
+				"scheduler": "^0.23.2"
 			},
 			"peerDependencies": {
-				"react": "^19.2.6"
+				"react": "^18.3.1"
 			}
 		},
 		"node_modules/react-is": {
@@ -6197,10 +6152,13 @@
 			}
 		},
 		"node_modules/scheduler": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-			"license": "MIT"
+			"version": "0.23.2",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			}
 		},
 		"node_modules/search-insights": {
 			"version": "2.17.3",
@@ -7432,16 +7390,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/vitepress/node_modules/@types/node": {
-			"version": "25.9.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": ">=7.24.0 <7.24.7"
-			}
-		},
 		"node_modules/vitepress/node_modules/@vitejs/plugin-vue": {
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
@@ -7494,13 +7442,6 @@
 				"@esbuild/win32-ia32": "0.21.5",
 				"@esbuild/win32-x64": "0.21.5"
 			}
-		},
-		"node_modules/vitepress/node_modules/undici-types": {
-			"version": "7.24.6",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-			"extraneous": true,
-			"license": "MIT"
 		},
 		"node_modules/vitepress/node_modules/vite": {
 			"version": "5.4.21",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
 	"license": "Apache-2.0",
 	"devDependencies": {
 		"@types/node": "^16.11.6",
-		"@types/react": "^19.1.13",
-		"@types/react-dom": "^19.1.9",
+		"@types/react": "18.3.29",
+		"@types/react-dom": "18.3.7",
 		"@types/semver": "^7.7.1",
 		"@typescript-eslint/parser": "^8.0.0",
 		"@typescript-eslint/utils": "^8.0.0",
@@ -41,8 +41,8 @@
 		"@codemirror/view": "^6.35.0",
 		"@tanstack/react-virtual": "^3.13.23",
 		"diff": "^8.0.2",
-		"react": "^19.1.1",
-		"react-dom": "^19.1.1",
+		"react": "18.3.1",
+		"react-dom": "18.3.1",
 		"semver": "^7.7.3"
 	}
 }


### PR DESCRIPTION
## Description

Obsidian's automated review system (launched May 12, 2026) recently elevated the "dynamic `<script>` element creations" check from Warning to Error. v0.10.4 now fails review with 3 detected occurrences, all originating from React 19's internal "hoistable resources" feature (dead code in Obsidian since we don't render `<script>` JSX or use SSR).

Multiple plugins are reporting the same issue on Obsidian Discord; some have already been removed from the directory.

**Fix:** Downgrade `react` and `react-dom` from 19.1.x to 18.3.x. The plugin uses zero React 19-specific APIs (no `use()`, `useActionState`, `useOptimistic`, ref-as-prop, etc.), so this is a pure version swap with no source code changes.

After the fix:
- `createElement("script")` in main.js: 3 → 0
- Bundle size: 812 KB → 761 KB (-51 KB)

## Related issue

N/A — Obsidian automated review failure

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: Windows (WSL), macOS

## Screenshots

N/A — dependency-only change