### PR TITLE
feat: show session title in ChatView tab header

### DIFF
--- a/src/services/session-helpers.ts
+++ b/src/services/session-helpers.ts
@@ -10,8 +10,10 @@ import type {
 	GeminiAgentSettings,
 	CodexAgentSettings,
 } from "../types/agent";
-import type { ChatSession } from "../types/session";
+import type { ChatSession, SavedSessionInfo } from "../types/session";
+import type { ChatMessage } from "../types/chat";
 import { toAgentConfig } from "./settings-normalizer";
+import { truncateTitle } from "../utils/text";
 
 // ============================================================================
 // Types
@@ -186,4 +188,42 @@ export function createInitialSession(
 		lastActivityAt: new Date(),
 		workingDirectory,
 	};
+}
+
+// ============================================================================
+// Session Title Derivation
+// ============================================================================
+
+/**
+ * Derive the display title for a session from its persisted metadata and
+ * in-memory message list. Returns "New session" as the well-defined fallback.
+ *
+ * Source-of-truth precedence (highest first):
+ *   1. Locally saved title (created on first message, edited via Rename UI)
+ *   2. Truncated text of the first user message (50-char limit)
+ *   3. "New session" (no sessionId yet, or no user messages)
+ *
+ * Pure function — shared by the Session Manager (via the live ChatPanelCallbacks
+ * read against settings + refs) and the chat view tab header (via a useMemo
+ * over React state).
+ */
+export function computeSessionTitle(
+	sessionId: string | null,
+	savedSessions: SavedSessionInfo[],
+	messages: ChatMessage[],
+): string {
+	if (sessionId) {
+		const saved = savedSessions.find((s) => s.sessionId === sessionId);
+		if (saved?.title) return saved.title;
+	}
+	const firstUserMessage = messages.find((m) => m.role === "user");
+	if (firstUserMessage) {
+		const textContent = firstUserMessage.content.find(
+			(c) => c.type === "text" || c.type === "text_with_context",
+		);
+		if (textContent && "text" in textContent) {
+			return truncateTitle(textContent.text);
+		}
+	}
+	return "New session";
 }

--- a/src/services/session-helpers.ts
+++ b/src/services/session-helpers.ts
@@ -194,19 +194,7 @@ export function createInitialSession(
 // Session Title Derivation
 // ============================================================================
 
-/**
- * Derive the display title for a session from its persisted metadata and
- * in-memory message list. Returns "New session" as the well-defined fallback.
- *
- * Source-of-truth precedence (highest first):
- *   1. Locally saved title (created on first message, edited via Rename UI)
- *   2. Truncated text of the first user message (50-char limit)
- *   3. "New session" (no sessionId yet, or no user messages)
- *
- * Pure function — shared by the Session Manager (via the live ChatPanelCallbacks
- * read against settings + refs) and the chat view tab header (via a useMemo
- * over React state).
- */
+/** Derive the session display title (saved title > first user message > "New session"). */
 export function computeSessionTitle(
 	sessionId: string | null,
 	savedSessions: SavedSessionInfo[],

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -11,7 +11,7 @@ import {
 
 import type { AttachedFile, ChatInputState } from "../types/chat";
 import { isSameDirectory } from "../utils/platform";
-import { truncateTitle } from "../utils/text";
+import { computeSessionTitle } from "../services/session-helpers";
 import { useHistoryModal } from "../hooks/useHistoryModal";
 import { useChatActions } from "../hooks/useChatActions";
 import { ChangeDirectoryModal } from "./ChangeDirectoryModal";
@@ -86,6 +86,11 @@ export interface ChatPanelProps {
 	onRegisterCallbacks?: (callbacks: ChatPanelCallbacks) => void;
 	/** Called when agent ID changes (sidebar only — persists in Obsidian state) */
 	onAgentIdChanged?: (agentId: string) => void;
+	/**
+	 * Called when the derived session title may have changed (sidebar only —
+	 * triggers Obsidian to re-read getDisplayText() and update the tab header).
+	 */
+	onSessionTitleChanged?: () => void;
 	// Floating-specific
 	onMinimize?: () => void;
 	onClose?: () => void;
@@ -130,6 +135,7 @@ export function ChatPanel({
 	config,
 	onRegisterCallbacks,
 	onAgentIdChanged,
+	onSessionTitleChanged,
 	onMinimize,
 	onClose,
 	onOpenNewWindow,
@@ -783,6 +789,26 @@ export function ChatPanel({
 	]);
 
 	// ============================================================
+	// Effects - Notify Sidebar Container of Session Title Changes
+	// ============================================================
+	// Used to refresh the ChatView's Obsidian tab header.
+	// The Session Manager UI reacts via the notifyChange effect above
+	// (it re-reads getSessionTitle() during its render), so this effect is
+	// exclusively for the sidebar tab header re-paint trigger.
+	const sessionTitle = useMemo(
+		() =>
+			computeSessionTitle(
+				session.sessionId,
+				settings.savedSessions ?? [],
+				messages,
+			),
+		[session.sessionId, settings.savedSessions, messages],
+	);
+	useEffect(() => {
+		onSessionTitleChanged?.();
+	}, [onSessionTitleChanged, sessionTitle]);
+
+	// ============================================================
 	// Effects - System Notification on Permission Request
 	// ============================================================
 	const prevHasActivePermissionRef = useRef<boolean>(false);
@@ -1000,29 +1026,12 @@ export function ChatPanel({
 				if (state === "ready") return "ready";
 				return "busy";
 			},
-			getSessionTitle: () => {
-				const sessionId = sessionIdRef.current;
-				if (sessionId) {
-					const saved = plugin.settingsService
-						.getSavedSessions()
-						.find((s) => s.sessionId === sessionId);
-					if (saved?.title) return saved.title;
-				}
-				const firstUserMessage = messagesRef.current.find(
-					(m) => m.role === "user",
-				);
-				if (firstUserMessage) {
-					const textContent = firstUserMessage.content.find(
-						(c) =>
-							c.type === "text" ||
-							c.type === "text_with_context",
-					);
-					if (textContent && "text" in textContent) {
-						return truncateTitle(textContent.text);
-					}
-				}
-				return "New session";
-			},
+			getSessionTitle: () =>
+				computeSessionTitle(
+					sessionIdRef.current,
+					plugin.settingsService.getSnapshot().savedSessions ?? [],
+					messagesRef.current,
+				),
 			getSessionId: () => sessionIdRef.current,
 			getInputState: () => ({
 				text: inputValueRef.current,

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -791,10 +791,6 @@ export function ChatPanel({
 	// ============================================================
 	// Effects - Notify Sidebar Container of Session Title Changes
 	// ============================================================
-	// Used to refresh the ChatView's Obsidian tab header.
-	// The Session Manager UI reacts via the notifyChange effect above
-	// (it re-reads getSessionTitle() during its render), so this effect is
-	// exclusively for the sidebar tab header re-paint trigger.
 	const sessionTitle = useMemo(
 		() =>
 			computeSessionTitle(
@@ -804,6 +800,7 @@ export function ChatPanel({
 			),
 		[session.sessionId, settings.savedSessions, messages],
 	);
+	// Fires on initial mount + every sessionTitle change so the tab reflects the current title.
 	useEffect(() => {
 		onSessionTitleChanged?.();
 	}, [onSessionTitleChanged, sessionTitle]);

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -79,6 +79,7 @@ function ChatComponent({
 					view.setCallbacks(callbacks)
 				}
 				onAgentIdChanged={(agentId) => view.setAgentId(agentId)}
+				onSessionTitleChanged={() => view.refreshDisplayText()}
 			/>
 		</ChatContextProvider>
 	);
@@ -127,7 +128,9 @@ export class ChatView extends ItemView implements IChatViewContainer {
 	}
 
 	getDisplayText() {
-		return "Agent client";
+		// Delegate to the session title source — same value the Session Manager
+		// shows. Until ChatPanel registers callbacks, fall back to "New session".
+		return this.callbacks?.getSessionTitle() ?? "New session";
 	}
 
 	getIcon() {
@@ -222,6 +225,20 @@ export class ChatView extends ItemView implements IChatViewContainer {
 
 	closeContainer(): void {
 		this.leaf.detach();
+	}
+
+	/**
+	 * Trigger Obsidian to re-read getDisplayText() so the tab header
+	 * reflects the latest session title.
+	 *
+	 * Uses an undocumented `WorkspaceLeaf.updateHeader()` method that
+	 * Obsidian core invokes internally for the same purpose. Widely used
+	 * by community plugins. Optional chaining keeps the call safe if a
+	 * future Obsidian version ever removes or renames it.
+	 */
+	refreshDisplayText(): void {
+		const leaf = this.leaf as unknown as { updateHeader?: () => void };
+		leaf.updateHeader?.();
 	}
 
 	/**

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -65,11 +65,7 @@ function ChatComponent({
 		return unsubscribe;
 	}, [view]);
 
-	// ============================================================
-	// Stable callback for ChatPanel.onSessionTitleChanged so the title-
-	// update effect's dep array is value-stable (not function-identity-
-	// dependent). `view` is a prop and stable across ChatComponent renders.
-	// ============================================================
+	// Stable so ChatPanel's title-update effect deps are value-stable.
 	const handleSessionTitleChanged = useCallback(
 		() => view.refreshDisplayText(),
 		[view],
@@ -138,8 +134,7 @@ export class ChatView extends ItemView implements IChatViewContainer {
 	}
 
 	getDisplayText() {
-		// Single source of truth: same value the Session Manager shows for
-		// this view. The fallback to "New session" lives in getSessionTitle().
+		// Tab title == Session Manager title; fallback lives in getSessionTitle().
 		return this.getSessionTitle();
 	}
 
@@ -237,16 +232,8 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		this.leaf.detach();
 	}
 
-	/**
-	 * Trigger Obsidian to re-read getDisplayText() so the tab header
-	 * reflects the latest session title.
-	 *
-	 * Uses an undocumented `WorkspaceLeaf.updateHeader()` method that
-	 * Obsidian core invokes internally for the same purpose. Widely used
-	 * by community plugins. Optional chaining keeps the call safe if a
-	 * future Obsidian version ever removes or renames it.
-	 */
 	refreshDisplayText(): void {
+		// Undocumented WorkspaceLeaf.updateHeader() — Obsidian core uses the same internal method to refresh tab headers.
 		const leaf = this.leaf as unknown as { updateHeader?: () => void };
 		leaf.updateHeader?.();
 	}

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -5,7 +5,7 @@ import type {
 	SessionStatus,
 } from "../services/view-registry";
 import * as React from "react";
-const { useState, useEffect, useMemo } = React;
+const { useState, useEffect, useMemo, useCallback } = React;
 import { createRoot, Root } from "react-dom/client";
 
 import type AgentClientPlugin from "../plugin";
@@ -66,6 +66,16 @@ function ChatComponent({
 	}, [view]);
 
 	// ============================================================
+	// Stable callback for ChatPanel.onSessionTitleChanged so the title-
+	// update effect's dep array is value-stable (not function-identity-
+	// dependent). `view` is a prop and stable across ChatComponent renders.
+	// ============================================================
+	const handleSessionTitleChanged = useCallback(
+		() => view.refreshDisplayText(),
+		[view],
+	);
+
+	// ============================================================
 	// Render
 	// ============================================================
 	return (
@@ -79,7 +89,7 @@ function ChatComponent({
 					view.setCallbacks(callbacks)
 				}
 				onAgentIdChanged={(agentId) => view.setAgentId(agentId)}
-				onSessionTitleChanged={() => view.refreshDisplayText()}
+				onSessionTitleChanged={handleSessionTitleChanged}
 			/>
 		</ChatContextProvider>
 	);

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -138,9 +138,9 @@ export class ChatView extends ItemView implements IChatViewContainer {
 	}
 
 	getDisplayText() {
-		// Delegate to the session title source — same value the Session Manager
-		// shows. Until ChatPanel registers callbacks, fall back to "New session".
-		return this.callbacks?.getSessionTitle() ?? "New session";
+		// Single source of truth: same value the Session Manager shows for
+		// this view. The fallback to "New session" lives in getSessionTitle().
+		return this.getSessionTitle();
 	}
 
 	getIcon() {

--- a/styles.css
+++ b/styles.css
@@ -501,6 +501,18 @@ If your plugin does not need CSS, delete this file.
 	overflow: hidden;
 }
 
+/* Hide only the title slot inside Obsidian's view-header (editor-area placement).
+ * The chat panel already shows the session title in the tab strip, and
+ * WorkspaceLeaf.updateHeader() does not refresh this inner title so it would
+ * otherwise be stuck at its initial value. The surrounding header bar (nav
+ * buttons, view actions from this and other plugins) is kept intact.
+ * `visibility: hidden` (not `display: none`) preserves the flex layout space,
+ * so view-actions stay on the right instead of collapsing to the left.
+ * In sidebar placement, .view-header is already absent so this is a no-op. */
+.workspace-leaf-content[data-type="agent-client-chat-view"] > .view-header .view-header-title-container {
+	visibility: hidden;
+}
+
 /* Main container */
 .agent-client-chat-view-container {
 	--ac-chat-font-size: var(--font-text-size);

--- a/styles.css
+++ b/styles.css
@@ -501,14 +501,7 @@ If your plugin does not need CSS, delete this file.
 	overflow: hidden;
 }
 
-/* Hide only the title slot inside Obsidian's view-header (editor-area placement).
- * The chat panel already shows the session title in the tab strip, and
- * WorkspaceLeaf.updateHeader() does not refresh this inner title so it would
- * otherwise be stuck at its initial value. The surrounding header bar (nav
- * buttons, view actions from this and other plugins) is kept intact.
- * `visibility: hidden` (not `display: none`) preserves the flex layout space,
- * so view-actions stay on the right instead of collapsing to the left.
- * In sidebar placement, .view-header is already absent so this is a no-op. */
+/* Hide stale inner view-header title (updateHeader() doesn't refresh it); visibility:hidden preserves flex layout. */
 .workspace-leaf-content[data-type="agent-client-chat-view"] > .view-header .view-header-title-container {
 	visibility: hidden;
 }


### PR DESCRIPTION
## Description

The sidebar Chat View's Obsidian tab title is currently a static `"Agent client"`. Make it dynamic so each tab reflects its own session — same value the Session Manager already shows — so multiple chat tabs become individually identifiable.

### Title source (highest precedence first)
1. Locally saved title (created on first message, edited via Rename UI)
2. Truncated text of the first user message (≤ 50 chars)
3. `"New session"` (no `sessionId` yet, or no user messages)

### Lifecycle examples

| Moment | Tab title |
|---|---|
| New chat just opened | `New session` |
| After sending the first message | First message text (truncated) |
| After Rename via Session Manager or chat header More menu | The new title |
| After `Restore session` from Session History | The restored session's title |
| After Obsidian restart (workspace restore) | `New session` (fresh session, by current design) |
| Floating chat | Unchanged (no Obsidian tab to update) |

### How it works

- Extracted the title derivation into a pure helper `computeSessionTitle(sessionId, savedSessions, messages)` in `services/session-helpers.ts`. The previously-inline logic in `ChatPanel`'s `getSessionTitle` callback now calls this helper, removing the duplication.
- Added a sidebar-only `onSessionTitleChanged?: () => void` prop on `ChatPanel` (mirrors the existing `onAgentIdChanged`). A `useMemo` over `[session.sessionId, settings.savedSessions, messages]` produces the title string; a `useEffect` fires the prop only when that string actually changes (`Object.is` value comparison).
- `ChatView.getDisplayText()` delegates to `callbacks?.getSessionTitle() ?? "New session"` and a new `ChatView.refreshDisplayText()` calls the undocumented `WorkspaceLeaf.updateHeader()` (the same internal method Obsidian core uses for native tabs) to ask Obsidian to re-read the title.
- `FloatingViewContainer` does not pass the new prop; the optional callback stays undefined and the effect is a no-op for floating chats.

The tab icon (`bot-message-square`) is unchanged, so the tab is still visually identifiable as an Agent Client tab even when the title becomes session-specific.

## Related issue

N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: macOS

## Screenshots

<img width="741" height="242" alt="image" src="https://github.com/user-attachments/assets/30b23496-5c4e-4784-8fca-ce9bd0df0cff" />

<img width="741" height="224" alt="image" src="https://github.com/user-attachments/assets/63009056-a1ac-4926-9897-72e24efc37ad" />
