### PR TITLE
fix: surface ACP error details in UI instead of "[object Object]"

### DIFF
--- a/src/hooks/useAgentMessages.ts
+++ b/src/hooks/useAgentMessages.ts
@@ -22,6 +22,7 @@ import type { ISettingsAccess } from "../services/settings-service";
 import type { ErrorInfo } from "../types/errors";
 import type { IMentionService } from "../utils/mention-parser";
 import { preparePrompt, sendPreparedPrompt } from "../services/message-sender";
+import { extractErrorMessage } from "../utils/error-utils";
 import { Platform } from "obsidian";
 import {
 	rebuildToolCallIndex,
@@ -365,7 +366,7 @@ export function useAgentMessages(
 					setIsSending(false);
 					setErrorInfo({
 						title: "Send Message Failed",
-						message: `Failed to send message: ${error instanceof Error ? error.message : String(error)}`,
+						message: `Failed to send message: ${extractErrorMessage(error)}`,
 					});
 				}
 			})();
@@ -410,7 +411,7 @@ export function useAgentMessages(
 			} catch (error) {
 				setErrorInfo({
 					title: "Permission Error",
-					message: `Failed to respond to permission request: ${error instanceof Error ? error.message : String(error)}`,
+					message: `Failed to respond to permission request: ${extractErrorMessage(error)}`,
 				});
 			}
 		},

--- a/src/hooks/useAgentSession.ts
+++ b/src/hooks/useAgentSession.ts
@@ -18,6 +18,7 @@ import type {
 import type { AcpClient } from "../acp/acp-client";
 import type { ISettingsAccess } from "../services/settings-service";
 import type { ErrorInfo } from "../types/errors";
+import { extractErrorMessage } from "../utils/error-utils";
 import {
 	type AgentDisplayInfo,
 	getDefaultAgentId,
@@ -278,7 +279,7 @@ export function useAgentSession(
 				setSession((prev) => ({ ...prev, state: "error" }));
 				setErrorInfo({
 					title: "Session Creation Failed",
-					message: `Failed to create new session: ${error instanceof Error ? error.message : String(error)}`,
+					message: `Failed to create new session: ${extractErrorMessage(error)}`,
 					suggestion:
 						"Please check the agent configuration and try again.",
 				});

--- a/src/hooks/useSessionHistory.ts
+++ b/src/hooks/useSessionHistory.ts
@@ -12,6 +12,7 @@ import type {
 	AgentCapabilities,
 } from "../types/session";
 import type { ChatMessage } from "../types/chat";
+import { extractErrorMessage } from "../utils/error-utils";
 
 // ============================================================================
 // Session Capability Helpers (from session-capability-utils.ts)
@@ -417,8 +418,7 @@ export function useSessionHistory(
 					timestamp: Date.now(),
 				};
 			} catch (err) {
-				const errorMessage =
-					err instanceof Error ? err.message : String(err);
+				const errorMessage = extractErrorMessage(err);
 				setError(`Failed to fetch sessions: ${errorMessage}`);
 				setSessions([]);
 				setNextCursor(undefined);
@@ -484,8 +484,7 @@ export function useSessionHistory(
 				};
 			}
 		} catch (err) {
-			const errorMessage =
-				err instanceof Error ? err.message : String(err);
+			const errorMessage = extractErrorMessage(err);
 			setError(`Failed to load more sessions: ${errorMessage}`);
 		} finally {
 			setLoading(false);
@@ -572,8 +571,7 @@ export function useSessionHistory(
 					throw new Error("Session restoration is not supported");
 				}
 			} catch (err) {
-				const errorMessage =
-					err instanceof Error ? err.message : String(err);
+				const errorMessage = extractErrorMessage(err);
 				setError(`Failed to restore session: ${errorMessage}`);
 				throw err; // Re-throw to allow caller to handle
 			} finally {
@@ -662,8 +660,7 @@ export function useSessionHistory(
 				// Invalidate cache since a new session was created
 				invalidateCache();
 			} catch (err) {
-				const errorMessage =
-					err instanceof Error ? err.message : String(err);
+				const errorMessage = extractErrorMessage(err);
 				setError(`Failed to fork session: ${errorMessage}`);
 				throw err; // Re-throw to allow caller to handle
 			} finally {
@@ -699,8 +696,7 @@ export function useSessionHistory(
 				// Invalidate cache to ensure consistency
 				invalidateCache();
 			} catch (err) {
-				const errorMessage =
-					err instanceof Error ? err.message : String(err);
+				const errorMessage = extractErrorMessage(err);
 				setError(`Failed to delete session: ${errorMessage}`);
 				throw err; // Re-throw to allow caller to handle
 			}
@@ -758,8 +754,7 @@ export function useSessionHistory(
 							: s,
 					),
 				);
-				const errorMessage =
-					err instanceof Error ? err.message : String(err);
+				const errorMessage = extractErrorMessage(err);
 				setError(`Failed to update title: ${errorMessage}`);
 				throw err;
 			}


### PR DESCRIPTION
## Description

When ACP / the underlying agent returned a JSON-RPC error during session creation, send, or session-history operations, the UI showed the generic `Failed to <X>: [object Object]` instead of the agent's actual reason. Reporters had to open DevTools to see what was really wrong, which led to misdiagnosis (see #294, where the reporter attributed the symptom to a `protocolVersion` mismatch).

**Root cause:** ACP JSON-RPC errors are plain objects of shape `{ code, message, data: { details } }`, not `Error` instances. The hook catches used `error instanceof Error ? error.message : String(error)`, so non-`Error` throws fell through to `String(error)` and produced `"[object Object]"`, discarding the meaningful `data.details` field (e.g. `"Claude Code process exited with code 1"`).

**Fix:** Switch all 9 hook catches in `src/hooks/` to `extractErrorMessage()` from `src/utils/error-utils.ts`, which checks `data.details → message → fallback`. The send path was already going through this helper indirectly via `toAcpError()`; this PR aligns the rest of the catches with that same pattern.

The user-visible `title` / `suggestion` fields are kept as-is so existing contextual framing (`"Session Creation Failed"`, etc.) is preserved — only `message` is rewritten.

### Changes

- `src/hooks/useAgentSession.ts` — `createSession` catch
- `src/hooks/useAgentMessages.ts` — `sendMessage` outer catch, `approvePermission` catch
- `src/hooks/useSessionHistory.ts` — `fetchSessions`, `loadMoreSessions`, `restoreSession`, `forkSession`, `deleteSession`, `updateSessionTitle` catches

`src/ui/TerminalBlock.tsx:55` is intentionally excluded — its `String(error)` only flows to the debug logger (never to the UI) and the context is terminal-polling rather than ACP.

## Related issue

Refs #294, #297. Both reports surface as `Session Creation Failed: [object Object]` while the actual reason (`Claude Code process exited with code 1`, from `data.details`) is hidden in DevTools. The underlying connection failures themselves are environment-specific (folder trust, Claude Code authentication, etc.) and remain out of scope for this hotfix — this PR only makes the real reason visible to the user so they can self-diagnose, and so future reports arrive with concrete error text.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: macOS, Windows

## Screenshots

N/A