### PR TITLE
feat: notify users of Gemini CLI discontinuation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -94,6 +94,15 @@ export default defineConfig({
           { text: "ACP Protocol Support", link: "/reference/acp-support" },
         ],
       },
+      {
+        text: "Announcements",
+        items: [
+          {
+            text: "Gemini CLI Discontinuation",
+            link: "/announcements/gemini-cli-deprecation",
+          },
+        ],
+      },
     ],
 
     socialLinks: [

--- a/docs/agent-setup/gemini-cli.md
+++ b/docs/agent-setup/gemini-cli.md
@@ -1,5 +1,9 @@
 # Gemini CLI Setup
 
+::: warning Gemini CLI is being discontinued
+Google is retiring account login for Gemini CLI (Pro / Ultra / free tiers) on **June 18, 2026**. Google states Gemini CLI stays accessible via a **paid** Gemini API key. See **[Gemini CLI Discontinuation & Migration](/announcements/gemini-cli-deprecation)**.
+:::
+
 Gemini CLI is Google's AI assistant. You can authenticate using your **Google account**, an **API key**, or **Vertex AI**.
 
 ## Install and Configure
@@ -40,6 +44,10 @@ Choose one of the following methods:
 
 If you have a Google account and prefer not to use an API key, you can log in directly.
 
+::: warning
+Account login is being discontinued for Pro / Ultra / free tiers on June 18, 2026. See [Gemini CLI Discontinuation & Migration](/announcements/gemini-cli-deprecation).
+:::
+
 1. Run Gemini CLI in your terminal and choose "Login with Google":
 
 ```bash
@@ -61,6 +69,10 @@ If you prefer to use an API key for authentication:
 1. Get your API key from [Google AI Studio](https://aistudio.google.com/apikey)
 2. Enter the API key in **Settings → Agent Client → Gemini CLI → API key**
 
+::: tip If the key isn't picked up
+If authentication still fails, set the key on the Gemini CLI side instead: run `gemini` in your terminal, type `/auth`, choose **Use Gemini API Key**, and paste your key (it's stored in your system keychain). Then leave the **API key field empty** in Agent Client.
+:::
+
 ### Option C: Vertex AI
 
 If you are using Vertex AI for enterprise workloads:
@@ -74,8 +86,8 @@ GOOGLE_GENAI_USE_VERTEXAI=true
 
 2. Leave the **API key field empty** (use Environment variables instead).
 
-::: tip
-Gemini CLI natively supports ACP, so no additional adapter is required.
+::: tip If it isn't picked up
+If authentication still fails, configure Vertex AI on the Gemini CLI side instead: run `gemini` in your terminal, type `/auth`, and choose **Vertex AI**.
 :::
 
 ## Verify Setup

--- a/docs/announcements/gemini-cli-deprecation.md
+++ b/docs/announcements/gemini-cli-deprecation.md
@@ -1,0 +1,69 @@
+# Gemini CLI Discontinuation & Migration
+
+::: warning Gemini CLI is being discontinued
+Google is retiring **account login for Gemini CLI (Pro / Ultra / free tiers) on June 18, 2026**. After that date, signing in with your Google account will stop working in Gemini CLI.
+
+According to Google, **Gemini CLI stays accessible via a paid Gemini API key**, so the reliable way to keep using Gemini in this plugin is a paid API key.
+:::
+
+## What's changing
+
+On **June 18, 2026**, Gemini CLI will **stop serving requests** for account-login tiers. This is part of Google's transition from Gemini CLI to the new **Antigravity CLI**, announced at Google I/O 2026.
+
+Account login (signing in with your Google account) is what stops — but Google also points to a way to keep using Gemini CLI:
+
+> "Gemini CLI will remain accessible via paid Gemini and Gemini Enterprise Agent Platform API keys."
+> — [Google Developers Blog](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/)
+
+Note that Google's wording specifies a **paid** API key. The blog does not state whether a **free-tier** API key will keep working with Gemini CLI after the cutoff, so free-tier continuation is **not guaranteed**. This plugin drives Gemini CLI with an API key, so a paid API key is the dependable path forward.
+
+## Who is affected
+
+| Tier / access | Still usable after June 18, 2026? |
+| --- | --- |
+| Free tier (account login) | ❌ No — account login stops |
+| Google AI Pro (account login) | ❌ No — account login stops |
+| Google AI Ultra (account login) | ❌ No — account login stops |
+| **Gemini CLI via a paid API key** | ✅ Yes — keeps working |
+
+::: tip Note
+Being on a paid plan (Pro or Ultra) does **not** exempt you — the cutoff is about the *account-login* method, not whether you pay. The reliable way to keep going is a **paid API key** (see below).
+:::
+
+## How to keep using Gemini in this plugin
+
+### Option A — Use a paid Gemini API key (recommended)
+
+1. Create an API key in [Google AI Studio](https://aistudio.google.com/apikey) and enable billing to move it to a [paid tier](https://ai.google.dev/gemini-api/docs/billing). This is the access Google explicitly says keeps working.
+2. Configure the key in this plugin by following the [Gemini CLI Setup](/agent-setup/gemini-cli) page (Option B: API key, or Option C: Vertex AI).
+
+::: tip About the free tier
+The Gemini API has a free tier, and as of writing models such as `gemini-2.5-pro` and `gemini-3.5-flash` show as free of charge on the [pricing page](https://ai.google.dev/gemini-api/docs/pricing). **However, Google's announcement only guarantees access via a *paid* API key** — it does not say a free-tier key will keep working with Gemini CLI after June 18, 2026. A free key *may* work, but it is not guaranteed; if you need reliability, use a paid key. Rate limits for any tier can be checked in the [AI Studio rate-limit dashboard](https://aistudio.google.com/rate-limit).
+:::
+
+::: tip Privacy note
+A paid API key also helps with privacy. Agent Client can send your **note contents** to the model as context, and on **paid** tiers Google does not use that data to improve its products: *"When you use Paid Services, Google doesn't use your prompts ... or responses to improve our products."* (If you ever fall back to a free-tier key, note that free/unpaid usage **can** be used for product improvement and human review.) Source: [Gemini API Additional Terms of Service](https://ai.google.dev/gemini-api/terms).
+:::
+
+### Option B — Switch to another ACP agent
+
+This plugin works with any agent that speaks the Agent Client Protocol (ACP). If you'd rather move off Gemini entirely:
+
+- [Claude Code](/agent-setup/claude-code)
+- [Codex](/agent-setup/codex)
+
+## What about Antigravity CLI?
+
+Google's replacement, **Antigravity CLI**, does **not currently support ACP** (there is no `--experimental-acp` mode), so this plugin **cannot connect to it as a built-in agent yet**. Antigravity CLI is also not open source.
+
+If Google adds ACP support — or if an adapter built on the **Antigravity SDK** emerges (similar to how `claude-agent-acp` is built on the Claude Agent SDK rather than wrapping the CLI) — built-in support will be reconsidered. For Google's own migration steps, see the [Antigravity CLI migration guide](https://antigravity.google/docs/gcli-migration).
+
+A community ACP bridge, [`agy-acp`](https://github.com/openabdev/openab/tree/main/agy-acp), does exist and can be added as a [custom agent](/agent-setup/custom-agents). It works as a minimal text chat only — streaming, tool calls, and diffs don't come through — so it's an escape hatch rather than a full replacement.
+
+## Sources
+
+- [An important update: Transitioning Gemini CLI to Antigravity CLI — Google Developers Blog](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/)
+- [Google I/O 2026 developer highlights — Google blog](https://blog.google/intl/ja-jp/company-news/technology/google-io-2026-developer-highlights/)
+- [Gemini Developer API pricing](https://ai.google.dev/gemini-api/docs/pricing)
+- [Gemini API Additional Terms of Service](https://ai.google.dev/gemini-api/terms)
+- [Gemini API rate limits](https://ai.google.dev/gemini-api/docs/rate-limits)

--- a/src/services/session-helpers.ts
+++ b/src/services/session-helpers.ts
@@ -12,6 +12,7 @@ import type {
 } from "../types/agent";
 import type { ChatSession } from "../types/session";
 import { toAgentConfig } from "./settings-normalizer";
+import type { AgentUpdateNotification } from "./update-checker";
 
 // ============================================================================
 // Types
@@ -180,5 +181,31 @@ export function createInitialSession(
 		createdAt: new Date(),
 		lastActivityAt: new Date(),
 		workingDirectory,
+	};
+}
+
+// ============================================================================
+// Gemini CLI Deprecation Notice
+// ============================================================================
+
+/** Docs URL for the Gemini CLI deprecation announcement. */
+export const GEMINI_DEPRECATION_DOCS_URL =
+	"https://rait-09.github.io/obsidian-agent-client/announcements/gemini-cli-deprecation.html";
+
+/**
+ * Build the in-app notice shown while the Gemini CLI agent is selected.
+ *
+ * Google is retiring Gemini CLI for account-login (Pro/Ultra/free) tiers on
+ * June 18, 2026. This notice is static (no network) and is driven purely by the
+ * active agent id, unlike the npm-registry-backed agent update check.
+ */
+export function buildGeminiDeprecationNotice(): AgentUpdateNotification {
+	return {
+		variant: "info",
+		title: "Gemini CLI is being discontinued",
+		message:
+			"Google is retiring account login for Gemini CLI (Pro/Ultra/free tiers) on June 18, 2026. " +
+			"Google states Gemini CLI stays accessible via a paid Gemini API key — see the guide for setup and privacy notes.",
+		link: { text: "Learn more", url: GEMINI_DEPRECATION_DOCS_URL },
 	};
 }

--- a/src/services/update-checker.ts
+++ b/src/services/update-checker.ts
@@ -29,6 +29,8 @@ export interface AgentUpdateNotification {
 	message: string;
 	/** Actionable suggestion (e.g., npm command) */
 	suggestion?: string;
+	/** Optional external link rendered as an actionable anchor (e.g. docs). */
+	link?: { text: string; url: string };
 }
 
 // ============================================================================

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -55,6 +55,9 @@ export interface ErrorInfo {
 
 	/** Optional suggestion on how to resolve the error */
 	suggestion?: string;
+
+	/** Optional external link rendered as an actionable anchor (e.g. docs). */
+	link?: { text: string; url: string };
 }
 
 // ============================================================================

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -39,6 +39,7 @@ import {
 	type SessionConfigOption,
 } from "../types/session";
 import { checkAgentUpdate } from "../services/update-checker";
+import { buildGeminiDeprecationNotice } from "../services/session-helpers";
 
 /** Stable empty array for useSuggestions when no commands available */
 const EMPTY_COMMANDS: SlashCommand[] = [];
@@ -305,6 +306,46 @@ export function ChatPanel({
 		setAgentUpdateNotification,
 		autoExportIfEnabled,
 	} = actions;
+
+	// ============================================================
+	// Gemini CLI deprecation notice (static, agent-id driven)
+	// ============================================================
+	// Independent channel from the npm-backed agentUpdateNotification:
+	// derived synchronously from the active agent id (no network).
+	const geminiNotice = useMemo(
+		() =>
+			session.agentId === plugin.settings.gemini.id
+				? buildGeminiDeprecationNotice()
+				: null,
+		[session.agentId, plugin.settings.gemini.id],
+	);
+
+	// Dismiss state lives locally in ChatPanel so it never races with the
+	// async setAgentUpdateNotification owned by useChatActions.
+	const [geminiNoticeDismissed, setGeminiNoticeDismissed] = useState(false);
+
+	// Re-show the notice when switching agents (e.g. away and back to Gemini).
+	useEffect(() => {
+		setGeminiNoticeDismissed(false);
+	}, [session.agentId]);
+
+	const effectiveGeminiNotice =
+		geminiNotice && !geminiNoticeDismissed ? geminiNotice : null;
+
+	const handleClearGeminiNotice = useCallback(
+		() => setGeminiNoticeDismissed(true),
+		[],
+	);
+
+	// Wrap send so the Gemini notice also dismisses on send, mirroring how
+	// useChatActions clears agentUpdateNotification inside handleSendMessage.
+	const handleSendMessageWithGeminiDismiss = useCallback(
+		(content: string, attachments?: AttachedFile[]) => {
+			setGeminiNoticeDismissed(true);
+			return handleSendMessage(content, attachments);
+		},
+		[handleSendMessage],
+	);
 
 	const { handleOpenHistory } = useHistoryModal(
 		plugin,
@@ -1051,7 +1092,7 @@ export function ChatPanel({
 			suggestions={suggestions}
 			plugin={plugin}
 			view={viewHost}
-			onSendMessage={handleSendMessage}
+			onSendMessage={handleSendMessageWithGeminiDismiss}
 			onStopGeneration={handleStopGeneration}
 			onRestoredMessageConsumed={handleRestoredMessageConsumed}
 			modes={session.modes}
@@ -1076,6 +1117,9 @@ export function ChatPanel({
 			// Agent update notification props
 			agentUpdateNotification={agentUpdateNotification}
 			onClearAgentUpdate={handleClearAgentUpdate}
+			// Gemini CLI deprecation notice props
+			geminiNotice={effectiveGeminiNotice}
+			onClearGeminiNotice={handleClearGeminiNotice}
 			messages={messages}
 		/>
 	);

--- a/src/ui/ErrorBanner.tsx
+++ b/src/ui/ErrorBanner.tsx
@@ -89,6 +89,16 @@ export function ErrorBanner({
 					)}
 				</div>
 			)}
+			{errorInfo.link && (
+				<a
+					className="agent-client-error-overlay-link"
+					href={errorInfo.link.url}
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{errorInfo.link.text}
+				</a>
+			)}
 		</div>
 	);
 }

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -243,6 +243,10 @@ export interface InputAreaProps {
 	agentUpdateNotification: AgentUpdateNotification | null;
 	/** Callback to dismiss the agent update notification */
 	onClearAgentUpdate: () => void;
+	/** Gemini CLI deprecation notice (shown while Gemini agent is selected) */
+	geminiNotice: AgentUpdateNotification | null;
+	/** Callback to dismiss the Gemini notice */
+	onClearGeminiNotice: () => void;
 	/** Messages array for input history navigation */
 	messages: ChatMessage[];
 }
@@ -293,6 +297,9 @@ export function InputArea({
 	// Agent update notification props
 	agentUpdateNotification,
 	onClearAgentUpdate,
+	// Gemini CLI deprecation notice props
+	geminiNotice,
+	onClearGeminiNotice,
 	// Input history
 	messages,
 }: InputAreaProps) {
@@ -959,6 +966,17 @@ export function InputArea({
 					showEmojis={showEmojis}
 					view={view}
 					variant={agentUpdateNotification.variant}
+				/>
+			)}
+
+			{/* Gemini CLI deprecation notice - lowest priority overlay */}
+			{!errorInfo && !agentUpdateNotification && geminiNotice && (
+				<ErrorBanner
+					errorInfo={geminiNotice}
+					onClose={onClearGeminiNotice}
+					showEmojis={showEmojis}
+					view={view}
+					variant={geminiNotice.variant}
 				/>
 			)}
 

--- a/styles.css
+++ b/styles.css
@@ -654,6 +654,18 @@ If your plugin does not need CSS, delete this file.
 	cursor: text;
 }
 
+.agent-client-error-overlay-link {
+	display: inline-block;
+	margin-top: 8px;
+	font-size: 12px;
+	color: var(--text-accent);
+	text-decoration: none;
+}
+
+.agent-client-error-overlay-link:hover {
+	text-decoration: underline;
+}
+
 /* Empty state */
 .agent-client-chat-empty-state {
 	color: var(--text-muted);


### PR DESCRIPTION
## Description

Google is retiring account login for Gemini CLI (Pro / Ultra / free tiers) on **June 18, 2026**, as part of its transition to the new Antigravity CLI. Since this plugin ships Gemini CLI as a built-in agent, affected users' workflows would break with no warning. This PR surfaces the change in-app and documents the migration path. (See #296.)

Antigravity CLI is **not** ACP-capable yet (no `--experimental-acp`), so auto-detecting/replacing `gemini` with `agy` — as originally proposed in the issue — is not viable. This PR scopes to notifying users and pointing them to a working path forward instead.

### In-app banner

- While the Gemini CLI agent is selected, an info banner appears above the input, reusing the existing `ErrorBanner` (info variant) so it matches the current agent-update notification style.
- It's derived synchronously from the active agent id (no network), on its own channel separate from the npm-backed agent update notification — so the two never race. Dismisses on close, on send, or on agent switch, mirroring the existing notification's behavior.
- Added an optional `link` field to `ErrorInfo` / `AgentUpdateNotification` so the banner can render a "Learn more" anchor to the docs. Backward compatible — existing usages are unaffected.

### Docs

- New page under a new **Announcements** sidebar section: what's changing, who's affected, and how to keep using Gemini via a **paid** API key. Google's wording only guarantees *paid* keys, so the page is careful not to over-promise the free tier, and notes the free-tier privacy trade-off (free-tier input/output can be used for product improvement; paid is not).
- It also notes Antigravity CLI is not supported yet, and mentions the community `agy-acp` bridge as a limited custom-agent workaround.
- Added a deprecation callout to the Gemini CLI setup page, plus tips to fall back to `gemini /auth` when an in-app API key isn't picked up (a recurring user question, unrelated to this deprecation).

### Changes

- `src/types/errors.ts` — add optional `link` to `ErrorInfo`
- `src/services/update-checker.ts` — add optional `link` to `AgentUpdateNotification`
- `src/services/session-helpers.ts` — add `buildGeminiDeprecationNotice()` + docs URL constant
- `src/ui/ErrorBanner.tsx` — render the `link` anchor when present
- `src/ui/ChatPanel.tsx` — derive the Gemini notice, dismiss state, and send-wrap; pass to `InputArea`
- `src/ui/InputArea.tsx` — render the Gemini banner (priority: error > update > deprecation)
- `styles.css` — `.agent-client-error-overlay-link`
- `docs/announcements/gemini-cli-deprecation.md` — new announcement page
- `docs/agent-setup/gemini-cli.md` — deprecation callout + `/auth` fallback tips
- `docs/.vitepress/config.mts` — add Announcements sidebar section

## Related issue

Closes #296

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Gemini CLI
- OS: macOS

## Screenshots

<img width="443" height="313" alt="image" src="https://github.com/user-attachments/assets/1d31a76f-da68-4e26-872a-a31a8895d1fb" />
