### PR TITLE
docs: link Gemini deprecation page to the announcement discussion

### DIFF
--- a/docs/announcements/gemini-cli-deprecation.md
+++ b/docs/announcements/gemini-cli-deprecation.md
@@ -60,6 +60,10 @@ If Google adds ACP support — or if an adapter built on the **Antigravity SDK**
 
 A community ACP bridge, [`agy-acp`](https://github.com/openabdev/openab/tree/main/agy-acp), does exist and can be added as a [custom agent](/agent-setup/custom-agents). It works as a minimal text chat only — streaming, tool calls, and diffs don't come through — so it's an escape hatch rather than a full replacement.
 
+## Questions?
+
+If anything is unclear or you run into trouble migrating, join the discussion on [GitHub](https://github.com/RAIT-09/obsidian-agent-client/discussions/300).
+
 ## Sources
 
 - [An important update: Transitioning Gemini CLI to Antigravity CLI — Google Developers Blog](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/)


### PR DESCRIPTION
## Description

Adds a "Questions?" section to the Gemini CLI deprecation page, linking to the announcement discussion ([#300](https://github.com/RAIT-09/obsidian-agent-client/discussions/300)) so users have a place to ask migration questions. Follow-up to #299 (now merged).

## Related issue

Follows up #296 / #299

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [ ] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [ ] `npm run build` passes
- [ ] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: N/A — docs-only change
- OS: macOS

## Screenshots

N/A — docs-only change
