### PR TITLE
Use direct WSL exec for absolute-path agent commands

### DIFF
--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -307,13 +307,29 @@ export function wrapCommandForWsl(
 		pathPrefix = `export PATH="${escapePathForShell(wslPath)}:$PATH"; `;
 	}
 
-	const innerCommand = `${pathPrefix}cd ${escapeShellArgBash(wslCwd)} && ${command}${argsString}`;
-	wslArgs.push("sh", "-c", buildWslShellWrapper(innerCommand));
+    const commandIsAbsoluteWslPath = command.startsWith("/");
+    const commandHasShellSyntax = /[\s"'`$&|;<>(){}[\]*?!\\]/.test(command);
+    const canUseDirectExec =
+	    commandIsAbsoluteWslPath &&
+	    !commandHasShellSyntax &&
+	    !additionalPath;
 
-	return {
-		command: "C:\\Windows\\System32\\wsl.exe",
-		args: wslArgs,
-	};
+    if (canUseDirectExec) {
+	    wslArgs.push("--cd", wslCwd, "--exec", command, ...args);
+
+	    return {
+		    command: "C:\\Windows\\System32\\wsl.exe",
+		    args: wslArgs,
+	    };
+    }
+
+    const innerCommand = `${pathPrefix}cd ${escapeShellArgBash(wslCwd)} && ${command}${argsString}`;
+    wslArgs.push("sh", "-c", buildWslShellWrapper(innerCommand));
+
+    return {
+	    command: "C:\\Windows\\System32\\wsl.exe",
+	    args: wslArgs,
+    };
 }
 
 /**


### PR DESCRIPTION
## Description

In WSL mode, this change launches simple absolute-path agent commands using `wsl.exe --cd <cwd> --exec <command> ...args` instead of routing them through the nested `sh -c` shell wrapper.

This avoids fragile shell quoting behavior when launching executable+argv CLIs from Windows into WSL. In the simple absolute-path case, the command already identifies the Linux executable directly and does not need shell expansion, pipes, redirects, or login-shell behavior.

The existing shell-wrapper path is preserved for commands that may need shell semantics, including relative commands, PATH injection via `additionalPath`, or commands containing shell metacharacters. This keeps compatibility with existing configurations while allowing straightforward WSL executables to launch without unnecessary quoting layers.

## Related issue

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [ ] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [ ] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: OpenCode
- OS: Windows with WSL

## Screenshots

N/A