### PR TITLE
feat: add embeddable agent blocks

### DIFF
--- a/src/hooks/useChatActions.ts
+++ b/src/hooks/useChatActions.ts
@@ -78,6 +78,7 @@ export function useChatActions(
 	messages: ChatMessage[],
 	settings: AgentClientPluginSettings,
 	vaultPath: string,
+	persistentSourcePath?: string,
 ): UseChatActionsReturn {
 	const logger = getLogger();
 
@@ -193,6 +194,7 @@ export function useChatActions(
 				await sessionHistory.saveSessionLocally(
 					session.sessionId,
 					content,
+					persistentSourcePath,
 				);
 				logger.log(
 					`[ChatPanel] Session saved locally: ${session.sessionId}`,
@@ -205,6 +207,7 @@ export function useChatActions(
 			messages.length,
 			session.sessionId,
 			sessionHistory.saveSessionLocally,
+			persistentSourcePath,
 			logger,
 			suggestions.mentions.activeNote,
 			suggestions.mentions.isAutoMentionDisabled,

--- a/src/hooks/useSessionHistory.ts
+++ b/src/hooks/useSessionHistory.ts
@@ -188,6 +188,7 @@ export interface UseSessionHistoryReturn {
 	saveSessionLocally: (
 		sessionId: string,
 		messageContent: string,
+		sourcePath?: string,
 	) => Promise<void>;
 
 	/**
@@ -779,7 +780,11 @@ export function useSessionHistory(
 	 * Called when the first message is sent in a new session.
 	 */
 	const saveSessionLocally = useCallback(
-		async (sessionId: string, messageContent: string) => {
+		async (
+			sessionId: string,
+			messageContent: string,
+			sourcePath?: string,
+		) => {
 			if (!session.agentId) return;
 
 			const title = truncateTitle(messageContent);
@@ -789,6 +794,7 @@ export function useSessionHistory(
 				agentId: session.agentId,
 				cwd: agentCwd,
 				title,
+				sourcePath,
 				createdAt: new Date().toISOString(),
 				updatedAt: new Date().toISOString(),
 			});

--- a/src/hooks/useSuggestions.ts
+++ b/src/hooks/useSuggestions.ts
@@ -91,6 +91,7 @@ export function useSuggestions(
 	plugin: AgentClientPlugin,
 	availableCommands: SlashCommand[],
 	autoMentionDefault: boolean,
+	pinnedActiveNote?: NoteMetadata | null,
 ): UseSuggestionsReturn {
 	// ============================================================
 	// Mention State
@@ -103,7 +104,9 @@ export function useSuggestions(
 	const [mentionContext, setMentionContext] = useState<MentionContext | null>(
 		null,
 	);
-	const [activeNote, setActiveNote] = useState<NoteMetadata | null>(null);
+	const [activeNote, setActiveNote] = useState<NoteMetadata | null>(
+		pinnedActiveNote ?? null,
+	);
 	const [isAutoMentionDisabled, setIsAutoMentionDisabled] = useState(
 		!autoMentionDefault,
 	);
@@ -206,9 +209,13 @@ export function useSuggestions(
 	}, []);
 
 	const updateActiveNote = useCallback(async () => {
+		if (pinnedActiveNote) {
+			setActiveNote(pinnedActiveNote);
+			return;
+		}
 		const note = await vaultAccess.getActiveNote();
 		setActiveNote(note);
-	}, [vaultAccess]);
+	}, [vaultAccess, pinnedActiveNote]);
 
 	// ============================================================
 	// Command Callbacks

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,9 +3,14 @@ import {
 	WorkspaceLeaf,
 	Notice,
 	requestUrl,
+	MarkdownRenderChild,
+	type MarkdownPostProcessorContext,
 } from "obsidian";
 import * as semver from "semver";
 import { ChatView, VIEW_TYPE_CHAT } from "./ui/ChatView";
+import { mountCodeBlockChat } from "./ui/CodeBlockChatView";
+import { mountAgentButtonBlock } from "./ui/AgentButtonBlock";
+import { parseAgentBlock } from "./utils/agent-block-parser";
 import {
 	SessionManagerView,
 	VIEW_TYPE_SESSION_MANAGER,
@@ -62,12 +67,20 @@ export type SendMessageShortcut = "enter" | "cmd-enter";
  * - 'right-split': Open in right pane with vertical split
  * - 'editor-tab': Open in editor area as tabs
  * - 'editor-split': Open in editor area with right split
+ * - 'floating': Open as a floating chat window
  */
 export type ChatViewLocation =
 	| "right-tab"
 	| "right-split"
 	| "editor-tab"
-	| "editor-split";
+	| "editor-split"
+	| "floating";
+
+export interface EmbeddedChatRegistration {
+	viewId: string;
+	sourcePath: string;
+	lineStart: number;
+}
 
 export interface AgentClientPluginSettings {
 	gemini: GeminiAgentSettings;
@@ -218,6 +231,8 @@ export default class AgentClientPlugin extends Plugin {
 	private floatingButton: FloatingButtonContainer | null = null;
 	/** Counter for generating unique floating chat instance IDs */
 	private floatingChatCounter = 0;
+	/** Embedded chat instances mounted from markdown code blocks. */
+	private embeddedChats = new Map<string, EmbeddedChatRegistration>();
 
 	async onload() {
 		await this.loadSettings();
@@ -355,6 +370,14 @@ export default class AgentClientPlugin extends Plugin {
 		});
 
 		this.addSettingTab(new AgentClientSettingTab(this.app, this));
+
+		this.registerMarkdownCodeBlockProcessor(
+			"agent-client",
+			(source, el, ctx) => this.renderAgentBlock(source, el, ctx),
+		);
+		this.registerMarkdownCodeBlockProcessor("agent", (source, el, ctx) =>
+			this.renderAgentBlock(source, el, ctx),
+		);
 
 		// Mount floating button (always present; visibility controlled by settings inside component)
 		this.floatingButton = new FloatingButtonContainer(this);
@@ -565,6 +588,8 @@ export default class AgentClientPlugin extends Plugin {
 		const location = this.settings.chatViewLocation;
 
 		switch (location) {
+			case "floating":
+				return null;
 			case "right-tab":
 				if (isAdditional) {
 					return this.createSidebarTab("right");
@@ -616,11 +641,17 @@ export default class AgentClientPlugin extends Plugin {
 	 * Open a new chat view with a specific agent.
 	 * Always creates a new view (doesn't reuse existing).
 	 */
-	async openNewChatViewWithAgent(agentId: string): Promise<void> {
+	async openNewChatViewWithAgent(agentId: string): Promise<string | null> {
+		if (this.settings.chatViewLocation === "floating") {
+			const counterBefore = this.floatingChatCounter;
+			this.openNewFloatingChat(true);
+			return `floating-chat-${counterBefore}`;
+		}
+
 		const leaf = this.createNewChatLeaf(true);
 		if (!leaf) {
 			getLogger().warn("[AgentClient] Failed to create new leaf");
-			return;
+			return null;
 		}
 
 		await leaf.setViewState({
@@ -630,6 +661,8 @@ export default class AgentClientPlugin extends Plugin {
 		});
 
 		await this.app.workspace.revealLeaf(leaf);
+		const view = leaf.view as ChatView | null;
+		const viewId = view?.viewId ?? null;
 
 		// Focus textarea after revealing the leaf
 		const viewContainerEl = leaf.view?.containerEl;
@@ -643,6 +676,7 @@ export default class AgentClientPlugin extends Plugin {
 				}
 			}, 0);
 		}
+		return viewId;
 	}
 
 	/**
@@ -657,6 +691,35 @@ export default class AgentClientPlugin extends Plugin {
 		// FloatingViewContainer will create viewId as "floating-chat-{instanceId}"
 		const instanceId = String(this.floatingChatCounter++);
 		createFloatingChat(this, instanceId, initialExpanded, initialPosition);
+	}
+
+	registerEmbeddedChat(registration: EmbeddedChatRegistration): () => void {
+		this.embeddedChats.set(registration.viewId, registration);
+		return () => {
+			const current = this.embeddedChats.get(registration.viewId);
+			if (current === registration) {
+				this.embeddedChats.delete(registration.viewId);
+			}
+		};
+	}
+
+	findNearestEmbeddedChat(
+		sourcePath: string,
+		lineStart: number,
+	): string | null {
+		let nearest: EmbeddedChatRegistration | null = null;
+		let nearestDistance = Number.POSITIVE_INFINITY;
+
+		for (const registration of this.embeddedChats.values()) {
+			if (registration.sourcePath !== sourcePath) continue;
+			const distance = Math.abs(registration.lineStart - lineStart);
+			if (distance < nearestDistance) {
+				nearest = registration;
+				nearestDistance = distance;
+			}
+		}
+
+		return nearest?.viewId ?? null;
 	}
 
 	/**
@@ -687,6 +750,118 @@ export default class AgentClientPlugin extends Plugin {
 		if (view) {
 			view.expand();
 		}
+	}
+
+	/**
+	 * Render an `agent-client` code block. Dispatches to embedded chat or
+	 * quick-action button based on the parsed `type` field.
+	 */
+	private renderAgentBlock(
+		source: string,
+		el: HTMLElement,
+		ctx: MarkdownPostProcessorContext,
+	): void {
+		const child = new MarkdownRenderChild(el);
+		const parsed = parseAgentBlock(source);
+
+		if (!parsed.ok) {
+			const errorEl = el.createDiv({
+				cls: "agent-client-code-block-error",
+			});
+			errorEl.createSpan({
+				cls: "agent-client-code-block-error-label",
+				text: "agent-client block error: ",
+			});
+			errorEl.createSpan({ text: parsed.error });
+			const sourceEl = errorEl.createEl("pre", {
+				cls: "agent-client-code-block-error-source",
+			});
+			sourceEl.setText(source);
+			ctx.addChild(child);
+			return;
+		}
+
+		const sectionInfo = ctx.getSectionInfo(el);
+		const sourcePath = ctx.sourcePath || "";
+		const lineStart = sectionInfo?.lineStart ?? 0;
+		const blockId = `${sourcePath || "untitled"}:${lineStart}`;
+
+		if (parsed.config.type === "chat") {
+			const root = mountCodeBlockChat(this, el, parsed.config, {
+				sourcePath,
+				blockId,
+				lineStart,
+			});
+			child.onunload = () => root.unmount();
+		} else {
+			const root = mountAgentButtonBlock(this, el, parsed.config, {
+				sourcePath,
+				lineStart,
+			});
+			child.onunload = () => root.unmount();
+		}
+		ctx.addChild(child);
+	}
+
+	/**
+	 * Open a chat view and inject a prompt into it. Used by quick-action
+	 * buttons (embedded code blocks, command palette entries, etc.).
+	 *
+	 * Fires `agent-client:run-prompt` shortly after the open call so the
+	 * target ChatPanel (matched by viewId or "any") can populate its input
+	 * box, optionally auto-sending once the session is ready.
+	 */
+	async runPromptInChat(options: {
+		agentId: string;
+		prompt: string;
+		autoSend: boolean;
+		viewType: "right-pane" | "floating" | "editor-tab" | "embedded";
+		sourcePath?: string;
+		lineStart?: number;
+	}): Promise<void> {
+		const { agentId, prompt, autoSend, viewType, sourcePath, lineStart } =
+			options;
+		let targetViewId: string | null = null;
+
+		if (viewType === "embedded") {
+			targetViewId =
+				sourcePath && typeof lineStart === "number"
+					? this.findNearestEmbeddedChat(sourcePath, lineStart)
+					: null;
+			if (!targetViewId) {
+				new Notice("No embedded chat block found in this note.");
+				return;
+			}
+		} else if (viewType === "floating") {
+			const counterBefore = this.floatingChatCounter;
+			this.openNewFloatingChat(true);
+			targetViewId = `floating-chat-${counterBefore}`;
+		} else if (viewType === "editor-tab") {
+			const leaf = this.app.workspace.getLeaf("tab");
+			await leaf.setViewState({
+				type: VIEW_TYPE_CHAT,
+				active: true,
+				state: { initialAgentId: agentId },
+			});
+			await this.app.workspace.revealLeaf(leaf);
+			const view = leaf.view as ChatView;
+			targetViewId = view?.viewId ?? null;
+		} else {
+			targetViewId = await this.openNewChatViewWithAgent(agentId);
+		}
+
+		if (!targetViewId) return;
+
+		// Defer slightly so the React root has mounted and registered its
+		// `agent-client:run-prompt` listener.
+		window.setTimeout(() => {
+			this.app.workspace.trigger(
+				"agent-client:run-prompt",
+				targetViewId,
+				prompt,
+				autoSend,
+			);
+		}, 100);
 	}
 
 	/**
@@ -938,6 +1113,12 @@ export default class AgentClientPlugin extends Plugin {
 				? rawDefaultId
 				: availableAgentIds[0] || D.claude.id;
 
+		const pickAvatarImage = (value: unknown): string | undefined => {
+			if (typeof value !== "string") return undefined;
+			const trimmed = value.trim();
+			return trimmed.length > 0 ? trimmed : undefined;
+		};
+
 		this.settings = {
 			claude: {
 				id: D.claude.id, // Fixed — never from raw
@@ -959,6 +1140,7 @@ export default class AgentClientPlugin extends Plugin {
 					D.claude.command,
 				args: sanitizeArgs(rc.args),
 				env: normalizeEnvVars(rc.env),
+				avatarImage: pickAvatarImage(rc.avatarImage),
 			},
 			codex: {
 				id: D.codex.id,
@@ -976,6 +1158,7 @@ export default class AgentClientPlugin extends Plugin {
 				command: str(rk.command, "") || D.codex.command,
 				args: sanitizeArgs(rk.args),
 				env: normalizeEnvVars(rk.env),
+				avatarImage: pickAvatarImage(rk.avatarImage),
 			},
 			gemini: {
 				id: D.gemini.id,
@@ -1000,6 +1183,7 @@ export default class AgentClientPlugin extends Plugin {
 						? sanitizeArgs(rg.args)
 						: D.gemini.args,
 				env: normalizeEnvVars(rg.env),
+				avatarImage: pickAvatarImage(rg.avatarImage),
 			},
 			customAgents,
 			defaultAgentId,
@@ -1077,7 +1261,13 @@ export default class AgentClientPlugin extends Plugin {
 			),
 			chatViewLocation: enumVal(
 				raw.chatViewLocation,
-				["right-tab", "right-split", "editor-tab", "editor-split"],
+				[
+					"right-tab",
+					"right-split",
+					"editor-tab",
+					"editor-split",
+					"floating",
+				],
 				D.chatViewLocation,
 			),
 			displaySettings: {

--- a/src/services/settings-normalizer.ts
+++ b/src/services/settings-normalizer.ts
@@ -128,6 +128,12 @@ export const normalizeCustomAgent = (
 		agent.displayName.trim().length > 0
 			? agent.displayName.trim()
 			: rawId;
+	const rawAvatar =
+		agent &&
+		typeof agent.avatarImage === "string" &&
+		agent.avatarImage.trim().length > 0
+			? agent.avatarImage.trim()
+			: undefined;
 	return {
 		id: rawId,
 		displayName: rawDisplayName,
@@ -139,6 +145,7 @@ export const normalizeCustomAgent = (
 				: "",
 		args: sanitizeArgs(agent?.args),
 		env: normalizeEnvVars(agent?.env),
+		avatarImage: rawAvatar,
 	};
 };
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -51,6 +51,12 @@ export interface BaseAgentSettings {
 
 	/** Environment variables for the agent process */
 	env: AgentEnvVar[];
+
+	/**
+	 * Per-agent avatar image used by embedded chat and quick-prompt buttons.
+	 * Accepts an http(s) URL, a data URL, or a vault-relative path.
+	 */
+	avatarImage?: string;
 }
 
 /**

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -593,6 +593,8 @@ export interface SavedSessionInfo {
 	cwd: string;
 	/** Human-readable session title (first 50 chars of first user message) */
 	title?: string;
+	/** Note path that owns a persistent embedded chat session. */
+	sourcePath?: string;
 	/** ISO 8601 timestamp of session creation */
 	createdAt: string;
 	/** ISO 8601 timestamp of last activity */

--- a/src/ui/AgentButtonBlock.tsx
+++ b/src/ui/AgentButtonBlock.tsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+const { useCallback, useMemo } = React;
+import { createRoot, type Root } from "react-dom/client";
+import { Notice } from "obsidian";
+
+import type AgentClientPlugin from "../plugin";
+import {
+	getAgentAvatarImage,
+	resolveImageSrc,
+} from "../utils/resolve-image-src";
+import type { AgentButtonBlockConfig } from "../utils/agent-block-parser";
+
+interface AgentButtonBlockProps {
+	plugin: AgentClientPlugin;
+	config: AgentButtonBlockConfig;
+	mountCtx: AgentButtonMountContext;
+}
+
+export interface AgentButtonMountContext {
+	sourcePath: string;
+	lineStart: number;
+}
+
+function resolveAgentId(
+	plugin: AgentClientPlugin,
+	preferred: string | undefined,
+): string {
+	const available = plugin.getAvailableAgents().map((a) => a.id);
+	if (preferred && available.includes(preferred)) return preferred;
+	return plugin.settings.defaultAgentId;
+}
+
+function AgentButtonBlockComponent({
+	plugin,
+	config,
+	mountCtx,
+}: AgentButtonBlockProps) {
+	const resolvedAgentId = useMemo(() => {
+		return resolveAgentId(plugin, config.agent);
+	}, [plugin, config.agent]);
+
+	const avatarSrc = useMemo(() => {
+		return resolveImageSrc(
+			plugin,
+			getAgentAvatarImage(plugin, resolvedAgentId),
+		);
+	}, [plugin, resolvedAgentId]);
+
+	const handleClick = useCallback(async () => {
+		try {
+			await plugin.runPromptInChat({
+				agentId: resolvedAgentId,
+				prompt: config.prompt,
+				autoSend: config.autoSend ?? false,
+				viewType: config.viewType ?? "right-pane",
+				sourcePath: mountCtx.sourcePath,
+				lineStart: mountCtx.lineStart,
+			});
+		} catch (error) {
+			console.error("[Agent Client] runPromptInChat failed:", error);
+			new Notice("Failed to open chat with prompt.");
+		}
+	}, [plugin, resolvedAgentId, config]);
+
+	return (
+		<div className="agent-client-button-block">
+			<button
+				type="button"
+				className="agent-client-button-block-button mod-cta"
+				onClick={() => void handleClick()}
+			>
+				{avatarSrc && (
+					<img
+						src={avatarSrc}
+						alt=""
+						className="agent-client-button-block-avatar"
+					/>
+				)}
+				<span className="agent-client-button-block-text">
+					{config.text}
+				</span>
+			</button>
+		</div>
+	);
+}
+
+export function mountAgentButtonBlock(
+	plugin: AgentClientPlugin,
+	el: HTMLElement,
+	config: AgentButtonBlockConfig,
+	mountCtx: AgentButtonMountContext,
+): Root {
+	const container = el.createDiv();
+	const root = createRoot(container);
+	root.render(
+		<AgentButtonBlockComponent
+			plugin={plugin}
+			config={config}
+			mountCtx={mountCtx}
+		/>,
+	);
+	return root;
+}

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -6,10 +6,12 @@ import {
 	Platform,
 	Menu,
 	setIcon,
+	TFile,
 	type MenuItem,
 } from "obsidian";
 
 import type { AttachedFile, ChatInputState } from "../types/chat";
+import type { NoteMetadata } from "../services/vault-service";
 import { isSameDirectory } from "../utils/platform";
 import { computeSessionTitle } from "../services/session-helpers";
 import { useHistoryModal } from "../hooks/useHistoryModal";
@@ -79,11 +81,17 @@ export interface ChatPanelCallbacks {
 // ============================================================================
 
 export interface ChatPanelProps {
-	variant: "sidebar" | "floating";
+	variant: "sidebar" | "floating" | "embedded";
 	viewId: string;
 	workingDirectory?: string;
 	initialAgentId?: string;
-	config?: { agent?: string; model?: string };
+	config?: {
+		agent?: string;
+		model?: string;
+		persist?: boolean;
+		noteContext?: "hosting";
+		sourcePath?: string;
+	};
 	onRegisterCallbacks?: (callbacks: ChatPanelCallbacks) => void;
 	/** Called when agent ID changes (sidebar only — persists in Obsidian state) */
 	onAgentIdChanged?: (agentId: string) => void;
@@ -198,11 +206,27 @@ export function ChatPanel({
 		errorInfo,
 	} = agent;
 
+	const pinnedActiveNote = useMemo<NoteMetadata | null>(() => {
+		if (config?.noteContext !== "hosting" || !config.sourcePath) {
+			return null;
+		}
+		const file = plugin.app.vault.getAbstractFileByPath(config.sourcePath);
+		if (!(file instanceof TFile)) return null;
+		return {
+			path: file.path,
+			name: file.basename,
+			extension: file.extension,
+			created: file.stat.ctime,
+			modified: file.stat.mtime,
+		};
+	}, [plugin, config?.noteContext, config?.sourcePath]);
+
 	const suggestions = useSuggestions(
 		vaultService,
 		plugin,
 		session.availableCommands || EMPTY_COMMANDS,
 		settings.autoMentionActiveNote,
+		pinnedActiveNote,
 	);
 
 	// Session history hook with callback for session load
@@ -252,6 +276,10 @@ export function ChatPanel({
 	const [inputValue, setInputValue] = useState("");
 	const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>([]);
 
+	// Pending auto-send queued by `agent-client:run-prompt` (drained when ready)
+	const [pendingAutoSend, setPendingAutoSend] = useState<string | null>(null);
+	const persistRestoreAttemptedRef = useRef(false);
+
 	// ============================================================
 	// Refs
 	// ============================================================
@@ -299,6 +327,7 @@ export function ChatPanel({
 		messages,
 		settings,
 		vaultPath,
+		config?.persist ? config.sourcePath : undefined,
 	);
 
 	const {
@@ -636,14 +665,14 @@ export function ChatPanel({
 		// Floating: create a shim with listener tracking
 		return {
 			app: plugin.app,
-			registerDomEvent: ((
+			registerDomEvent: (
 				target: Window | Document | HTMLElement,
 				type: string,
 				callback: EventListenerOrEventListenerObject,
 			) => {
 				target.addEventListener(type, callback);
 				registeredListenersRef.current.push({ target, type, callback });
-			}),
+			},
 		};
 	}, [viewHostProp, plugin.app]);
 
@@ -669,6 +698,35 @@ export function ChatPanel({
 		logger.log("[Debug] Starting connection setup via useSession...");
 		void agent.createSession(config?.agent || initialAgentId);
 	}, [agent.createSession, config?.agent, initialAgentId]);
+
+	useEffect(() => {
+		if (variant !== "embedded") return;
+		if (!config?.persist || !config.sourcePath) return;
+		if (!isSessionReady || !session.sessionId || !session.agentId) return;
+		if (!sessionHistory.canRestore) return;
+		if (persistRestoreAttemptedRef.current) return;
+		persistRestoreAttemptedRef.current = true;
+
+		const savedSession = plugin.settingsService
+			.getSavedSessions(session.agentId, agentCwd)
+			.find((item) => item.sourcePath === config.sourcePath);
+		if (!savedSession || savedSession.sessionId === session.sessionId) {
+			return;
+		}
+
+		void sessionHistory.restoreSession(savedSession.sessionId, agentCwd);
+	}, [
+		variant,
+		config?.persist,
+		config?.sourcePath,
+		isSessionReady,
+		session.sessionId,
+		session.agentId,
+		sessionHistory.canRestore,
+		sessionHistory.restoreSession,
+		plugin.settingsService,
+		agentCwd,
+	]);
 
 	// Apply configured model when session is ready
 	useEffect(() => {
@@ -793,7 +851,10 @@ export function ChatPanel({
 			);
 
 			// System notification on response completion
-			if (settings.enableSystemNotifications && !activeDocument.hasFocus()) {
+			if (
+				settings.enableSystemNotifications &&
+				!activeDocument.hasFocus()
+			) {
 				new Notification("Agent Client", {
 					body: `${activeAgentLabel} has completed the response.`,
 				});
@@ -990,6 +1051,27 @@ export function ChatPanel({
 				if (targetViewId && targetViewId !== viewId) return;
 				void handleExportChatRef.current();
 			}),
+
+			// Run prompt injected by quick-action button or code block.
+			// `targetViewId` filter: null/empty matches any view (used when the
+			// caller created the leaf via openNewChatViewWithAgent and cannot
+			// know the new viewId synchronously).
+			ws.on(
+				"agent-client:run-prompt",
+				(
+					targetViewId: string | null,
+					prompt: string,
+					autoSend?: boolean,
+				) => {
+					if (targetViewId && targetViewId !== viewId) return;
+					if (typeof prompt !== "string" || prompt.length === 0)
+						return;
+					setInputValue(prompt);
+					if (autoSend) {
+						setPendingAutoSend(prompt);
+					}
+				},
+			),
 		];
 
 		return () => {
@@ -1003,6 +1085,27 @@ export function ChatPanel({
 		viewId,
 		variant,
 		suggestions.mentions.toggleAutoMention,
+	]);
+
+	// ============================================================
+	// Effects - Drain pending auto-send when session becomes ready
+	// ============================================================
+	useEffect(() => {
+		if (!pendingAutoSend) return;
+		if (!isSessionReady) return;
+		if (isSending) return;
+		if (sessionHistory.loading) return;
+
+		const prompt = pendingAutoSend;
+		setPendingAutoSend(null);
+		setInputValue("");
+		void handleSendMessage(prompt);
+	}, [
+		pendingAutoSend,
+		isSessionReady,
+		isSending,
+		sessionHistory.loading,
+		handleSendMessage,
 	]);
 
 	// ============================================================
@@ -1135,6 +1238,8 @@ export function ChatPanel({
 				} as React.CSSProperties)
 			: undefined;
 
+	const shouldShowAgentSelector = variant !== "embedded" || !config?.agent;
+
 	const headerElement =
 		variant === "sidebar" ? (
 			<ChatHeader
@@ -1150,7 +1255,7 @@ export function ChatPanel({
 			<ChatHeader
 				variant="floating"
 				agentLabel={activeAgentLabel}
-				availableAgents={availableAgents}
+				availableAgents={shouldShowAgentSelector ? availableAgents : []}
 				currentAgentId={session.agentId}
 				isUpdateAvailable={isUpdateAvailable}
 				onAgentChange={(agentId) => void handleSwitchAgent(agentId)}
@@ -1251,6 +1356,25 @@ export function ChatPanel({
 					{inputAreaElement}
 				</div>
 			</>
+		);
+	}
+
+	if (variant === "embedded") {
+		return (
+			<div
+				ref={containerRef}
+				className="agent-client-chat-view-container agent-client-embedded-chat-panel"
+				style={chatFontSizeStyle}
+			>
+				<div className="agent-client-embedded-header">
+					{headerElement}
+				</div>
+				{cwdBanner}
+				<div className="agent-client-embedded-messages-container">
+					{messageListElement}
+				</div>
+				{inputAreaElement}
+			</div>
 		);
 	}
 

--- a/src/ui/CodeBlockChatView.tsx
+++ b/src/ui/CodeBlockChatView.tsx
@@ -1,0 +1,124 @@
+import * as React from "react";
+const { useEffect, useMemo } = React;
+import { createRoot, type Root } from "react-dom/client";
+
+import type AgentClientPlugin from "../plugin";
+import { ChatContextProvider } from "./ChatContext";
+import { ChatPanel } from "./ChatPanel";
+import { VaultService } from "../services/vault-service";
+import {
+	getAgentAvatarImage,
+	resolveImageSrc,
+} from "../utils/resolve-image-src";
+import type { AgentChatBlockConfig } from "../utils/agent-block-parser";
+
+export interface CodeBlockMountContext {
+	sourcePath: string;
+	blockId: string;
+	lineStart: number;
+}
+
+interface CodeBlockChatProps {
+	plugin: AgentClientPlugin;
+	config: AgentChatBlockConfig;
+	mountCtx: CodeBlockMountContext;
+}
+
+function CodeBlockChatComponent({
+	plugin,
+	config,
+	mountCtx,
+}: CodeBlockChatProps) {
+	const viewId = `code-block:${mountCtx.blockId}`;
+
+	const acpClient = useMemo(
+		() => plugin.getOrCreateAcpClient(viewId),
+		[plugin, viewId],
+	);
+
+	const vaultService = useMemo(() => new VaultService(plugin), [plugin]);
+
+	useEffect(() => {
+		const unregisterEmbeddedChat = plugin.registerEmbeddedChat({
+			viewId,
+			sourcePath: mountCtx.sourcePath,
+			lineStart: mountCtx.lineStart,
+		});
+		return () => {
+			unregisterEmbeddedChat();
+			vaultService.destroy();
+			void plugin.removeAcpClient(viewId);
+		};
+	}, [plugin, viewId, vaultService, mountCtx.sourcePath, mountCtx.lineStart]);
+
+	const contextValue = useMemo(
+		() => ({
+			plugin,
+			acpClient,
+			vaultService,
+			settingsService: plugin.settingsService,
+		}),
+		[plugin, acpClient, vaultService],
+	);
+
+	const avatarSrc = useMemo(() => {
+		return (
+			resolveImageSrc(plugin, config.image) ??
+			resolveImageSrc(
+				plugin,
+				getAgentAvatarImage(plugin, config.agent),
+			) ??
+			resolveImageSrc(plugin, plugin.settings.floatingButtonImage)
+		);
+	}, [plugin, config.image, config.agent]);
+
+	const heightStyle = config.height
+		? ({ "--ac-embedded-max-height": config.height } as React.CSSProperties)
+		: undefined;
+
+	return (
+		<div className="agent-client-code-block-chat" style={heightStyle}>
+			{avatarSrc && (
+				<div className="agent-client-code-block-chat-avatar-row">
+					<img
+						src={avatarSrc}
+						alt=""
+						className="agent-client-code-block-chat-avatar"
+					/>
+				</div>
+			)}
+			<ChatContextProvider value={contextValue}>
+				<ChatPanel
+					variant="embedded"
+					viewId={viewId}
+					initialAgentId={config.agent}
+					config={{
+						agent: config.agent,
+						model: config.model,
+						persist: config.persist,
+						noteContext: config.noteContext,
+						sourcePath: mountCtx.sourcePath,
+					}}
+				/>
+			</ChatContextProvider>
+		</div>
+	);
+}
+
+export function mountCodeBlockChat(
+	plugin: AgentClientPlugin,
+	el: HTMLElement,
+	config: AgentChatBlockConfig,
+	mountCtx: CodeBlockMountContext,
+): Root {
+	const container = el.createDiv({ cls: "agent-client-code-block-host" });
+	const root = createRoot(container);
+	root.render(
+		<CodeBlockChatComponent
+			plugin={plugin}
+			config={config}
+			mountCtx={mountCtx}
+		/>,
+	);
+	return root;
+}

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -202,6 +202,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					.addOption("right-split", "Right pane (split)")
 					.addOption("editor-tab", "Editor area (tabs)")
 					.addOption("editor-split", "Editor area (split)")
+					.addOption("floating", "Floating chat")
 					.setValue(this.plugin.settings.chatViewLocation)
 					.onChange(async (value) => {
 						await this.plugin.settingsService.updateSettings({
@@ -1027,6 +1028,11 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					});
 				text.inputEl.rows = 3;
 			});
+
+		this.renderAvatarSetting(sectionEl, gemini.avatarImage, async (v) => {
+			this.plugin.settings.gemini.avatarImage = v;
+			await this.plugin.saveSettings();
+		});
 	}
 
 	private renderClaudeSettings(sectionEl: HTMLElement) {
@@ -1122,6 +1128,11 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					});
 				text.inputEl.rows = 3;
 			});
+
+		this.renderAvatarSetting(sectionEl, claude.avatarImage, async (v) => {
+			this.plugin.settings.claude.avatarImage = v;
+			await this.plugin.saveSettings();
+		});
 	}
 
 	private renderCodexSettings(sectionEl: HTMLElement) {
@@ -1217,6 +1228,11 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					});
 				text.inputEl.rows = 3;
 			});
+
+		this.renderAvatarSetting(sectionEl, codex.avatarImage, async (v) => {
+			this.plugin.settings.codex.avatarImage = v;
+			await this.plugin.saveSettings();
+		});
 	}
 
 	private renderCustomAgents(containerEl: HTMLElement) {
@@ -1363,6 +1379,11 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					});
 				text.inputEl.rows = 3;
 			});
+
+		this.renderAvatarSetting(blockEl, agent.avatarImage, async (v) => {
+			this.plugin.settings.customAgents[index].avatarImage = v;
+			await this.plugin.saveSettings();
+		});
 	}
 
 	/**
@@ -1538,5 +1559,30 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		}
 
 		return normalizeEnvVars(envVars);
+	}
+
+	/**
+	 * Shared avatar field rendered at the bottom of every agent section.
+	 */
+	private renderAvatarSetting(
+		sectionEl: HTMLElement,
+		currentValue: string | undefined,
+		onChange: (value: string | undefined) => Promise<void>,
+	): void {
+		new Setting(sectionEl)
+			.setName("Avatar image")
+			.setDesc(
+				"URL or vault path to an image. Used by embedded `agent-client` chat blocks and quick-action buttons.",
+			)
+			.addText((text) => {
+				text.setPlaceholder("https://example.com/avatar.png")
+					.setValue(currentValue ?? "")
+					.onChange(async (value) => {
+						const trimmed = value.trim();
+						await onChange(
+							trimmed.length > 0 ? trimmed : undefined,
+						);
+					});
+			});
 	}
 }

--- a/src/utils/agent-block-parser.ts
+++ b/src/utils/agent-block-parser.ts
@@ -1,0 +1,203 @@
+/**
+ * Parser for the `agent-client` markdown code block.
+ *
+ * Pure function. No React, no Obsidian view APIs (parseYaml from obsidian
+ * is the only Obsidian import, used as a YAML utility).
+ *
+ * Fence body is parsed as YAML and dispatched by a `type` discriminator:
+ * - `chat` (default): embedded chat view
+ * - `button`: quick-action button that opens a chat with a prompt
+ */
+
+import { parseYaml } from "obsidian";
+
+export type AgentChatBlockConfig = {
+	type: "chat";
+	agent?: string;
+	model?: string;
+	/** Max height of the messages area, e.g. "400px". */
+	height?: string;
+	/** Restore the latest saved session for this note + agent. */
+	persist?: boolean;
+	/** Pin auto-mention context to the note hosting this block. */
+	noteContext?: "hosting";
+	/**
+	 * Per-block avatar override.
+	 * Accepts http(s) URL, data URL, or vault-relative path.
+	 * Falls back to the configured agent's avatarImage, then the
+	 * global floatingButtonImage.
+	 */
+	image?: string;
+};
+
+export type AgentButtonBlockConfig = {
+	type: "button";
+	text: string;
+	/** Prompt sent to the opened chat. */
+	prompt: string;
+	agent?: string;
+	/** Where to open the chat when clicked. */
+	viewType?: "right-pane" | "floating" | "editor-tab" | "embedded";
+	/** Send immediately on open. */
+	autoSend?: boolean;
+};
+
+export type AgentBlockConfig = AgentChatBlockConfig | AgentButtonBlockConfig;
+
+export type AgentBlockParseResult =
+	| { ok: true; config: AgentBlockConfig }
+	| { ok: false; error: string };
+
+const VALID_TYPES = new Set<string>(["chat", "button"]);
+const VALID_VIEW_TYPES = new Set<string>([
+	"right-pane",
+	"floating",
+	"editor-tab",
+	"embedded",
+]);
+const VALID_NOTE_CONTEXTS = new Set<string>(["hosting"]);
+
+function normalizeViewType(
+	value: string | undefined,
+): AgentButtonBlockConfig["viewType"] | undefined {
+	if (!value) return undefined;
+	if (value === "right" || value === "right-tab") return "right-pane";
+	if (value === "float" || value === "floating-chat") return "floating";
+	if (value === "tab") return "editor-tab";
+	if (value === "embed" || value === "embeddable") return "embedded";
+	return VALID_VIEW_TYPES.has(value)
+		? (value as AgentButtonBlockConfig["viewType"])
+		: undefined;
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+	return typeof value === "boolean" ? value : undefined;
+}
+
+function dedent(source: string): string {
+	const normalized = source.replace(/\r\n?/g, "\n");
+	const lines = normalized.split("\n");
+	const indents = lines
+		.filter((line) => line.trim().length > 0)
+		.map((line) => line.match(/^[ \t]*/)?.[0].length ?? 0);
+	const minIndent = indents.length > 0 ? Math.min(...indents) : 0;
+
+	if (minIndent === 0) return normalized.trim();
+
+	return lines
+		.map((line) => (line.trim().length > 0 ? line.slice(minIndent) : line))
+		.join("\n")
+		.trim();
+}
+
+function normalizeCssLength(value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	return value.replace(/^(-?\d+(?:\.\d+)?)\s+(px|em|rem|vh|vw|%)$/i, "$1$2");
+}
+
+/**
+ * Parse the fence body. An empty body yields a default `chat` block.
+ *
+ * Returns a discriminated result. Callers should render an inline error
+ * (createDiv/createSpan, never innerHTML) when ok is false.
+ */
+export function parseAgentBlock(source: string): AgentBlockParseResult {
+	const trimmed = dedent(source);
+
+	let raw: unknown;
+	if (trimmed.length === 0) {
+		raw = {};
+	} else {
+		try {
+			raw = parseYaml(trimmed);
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : String(error);
+			return { ok: false, error: `Invalid YAML: ${message}` };
+		}
+	}
+
+	if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+		return {
+			ok: false,
+			error: "Block body must be a YAML mapping (key: value pairs).",
+		};
+	}
+
+	const obj = raw as Record<string, unknown>;
+	const typeValue = asString(obj.type) ?? "chat";
+
+	if (!VALID_TYPES.has(typeValue)) {
+		return {
+			ok: false,
+			error: `Unknown type: "${typeValue}". Expected "chat" or "button".`,
+		};
+	}
+
+	if (typeValue === "chat") {
+		const rawNoteContext = asString(obj.noteContext);
+		const noteContext = rawNoteContext
+			? VALID_NOTE_CONTEXTS.has(rawNoteContext)
+				? (rawNoteContext as AgentChatBlockConfig["noteContext"])
+				: undefined
+			: undefined;
+		if (rawNoteContext && !noteContext) {
+			return {
+				ok: false,
+				error: `Unknown noteContext: "${rawNoteContext}". Expected "hosting".`,
+			};
+		}
+
+		const config: AgentChatBlockConfig = {
+			type: "chat",
+			agent: asString(obj.agent),
+			model: asString(obj.model),
+			height: normalizeCssLength(asString(obj.height)),
+			persist: asBoolean(obj.persist) ?? false,
+			noteContext,
+			image: asString(obj.image),
+		};
+		return { ok: true, config };
+	}
+
+	const text = asString(obj.text);
+	if (!text) {
+		return {
+			ok: false,
+			error: 'Button block requires a non-empty "text" field.',
+		};
+	}
+
+	const prompt = asString(obj.prompt);
+	if (!prompt) {
+		return {
+			ok: false,
+			error: 'Button block requires a non-empty "prompt" field.',
+		};
+	}
+
+	const rawViewType = asString(obj.viewType);
+	const viewType = normalizeViewType(rawViewType);
+	if (rawViewType && !viewType) {
+		return {
+			ok: false,
+			error: `Unknown viewType: "${rawViewType}". Expected "right-pane", "floating", "editor-tab", or "embedded".`,
+		};
+	}
+
+	const config: AgentButtonBlockConfig = {
+		type: "button",
+		text,
+		prompt,
+		agent: asString(obj.agent),
+		viewType: viewType ?? "right-pane",
+		autoSend: asBoolean(obj.autoSend) ?? false,
+	};
+	return { ok: true, config };
+}

--- a/src/utils/resolve-image-src.ts
+++ b/src/utils/resolve-image-src.ts
@@ -1,0 +1,45 @@
+/**
+ * Resolve a user-supplied image reference to a value usable in an <img src>.
+ *
+ * Accepts:
+ * - http:// or https:// URLs (returned unchanged)
+ * - data: URLs (returned unchanged)
+ * - vault-relative paths (resolved via FileSystemAdapter.getResourcePath)
+ *
+ * Returns null for empty/missing input or non-FileSystemAdapter vaults.
+ */
+
+import { FileSystemAdapter } from "obsidian";
+import type AgentClientPlugin from "../plugin";
+
+export function resolveImageSrc(
+	plugin: AgentClientPlugin,
+	value: string | undefined | null,
+): string | null {
+	if (!value) return null;
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return null;
+
+	if (/^(https?:|data:)/i.test(trimmed)) {
+		return trimmed;
+	}
+
+	const adapter = plugin.app.vault.adapter;
+	if (adapter instanceof FileSystemAdapter) {
+		return adapter.getResourcePath(trimmed);
+	}
+	return null;
+}
+
+export function getAgentAvatarImage(
+	plugin: AgentClientPlugin,
+	agentId: string | undefined,
+): string | undefined {
+	if (!agentId) return undefined;
+	const settings = plugin.settings;
+	if (agentId === settings.claude.id) return settings.claude.avatarImage;
+	if (agentId === settings.codex.id) return settings.codex.avatarImage;
+	if (agentId === settings.gemini.id) return settings.gemini.avatarImage;
+	return settings.customAgents.find((agent) => agent.id === agentId)
+		?.avatarImage;
+}

--- a/styles.css
+++ b/styles.css
@@ -2199,48 +2199,6 @@ If your plugin does not need CSS, delete this file.
 	color: var(--interactive-accent);
 }
 
-/* ===== Code Block Chat View ===== */
-/* TODO(code-block): Styles for future code block chat view */
-.agent-client-code-block-container {
-	display: flex;
-	flex-direction: column;
-	border: 1px solid var(--background-modifier-border);
-	border-radius: 8px;
-	background: var(--background-primary);
-	overflow: hidden;
-}
-
-.agent-client-code-block-content {
-	display: flex;
-	flex-direction: column;
-	padding: 8px;
-}
-
-.agent-client-code-block-status {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 4px 8px;
-	background: var(--background-secondary);
-	border-radius: 4px;
-	margin-bottom: 4px;
-	flex-wrap: wrap;
-	gap: 8px;
-}
-
-.agent-client-code-block-status-actions {
-	display: flex;
-	align-items: center;
-	gap: 4px;
-	flex-wrap: wrap;
-}
-
-.agent-client-code-block-messages {
-	max-height: 400px;
-	overflow-y: auto;
-	margin-bottom: 8px;
-}
-
 /* ===== Agent Selector (InlineHeader) ===== */
 .agent-client-agent-selector {
 	display: inline-flex;
@@ -2304,4 +2262,161 @@ If your plugin does not need CSS, delete this file.
 .agent-client-agent-label {
 	color: var(--text-normal);
 	font-size: 12px;
+}
+
+/* ============================================================
+   Embedded agent-client code blocks
+   ============================================================ */
+
+.agent-client-code-block-error {
+	border: 1px solid var(--background-modifier-error-border, var(--text-error));
+	background: var(--background-modifier-error);
+	color: var(--text-on-accent, #fff);
+	padding: 10px 14px;
+	border-radius: 6px;
+	font-size: 0.95em;
+	margin: 4px 0;
+	font-family: var(--font-interface);
+}
+
+.agent-client-code-block-error-label {
+	font-weight: 700;
+	margin-right: 4px;
+	color: var(--text-on-accent, #fff);
+}
+
+.agent-client-code-block-error-source {
+	margin-top: 8px;
+	padding: 6px 10px;
+	background: rgba(0, 0, 0, 0.25);
+	border-radius: 4px;
+	font-family: var(--font-monospace);
+	font-size: 0.85em;
+	color: var(--text-on-accent, #fff);
+	white-space: pre-wrap;
+	word-break: break-word;
+	max-height: 200px;
+	overflow: auto;
+}
+
+.agent-client-code-block-host {
+	margin: 8px 0;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	overflow: hidden;
+	background: var(--background-primary);
+}
+
+.agent-client-code-block-chat {
+	display: flex;
+	flex-direction: column;
+	height: var(--ac-embedded-max-height, 520px);
+	min-height: 320px;
+	max-height: min(var(--ac-embedded-max-height, 520px), 80vh);
+	overflow: hidden;
+}
+
+.agent-client-code-block-chat-avatar-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-height: 40px;
+	padding: 6px 10px;
+	border-bottom: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary);
+}
+
+.agent-client-code-block-chat-avatar {
+	display: block;
+	flex: 0 0 28px;
+	width: 28px !important;
+	height: 28px !important;
+	min-width: 28px;
+	min-height: 28px;
+	max-width: 28px;
+	max-height: 28px;
+	aspect-ratio: 1 / 1;
+	border-radius: 50%;
+	object-fit: cover;
+	overflow: hidden;
+}
+
+.agent-client-embedded-chat-panel {
+	flex: 1 1 auto;
+	height: 100%;
+	min-height: 0;
+	overflow: hidden;
+	background: var(--background-primary);
+}
+
+.agent-client-embedded-header {
+	flex: 0 0 auto;
+	border-bottom: 1px solid var(--background-modifier-border);
+	background: var(--background-primary);
+}
+
+.agent-client-embedded-header .agent-client-inline-header {
+	min-height: 34px;
+	padding: 6px 10px;
+}
+
+.agent-client-embedded-messages-container {
+	flex: 1 1 auto;
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	overflow: hidden;
+}
+
+.agent-client-embedded-messages-container .agent-client-chat-view-messages {
+	flex: 1 1 auto;
+	min-height: 0;
+	padding: 12px 10px;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+}
+
+.agent-client-embedded-chat-panel .agent-client-chat-input-container {
+	flex: 0 0 auto;
+	padding: 8px 10px 10px;
+	border-top: 1px solid var(--background-modifier-border);
+	background: var(--background-primary);
+}
+
+/* ============================================================
+   Quick-action button blocks
+   ============================================================ */
+
+.agent-client-button-block {
+	display: inline-flex;
+	margin: 4px 0;
+}
+
+.agent-client-button-block-button {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 14px;
+	border-radius: 6px;
+	cursor: pointer;
+	font-weight: 500;
+}
+
+.agent-client-button-block-avatar {
+	display: block;
+	flex: 0 0 18px;
+	width: 18px !important;
+	height: 18px !important;
+	min-width: 18px;
+	min-height: 18px;
+	max-width: 18px;
+	max-height: 18px;
+	aspect-ratio: 1 / 1;
+	border-radius: 50%;
+	object-fit: cover;
+	overflow: hidden;
+}
+
+.agent-client-button-block-text {
+	white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
Adds markdown `agent-client` / `agent` code block rendering for embedded chats and quick-action but
## Block options (`type: chat`)
  - `agent`, `model` pin the embedded chat to a specific agent/model
  - `height` max height of the message area (e.g. `400px`)
  - `persist` restore the latest saved session for this note + agent
  - `noteContext: hosting` pin auto-mention context to the host note
  - `image` / `showImage` per-block avatar override (URL, data URL, or vault path)

  ## Key changes
  - `src/utils/agent-block-parser.ts` pure YAML parser for the block config
  - `src/ui/CodeBlockChatView.tsx` React mount for the embedded chat
  - `src/ui/AgentButtonBlock.tsx` the `button` variant
  - `src/utils/resolve-image-src.ts` resolves avatar from URL / data URL / vault path
  - Registered as a markdown code-block processor in `plugin.ts`; settings + styles added

  ## Testing
  - Built with `npm run build`.
  - Verified `chat` and `button` blocks render in both Reading mode and Live Preview.
<img width="1280" height="853" alt="meAlA54_d" src="https://github.com/user-attachments/assets/4b1eb570-1693-4a94-8216-7d8d869987f3" />
<img width="1558" height="1234" alt="agent client demo" src="https://github.com/user-attachments/assets/582938ef-d665-41a9-ae26-ace4b8bd1239" />
