### PR TITLE
feat: add recent chats and agent images

### DIFF
--- a/src/hooks/useAgentMessages.ts
+++ b/src/hooks/useAgentMessages.ts
@@ -108,7 +108,7 @@ export function useAgentMessages(
 	const [isSending, setIsSending] = useState(false);
 	const [lastUserMessage, setLastUserMessage] = useState<string | null>(null);
 
-	// Tool call index: toolCallId → message index for O(1) lookup
+	// Tool call index: toolCallId to message index for O(1) lookup
 	const toolCallIndexRef = useRef<Map<string, number>>(new Map());
 
 	// Ignore updates flag (used during session/load to skip history replay)
@@ -256,7 +256,11 @@ export function useAgentMessages(
 			// Wait for any in-flight send to settle (e.g. after cancel/stop)
 			// before starting a new one to avoid interleaved state updates.
 			if (sendPromiseRef.current) {
-				try { await sendPromiseRef.current; } catch { /* ignore */ }
+				try {
+					await sendPromiseRef.current;
+				} catch {
+					/* ignore */
+				}
 			}
 
 			const currentSessionId = session.sessionId;

--- a/src/hooks/useChatActions.ts
+++ b/src/hooks/useChatActions.ts
@@ -78,6 +78,7 @@ export function useChatActions(
 	messages: ChatMessage[],
 	settings: AgentClientPluginSettings,
 	vaultPath: string,
+	persistentSourcePath?: string,
 ): UseChatActionsReturn {
 	const logger = getLogger();
 
@@ -193,6 +194,7 @@ export function useChatActions(
 				await sessionHistory.saveSessionLocally(
 					session.sessionId,
 					content,
+					persistentSourcePath,
 				);
 				logger.log(
 					`[ChatPanel] Session saved locally: ${session.sessionId}`,
@@ -205,6 +207,7 @@ export function useChatActions(
 			messages.length,
 			session.sessionId,
 			sessionHistory.saveSessionLocally,
+			persistentSourcePath,
 			logger,
 			suggestions.mentions.activeNote,
 			suggestions.mentions.isAutoMentionDisabled,

--- a/src/hooks/useSessionHistory.ts
+++ b/src/hooks/useSessionHistory.ts
@@ -188,6 +188,7 @@ export interface UseSessionHistoryReturn {
 	saveSessionLocally: (
 		sessionId: string,
 		messageContent: string,
+		sourcePath?: string,
 	) => Promise<void>;
 
 	/**
@@ -779,7 +780,11 @@ export function useSessionHistory(
 	 * Called when the first message is sent in a new session.
 	 */
 	const saveSessionLocally = useCallback(
-		async (sessionId: string, messageContent: string) => {
+		async (
+			sessionId: string,
+			messageContent: string,
+			sourcePath?: string,
+		) => {
 			if (!session.agentId) return;
 
 			const title = truncateTitle(messageContent);
@@ -789,6 +794,7 @@ export function useSessionHistory(
 				agentId: session.agentId,
 				cwd: agentCwd,
 				title,
+				sourcePath,
 				createdAt: new Date().toISOString(),
 				updatedAt: new Date().toISOString(),
 			});

--- a/src/hooks/useSuggestions.ts
+++ b/src/hooks/useSuggestions.ts
@@ -91,6 +91,7 @@ export function useSuggestions(
 	plugin: AgentClientPlugin,
 	availableCommands: SlashCommand[],
 	autoMentionDefault: boolean,
+	pinnedActiveNote?: NoteMetadata | null,
 ): UseSuggestionsReturn {
 	// ============================================================
 	// Mention State
@@ -103,7 +104,9 @@ export function useSuggestions(
 	const [mentionContext, setMentionContext] = useState<MentionContext | null>(
 		null,
 	);
-	const [activeNote, setActiveNote] = useState<NoteMetadata | null>(null);
+	const [activeNote, setActiveNote] = useState<NoteMetadata | null>(
+		pinnedActiveNote ?? null,
+	);
 	const [isAutoMentionDisabled, setIsAutoMentionDisabled] = useState(
 		!autoMentionDefault,
 	);
@@ -206,9 +209,13 @@ export function useSuggestions(
 	}, []);
 
 	const updateActiveNote = useCallback(async () => {
+		if (pinnedActiveNote) {
+			setActiveNote(pinnedActiveNote);
+			return;
+		}
 		const note = await vaultAccess.getActiveNote();
 		setActiveNote(note);
-	}, [vaultAccess]);
+	}, [vaultAccess, pinnedActiveNote]);
 
 	// ============================================================
 	// Command Callbacks

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,9 +3,14 @@ import {
 	WorkspaceLeaf,
 	Notice,
 	requestUrl,
+	MarkdownRenderChild,
+	type MarkdownPostProcessorContext,
 } from "obsidian";
 import * as semver from "semver";
 import { ChatView, VIEW_TYPE_CHAT } from "./ui/ChatView";
+import { mountCodeBlockChat } from "./ui/CodeBlockChatView";
+import { mountAgentButtonBlock } from "./ui/AgentButtonBlock";
+import { parseAgentBlock } from "./utils/agent-block-parser";
 import {
 	SessionManagerView,
 	VIEW_TYPE_SESSION_MANAGER,
@@ -62,12 +67,20 @@ export type SendMessageShortcut = "enter" | "cmd-enter";
  * - 'right-split': Open in right pane with vertical split
  * - 'editor-tab': Open in editor area as tabs
  * - 'editor-split': Open in editor area with right split
+ * - 'floating': Open as a floating chat window
  */
 export type ChatViewLocation =
 	| "right-tab"
 	| "right-split"
 	| "editor-tab"
-	| "editor-split";
+	| "editor-split"
+	| "floating";
+
+export interface EmbeddedChatRegistration {
+	viewId: string;
+	sourcePath: string;
+	lineStart: number;
+}
 
 export interface AgentClientPluginSettings {
 	gemini: GeminiAgentSettings;
@@ -218,6 +231,8 @@ export default class AgentClientPlugin extends Plugin {
 	private floatingButton: FloatingButtonContainer | null = null;
 	/** Counter for generating unique floating chat instance IDs */
 	private floatingChatCounter = 0;
+	/** Embedded chat instances mounted from markdown code blocks. */
+	private embeddedChats = new Map<string, EmbeddedChatRegistration>();
 
 	async onload() {
 		await this.loadSettings();
@@ -355,6 +370,14 @@ export default class AgentClientPlugin extends Plugin {
 		});
 
 		this.addSettingTab(new AgentClientSettingTab(this.app, this));
+
+		this.registerMarkdownCodeBlockProcessor(
+			"agent-client",
+			(source, el, ctx) => this.renderAgentBlock(source, el, ctx),
+		);
+		this.registerMarkdownCodeBlockProcessor("agent", (source, el, ctx) =>
+			this.renderAgentBlock(source, el, ctx),
+		);
 
 		// Mount floating button (always present; visibility controlled by settings inside component)
 		this.floatingButton = new FloatingButtonContainer(this);
@@ -565,6 +588,8 @@ export default class AgentClientPlugin extends Plugin {
 		const location = this.settings.chatViewLocation;
 
 		switch (location) {
+			case "floating":
+				return null;
 			case "right-tab":
 				if (isAdditional) {
 					return this.createSidebarTab("right");
@@ -616,11 +641,17 @@ export default class AgentClientPlugin extends Plugin {
 	 * Open a new chat view with a specific agent.
 	 * Always creates a new view (doesn't reuse existing).
 	 */
-	async openNewChatViewWithAgent(agentId: string): Promise<void> {
+	async openNewChatViewWithAgent(agentId: string): Promise<string | null> {
+		if (this.settings.chatViewLocation === "floating") {
+			const counterBefore = this.floatingChatCounter;
+			this.openNewFloatingChat(true);
+			return `floating-chat-${counterBefore}`;
+		}
+
 		const leaf = this.createNewChatLeaf(true);
 		if (!leaf) {
 			getLogger().warn("[AgentClient] Failed to create new leaf");
-			return;
+			return null;
 		}
 
 		await leaf.setViewState({
@@ -630,6 +661,8 @@ export default class AgentClientPlugin extends Plugin {
 		});
 
 		await this.app.workspace.revealLeaf(leaf);
+		const view = leaf.view as ChatView | null;
+		const viewId = view?.viewId ?? null;
 
 		// Focus textarea after revealing the leaf
 		const viewContainerEl = leaf.view?.containerEl;
@@ -643,6 +676,7 @@ export default class AgentClientPlugin extends Plugin {
 				}
 			}, 0);
 		}
+		return viewId;
 	}
 
 	/**
@@ -657,6 +691,35 @@ export default class AgentClientPlugin extends Plugin {
 		// FloatingViewContainer will create viewId as "floating-chat-{instanceId}"
 		const instanceId = String(this.floatingChatCounter++);
 		createFloatingChat(this, instanceId, initialExpanded, initialPosition);
+	}
+
+	registerEmbeddedChat(registration: EmbeddedChatRegistration): () => void {
+		this.embeddedChats.set(registration.viewId, registration);
+		return () => {
+			const current = this.embeddedChats.get(registration.viewId);
+			if (current === registration) {
+				this.embeddedChats.delete(registration.viewId);
+			}
+		};
+	}
+
+	findNearestEmbeddedChat(
+		sourcePath: string,
+		lineStart: number,
+	): string | null {
+		let nearest: EmbeddedChatRegistration | null = null;
+		let nearestDistance = Number.POSITIVE_INFINITY;
+
+		for (const registration of this.embeddedChats.values()) {
+			if (registration.sourcePath !== sourcePath) continue;
+			const distance = Math.abs(registration.lineStart - lineStart);
+			if (distance < nearestDistance) {
+				nearest = registration;
+				nearestDistance = distance;
+			}
+		}
+
+		return nearest?.viewId ?? null;
 	}
 
 	/**
@@ -687,6 +750,118 @@ export default class AgentClientPlugin extends Plugin {
 		if (view) {
 			view.expand();
 		}
+	}
+
+	/**
+	 * Render an `agent-client` code block. Dispatches to embedded chat or
+	 * quick-action button based on the parsed `type` field.
+	 */
+	private renderAgentBlock(
+		source: string,
+		el: HTMLElement,
+		ctx: MarkdownPostProcessorContext,
+	): void {
+		const child = new MarkdownRenderChild(el);
+		const parsed = parseAgentBlock(source);
+
+		if (!parsed.ok) {
+			const errorEl = el.createDiv({
+				cls: "agent-client-code-block-error",
+			});
+			errorEl.createSpan({
+				cls: "agent-client-code-block-error-label",
+				text: "agent-client block error: ",
+			});
+			errorEl.createSpan({ text: parsed.error });
+			const sourceEl = errorEl.createEl("pre", {
+				cls: "agent-client-code-block-error-source",
+			});
+			sourceEl.setText(source);
+			ctx.addChild(child);
+			return;
+		}
+
+		const sectionInfo = ctx.getSectionInfo(el);
+		const sourcePath = ctx.sourcePath || "";
+		const lineStart = sectionInfo?.lineStart ?? 0;
+		const blockId = `${sourcePath || "untitled"}:${lineStart}`;
+
+		if (parsed.config.type === "chat") {
+			const root = mountCodeBlockChat(this, el, parsed.config, {
+				sourcePath,
+				blockId,
+				lineStart,
+			});
+			child.onunload = () => root.unmount();
+		} else {
+			const root = mountAgentButtonBlock(this, el, parsed.config, {
+				sourcePath,
+				lineStart,
+			});
+			child.onunload = () => root.unmount();
+		}
+		ctx.addChild(child);
+	}
+
+	/**
+	 * Open a chat view and inject a prompt into it. Used by quick-action
+	 * buttons (embedded code blocks, command palette entries, etc.).
+	 *
+	 * Fires `agent-client:run-prompt` shortly after the open call so the
+	 * target ChatPanel (matched by viewId or "any") can populate its input
+	 * box, optionally auto-sending once the session is ready.
+	 */
+	async runPromptInChat(options: {
+		agentId: string;
+		prompt: string;
+		autoSend: boolean;
+		viewType: "right-pane" | "floating" | "editor-tab" | "embedded";
+		sourcePath?: string;
+		lineStart?: number;
+	}): Promise<void> {
+		const { agentId, prompt, autoSend, viewType, sourcePath, lineStart } =
+			options;
+		let targetViewId: string | null = null;
+
+		if (viewType === "embedded") {
+			targetViewId =
+				sourcePath && typeof lineStart === "number"
+					? this.findNearestEmbeddedChat(sourcePath, lineStart)
+					: null;
+			if (!targetViewId) {
+				new Notice("No embedded chat block found in this note.");
+				return;
+			}
+		} else if (viewType === "floating") {
+			const counterBefore = this.floatingChatCounter;
+			this.openNewFloatingChat(true);
+			targetViewId = `floating-chat-${counterBefore}`;
+		} else if (viewType === "editor-tab") {
+			const leaf = this.app.workspace.getLeaf("tab");
+			await leaf.setViewState({
+				type: VIEW_TYPE_CHAT,
+				active: true,
+				state: { initialAgentId: agentId },
+			});
+			await this.app.workspace.revealLeaf(leaf);
+			const view = leaf.view as ChatView;
+			targetViewId = view?.viewId ?? null;
+		} else {
+			targetViewId = await this.openNewChatViewWithAgent(agentId);
+		}
+
+		if (!targetViewId) return;
+
+		// Defer slightly so the React root has mounted and registered its
+		// `agent-client:run-prompt` listener.
+		window.setTimeout(() => {
+			this.app.workspace.trigger(
+				"agent-client:run-prompt",
+				targetViewId,
+				prompt,
+				autoSend,
+			);
+		}, 100);
 	}
 
 	/**
@@ -938,6 +1113,12 @@ export default class AgentClientPlugin extends Plugin {
 				? rawDefaultId
 				: availableAgentIds[0] || D.claude.id;
 
+		const pickAvatarImage = (value: unknown): string | undefined => {
+			if (typeof value !== "string") return undefined;
+			const trimmed = value.trim();
+			return trimmed.length > 0 ? trimmed : undefined;
+		};
+
 		this.settings = {
 			claude: {
 				id: D.claude.id, // Fixed — never from raw
@@ -959,6 +1140,7 @@ export default class AgentClientPlugin extends Plugin {
 					D.claude.command,
 				args: sanitizeArgs(rc.args),
 				env: normalizeEnvVars(rc.env),
+				avatarImage: pickAvatarImage(rc.avatarImage),
 			},
 			codex: {
 				id: D.codex.id,
@@ -976,6 +1158,7 @@ export default class AgentClientPlugin extends Plugin {
 				command: str(rk.command, "") || D.codex.command,
 				args: sanitizeArgs(rk.args),
 				env: normalizeEnvVars(rk.env),
+				avatarImage: pickAvatarImage(rk.avatarImage),
 			},
 			gemini: {
 				id: D.gemini.id,
@@ -1000,6 +1183,7 @@ export default class AgentClientPlugin extends Plugin {
 						? sanitizeArgs(rg.args)
 						: D.gemini.args,
 				env: normalizeEnvVars(rg.env),
+				avatarImage: pickAvatarImage(rg.avatarImage),
 			},
 			customAgents,
 			defaultAgentId,
@@ -1077,7 +1261,13 @@ export default class AgentClientPlugin extends Plugin {
 			),
 			chatViewLocation: enumVal(
 				raw.chatViewLocation,
-				["right-tab", "right-split", "editor-tab", "editor-split"],
+				[
+					"right-tab",
+					"right-split",
+					"editor-tab",
+					"editor-split",
+					"floating",
+				],
 				D.chatViewLocation,
 			),
 			displaySettings: {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,6 +4,9 @@ import {
 	Notice,
 	requestUrl,
 	MarkdownRenderChild,
+	SuggestModal,
+	setIcon,
+	type App,
 	type MarkdownPostProcessorContext,
 } from "obsidian";
 import * as semver from "semver";
@@ -49,10 +52,30 @@ import {
 	CustomAgentSettings,
 } from "./types/agent";
 import type { SavedSessionInfo } from "./types/session";
+import { classifyIconRef, resolveImageSrc } from "./utils/resolve-image-src";
 import { initializeLogger, getLogger } from "./utils/logger";
 
 // Re-export for backward compatibility
 export type { AgentEnvVar, CustomAgentSettings };
+
+export interface QuickPrompt {
+	name: string;
+	prompt: string;
+	agentId?: string;
+	usageCount: number;
+	/**
+	 * Icon shown on the quick-prompt chip. Either a Lucide icon id
+	 * (e.g. "sparkles", "wand-2") or an image reference (http(s)/data URL
+	 * or vault-relative path). Falls back to "sparkles" when unset.
+	 */
+	icon?: string;
+	/**
+	 * When true, the quick-prompt chip hides itself after it is clicked,
+	 * for the lifetime of the current chat view. Reopening the chat
+	 * restores it. Non-persistent and non-destructive.
+	 */
+	hideAfterClick?: boolean;
+}
 
 /**
  * Send message shortcut configuration.
@@ -122,6 +145,8 @@ export interface AgentClientPluginSettings {
 	windowsWslDistribution?: string;
 	// Input behavior
 	sendMessageShortcut: SendMessageShortcut;
+	showQuickPromptsInChat: boolean;
+	quickPrompts: QuickPrompt[];
 	// View settings
 	chatViewLocation: ChatViewLocation;
 	// Display settings
@@ -199,6 +224,8 @@ const DEFAULT_SETTINGS: AgentClientPluginSettings = {
 	windowsWslMode: false,
 	windowsWslDistribution: undefined,
 	sendMessageShortcut: "enter",
+	showQuickPromptsInChat: true,
+	quickPrompts: [],
 	chatViewLocation: "right-tab",
 	displaySettings: {
 		autoCollapseDiffs: false,
@@ -302,6 +329,18 @@ export default class AgentClientPlugin extends Plugin {
 			name: "Open session manager",
 			callback: () => {
 				void this.activateSessionManager();
+			},
+		});
+
+		this.addCommand({
+			id: "run-quick-prompt",
+			name: "Run quick prompt",
+			checkCallback: (checking) => {
+				if (this.settings.quickPrompts.length === 0) return false;
+				if (checking) return true;
+				new QuickPromptSuggestModal(this.app, this, (prompt) => {
+					void this.runQuickPrompt(prompt);
+				}).open();
 			},
 		});
 
@@ -492,6 +531,16 @@ export default class AgentClientPlugin extends Plugin {
 	async activateView() {
 		const { workspace } = this.app;
 
+		if (this.settings.chatViewLocation === "floating") {
+			const instances = this.getFloatingChatInstances();
+			if (instances.length === 0) {
+				this.openNewFloatingChat(true);
+			} else {
+				this.expandFloatingChat(instances[instances.length - 1]);
+			}
+			return;
+		}
+
 		let leaf: WorkspaceLeaf | null = null;
 		const leaves = workspace.getLeavesOfType(VIEW_TYPE_CHAT);
 
@@ -583,9 +632,11 @@ export default class AgentClientPlugin extends Plugin {
 	 * Create a new leaf for ChatView based on the configured location setting.
 	 * @param isAdditional - true when opening additional views (e.g., Open New View)
 	 */
-	private createNewChatLeaf(isAdditional: boolean): WorkspaceLeaf | null {
+	private createNewChatLeaf(
+		isAdditional: boolean,
+		location: ChatViewLocation = this.settings.chatViewLocation,
+	): WorkspaceLeaf | null {
 		const { workspace } = this.app;
-		const location = this.settings.chatViewLocation;
 
 		switch (location) {
 			case "floating":
@@ -641,14 +692,17 @@ export default class AgentClientPlugin extends Plugin {
 	 * Open a new chat view with a specific agent.
 	 * Always creates a new view (doesn't reuse existing).
 	 */
-	async openNewChatViewWithAgent(agentId: string): Promise<string | null> {
-		if (this.settings.chatViewLocation === "floating") {
+	async openNewChatViewWithAgent(
+		agentId: string,
+		location: ChatViewLocation = this.settings.chatViewLocation,
+	): Promise<string | null> {
+		if (location === "floating") {
 			const counterBefore = this.floatingChatCounter;
 			this.openNewFloatingChat(true);
 			return `floating-chat-${counterBefore}`;
 		}
 
-		const leaf = this.createNewChatLeaf(true);
+		const leaf = this.createNewChatLeaf(true, location);
 		if (!leaf) {
 			getLogger().warn("[AgentClient] Failed to create new leaf");
 			return null;
@@ -808,8 +862,8 @@ export default class AgentClientPlugin extends Plugin {
 	 * buttons (embedded code blocks, command palette entries, etc.).
 	 *
 	 * Fires `agent-client:run-prompt` shortly after the open call so the
-	 * target ChatPanel (matched by viewId or "any") can populate its input
-	 * box, optionally auto-sending once the session is ready.
+	 * target ChatPanel can populate its input box, optionally auto-sending
+	 * once the session is ready.
 	 */
 	async runPromptInChat(options: {
 		agentId: string;
@@ -837,21 +891,27 @@ export default class AgentClientPlugin extends Plugin {
 			this.openNewFloatingChat(true);
 			targetViewId = `floating-chat-${counterBefore}`;
 		} else if (viewType === "editor-tab") {
-			const leaf = this.app.workspace.getLeaf("tab");
-			await leaf.setViewState({
-				type: VIEW_TYPE_CHAT,
-				active: true,
-				state: { initialAgentId: agentId },
-			});
-			await this.app.workspace.revealLeaf(leaf);
-			const view = leaf.view as ChatView;
-			targetViewId = view?.viewId ?? null;
+			targetViewId = await this.openNewChatViewWithAgent(
+				agentId,
+				"editor-tab",
+			);
 		} else {
-			targetViewId = await this.openNewChatViewWithAgent(agentId);
+			targetViewId = await this.openNewChatViewWithAgent(
+				agentId,
+				"right-tab",
+			);
 		}
 
 		if (!targetViewId) return;
 
+		this.dispatchPromptToChat(targetViewId, prompt, autoSend);
+	}
+
+	private dispatchPromptToChat(
+		targetViewId: string,
+		prompt: string,
+		autoSend: boolean,
+	): void {
 		// Defer slightly so the React root has mounted and registered its
 		// `agent-client:run-prompt` listener.
 		window.setTimeout(() => {
@@ -862,6 +922,52 @@ export default class AgentClientPlugin extends Plugin {
 				autoSend,
 			);
 		}, 100);
+	}
+
+	getQuickPrompts(): QuickPrompt[] {
+		return this.settings.quickPrompts
+			.filter((prompt) => prompt.name.trim() && prompt.prompt.trim())
+			.sort((a, b) => {
+				if (b.usageCount !== a.usageCount) {
+					return b.usageCount - a.usageCount;
+				}
+				return a.name.localeCompare(b.name);
+			});
+	}
+
+	findQuickPrompt(name: string | undefined): QuickPrompt | null {
+		const key = name?.trim();
+		if (!key) return null;
+		const exact = this.settings.quickPrompts.find((p) => p.name === key);
+		if (exact) return exact;
+		const lower = key.toLowerCase();
+		return (
+			this.settings.quickPrompts.find(
+				(p) => p.name.toLowerCase() === lower,
+			) ?? null
+		);
+	}
+
+	async incrementQuickPromptUsage(name: string): Promise<void> {
+		const next = this.settings.quickPrompts.map((prompt) =>
+			prompt.name === name
+				? { ...prompt, usageCount: prompt.usageCount + 1 }
+				: prompt,
+		);
+		await this.settingsService.updateSettings({ quickPrompts: next });
+	}
+
+	async runQuickPrompt(prompt: QuickPrompt): Promise<void> {
+		const agentId =
+			prompt.agentId &&
+			this.collectAvailableAgentIds().includes(prompt.agentId)
+				? prompt.agentId
+				: this.settings.defaultAgentId;
+		await this.incrementQuickPromptUsage(prompt.name);
+		const targetViewId = await this.openNewChatViewWithAgent(agentId);
+		if (targetViewId) {
+			this.dispatchPromptToChat(targetViewId, prompt.prompt, false);
+		}
 	}
 
 	/**
@@ -1259,6 +1365,40 @@ export default class AgentClientPlugin extends Plugin {
 				["enter", "cmd-enter"],
 				D.sendMessageShortcut,
 			),
+			showQuickPromptsInChat: bool(
+				raw.showQuickPromptsInChat,
+				D.showQuickPromptsInChat,
+			),
+			quickPrompts: (() => {
+				if (!Array.isArray(raw.quickPrompts)) return D.quickPrompts;
+				const seen = new Set<string>();
+				const prompts: QuickPrompt[] = [];
+				for (const entry of raw.quickPrompts) {
+					const item = obj(entry);
+					if (!item) continue;
+					const name = str(item.name, "").trim();
+					const prompt = str(item.prompt, "").trim();
+					if (!name || !prompt || seen.has(name)) continue;
+					seen.add(name);
+					const agentId = str(item.agentId, "").trim();
+					prompts.push({
+						name,
+						prompt,
+						agentId:
+							agentId.length > 0 &&
+							availableAgentIds.includes(agentId)
+								? agentId
+								: undefined,
+						usageCount: num(item.usageCount, 0, 0),
+						icon: str(item.icon, "").trim() || undefined,
+						hideAfterClick:
+							typeof item.hideAfterClick === "boolean"
+								? item.hideAfterClick
+								: undefined,
+					});
+				}
+				return prompts;
+			})(),
 			chatViewLocation: enumVal(
 				raw.chatViewLocation,
 				[
@@ -1504,5 +1644,81 @@ export default class AgentClientPlugin extends Plugin {
 			}
 		}
 		return Array.from(ids);
+	}
+}
+
+class QuickPromptSuggestModal extends SuggestModal<QuickPrompt> {
+	constructor(
+		app: App,
+		private plugin: AgentClientPlugin,
+		private onChoose: (prompt: QuickPrompt) => void,
+	) {
+		super(app);
+		this.setPlaceholder("Choose a quick prompt");
+	}
+
+	getSuggestions(query: string): QuickPrompt[] {
+		const needle = query.trim().toLowerCase();
+		const prompts = this.plugin.getQuickPrompts();
+		if (!needle) return prompts;
+		return prompts.filter((prompt) => {
+			return (
+				prompt.name.toLowerCase().includes(needle) ||
+				prompt.prompt.toLowerCase().includes(needle)
+			);
+		});
+	}
+
+	renderSuggestion(prompt: QuickPrompt, el: HTMLElement): void {
+		const row = el.createDiv({
+			cls: "agent-client-quick-prompt-suggestion",
+		});
+		this.renderPromptIcon(row, prompt);
+
+		const text = row.createDiv({
+			cls: "agent-client-quick-prompt-suggestion-text",
+		});
+		text.createDiv({
+			cls: "agent-client-quick-prompt-suggestion-name",
+			text: prompt.name,
+		});
+		text.createDiv({
+			cls: "agent-client-quick-prompt-suggestion-preview",
+			text:
+				prompt.prompt.length > 80
+					? prompt.prompt.slice(0, 80) + "\u2026"
+					: prompt.prompt,
+		});
+	}
+
+	/**
+	 * Render the prompt icon (Lucide id or image) into the row, mirroring the
+	 * chat-input chip. Falls back to "sparkles" when unset or unresolvable.
+	 */
+	private renderPromptIcon(parent: HTMLElement, prompt: QuickPrompt): void {
+		const classified = classifyIconRef(prompt.icon);
+
+		if (classified?.kind === "image") {
+			const src = resolveImageSrc(this.plugin, classified.value);
+			if (src) {
+				parent.createEl("img", {
+					cls: "agent-client-quick-prompt-suggestion-image",
+					attr: { src, alt: "" },
+				});
+				return;
+			}
+		}
+
+		const iconEl = parent.createSpan({
+			cls: "agent-client-quick-prompt-suggestion-icon",
+		});
+		setIcon(
+			iconEl,
+			classified?.kind === "lucide" ? classified.value : "sparkles",
+		);
+	}
+
+	onChooseSuggestion(prompt: QuickPrompt): void {
+		this.onChoose(prompt);
 	}
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -146,6 +146,8 @@ export interface AgentClientPluginSettings {
 	// Input behavior
 	sendMessageShortcut: SendMessageShortcut;
 	showQuickPromptsInChat: boolean;
+	showRecentChatsInChat: boolean;
+	showAgentImagesInChatInterfaces: boolean;
 	quickPrompts: QuickPrompt[];
 	// View settings
 	chatViewLocation: ChatViewLocation;
@@ -225,6 +227,8 @@ const DEFAULT_SETTINGS: AgentClientPluginSettings = {
 	windowsWslDistribution: undefined,
 	sendMessageShortcut: "enter",
 	showQuickPromptsInChat: true,
+	showRecentChatsInChat: false,
+	showAgentImagesInChatInterfaces: true,
 	quickPrompts: [],
 	chatViewLocation: "right-tab",
 	displaySettings: {
@@ -329,6 +333,17 @@ export default class AgentClientPlugin extends Plugin {
 			name: "Open session manager",
 			callback: () => {
 				void this.activateSessionManager();
+			},
+		});
+
+		this.addCommand({
+			id: "open-new-side-chat-view",
+			name: "Open new side chat view",
+			callback: () => {
+				void this.openNewChatViewWithAgent(
+					this.settings.defaultAgentId,
+					"right-tab",
+				);
 			},
 		});
 
@@ -1368,6 +1383,14 @@ export default class AgentClientPlugin extends Plugin {
 			showQuickPromptsInChat: bool(
 				raw.showQuickPromptsInChat,
 				D.showQuickPromptsInChat,
+			),
+			showRecentChatsInChat: bool(
+				raw.showRecentChatsInChat,
+				D.showRecentChatsInChat,
+			),
+			showAgentImagesInChatInterfaces: bool(
+				raw.showAgentImagesInChatInterfaces,
+				D.showAgentImagesInChatInterfaces,
 			),
 			quickPrompts: (() => {
 				if (!Array.isArray(raw.quickPrompts)) return D.quickPrompts;

--- a/src/services/settings-normalizer.ts
+++ b/src/services/settings-normalizer.ts
@@ -128,6 +128,12 @@ export const normalizeCustomAgent = (
 		agent.displayName.trim().length > 0
 			? agent.displayName.trim()
 			: rawId;
+	const rawAvatar =
+		agent &&
+		typeof agent.avatarImage === "string" &&
+		agent.avatarImage.trim().length > 0
+			? agent.avatarImage.trim()
+			: undefined;
 	return {
 		id: rawId,
 		displayName: rawDisplayName,
@@ -139,6 +145,7 @@ export const normalizeCustomAgent = (
 				: "",
 		args: sanitizeArgs(agent?.args),
 		env: normalizeEnvVars(agent?.env),
+		avatarImage: rawAvatar,
 	};
 };
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -51,6 +51,12 @@ export interface BaseAgentSettings {
 
 	/** Environment variables for the agent process */
 	env: AgentEnvVar[];
+
+	/**
+	 * Per-agent avatar image used by embedded chat and quick-prompt buttons.
+	 * Accepts an http(s) URL, a data URL, or a vault-relative path.
+	 */
+	avatarImage?: string;
 }
 
 /**

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -593,6 +593,8 @@ export interface SavedSessionInfo {
 	cwd: string;
 	/** Human-readable session title (first 50 chars of first user message) */
 	title?: string;
+	/** Note path that owns a persistent embedded chat session. */
+	sourcePath?: string;
 	/** ISO 8601 timestamp of session creation */
 	createdAt: string;
 	/** ISO 8601 timestamp of last activity */

--- a/src/ui/AgentButtonBlock.tsx
+++ b/src/ui/AgentButtonBlock.tsx
@@ -48,11 +48,18 @@ function AgentButtonBlockComponent({
 	}, [plugin, config.agent, quickPrompt?.agentId]);
 
 	const avatarSrc = useMemo(() => {
+		if (!plugin.settings.showAgentImagesInChatInterfaces) return null;
+		if (config.showImage === false) return null;
 		return resolveImageSrc(
 			plugin,
 			getAgentAvatarImage(plugin, resolvedAgentId),
 		);
-	}, [plugin, resolvedAgentId]);
+	}, [
+		plugin,
+		resolvedAgentId,
+		config.showImage,
+		plugin.settings.showAgentImagesInChatInterfaces,
+	]);
 
 	const handleClick = useCallback(async () => {
 		const promptText = config.prompt ?? quickPrompt?.prompt;

--- a/src/ui/AgentButtonBlock.tsx
+++ b/src/ui/AgentButtonBlock.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-const { useCallback, useMemo } = React;
+const { useCallback, useMemo, useState } = React;
 import { createRoot, type Root } from "react-dom/client";
 import { Notice } from "obsidian";
 
@@ -35,9 +35,17 @@ function AgentButtonBlockComponent({
 	config,
 	mountCtx,
 }: AgentButtonBlockProps) {
+	// Whether this rendered button has been clicked. Used to hide it when
+	// hideAfterClick is set; resets when the note is re-rendered.
+	const [dismissed, setDismissed] = useState(false);
+
+	const quickPrompt = useMemo(() => {
+		return plugin.findQuickPrompt(config.promptName);
+	}, [plugin, config.promptName]);
+
 	const resolvedAgentId = useMemo(() => {
-		return resolveAgentId(plugin, config.agent);
-	}, [plugin, config.agent]);
+		return resolveAgentId(plugin, config.agent ?? quickPrompt?.agentId);
+	}, [plugin, config.agent, quickPrompt?.agentId]);
 
 	const avatarSrc = useMemo(() => {
 		return resolveImageSrc(
@@ -47,23 +55,48 @@ function AgentButtonBlockComponent({
 	}, [plugin, resolvedAgentId]);
 
 	const handleClick = useCallback(async () => {
+		const promptText = config.prompt ?? quickPrompt?.prompt;
+		if (!promptText) {
+			new Notice(
+				config.promptName
+					? `Quick prompt "${config.promptName}" was not found.`
+					: "Button block has no prompt.",
+			);
+			return;
+		}
+
 		try {
+			if (quickPrompt && !config.prompt) {
+				await plugin.incrementQuickPromptUsage(quickPrompt.name);
+			}
 			await plugin.runPromptInChat({
 				agentId: resolvedAgentId,
-				prompt: config.prompt,
+				prompt: promptText,
 				autoSend: config.autoSend ?? false,
 				viewType: config.viewType ?? "right-pane",
 				sourcePath: mountCtx.sourcePath,
 				lineStart: mountCtx.lineStart,
 			});
+
+			// Hide the button after a successful click when requested. The
+			// YAML field wins; otherwise fall back to the quick prompt's setting.
+			const shouldHide =
+				config.hideAfterClick ?? quickPrompt?.hideAfterClick ?? false;
+			if (shouldHide) {
+				setDismissed(true);
+			}
 		} catch (error) {
 			console.error("[Agent Client] runPromptInChat failed:", error);
 			new Notice("Failed to open chat with prompt.");
 		}
-	}, [plugin, resolvedAgentId, config]);
+	}, [plugin, resolvedAgentId, config, quickPrompt, mountCtx]);
+
+	if (dismissed) return null;
 
 	return (
-		<div className="agent-client-button-block">
+		<div
+			className={`agent-client-button-block agent-client-button-block-align-${config.align ?? "left"}`}
+		>
 			<button
 				type="button"
 				className="agent-client-button-block-button mod-cta"

--- a/src/ui/AgentButtonBlock.tsx
+++ b/src/ui/AgentButtonBlock.tsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+const { useCallback, useMemo } = React;
+import { createRoot, type Root } from "react-dom/client";
+import { Notice } from "obsidian";
+
+import type AgentClientPlugin from "../plugin";
+import {
+	getAgentAvatarImage,
+	resolveImageSrc,
+} from "../utils/resolve-image-src";
+import type { AgentButtonBlockConfig } from "../utils/agent-block-parser";
+
+interface AgentButtonBlockProps {
+	plugin: AgentClientPlugin;
+	config: AgentButtonBlockConfig;
+	mountCtx: AgentButtonMountContext;
+}
+
+export interface AgentButtonMountContext {
+	sourcePath: string;
+	lineStart: number;
+}
+
+function resolveAgentId(
+	plugin: AgentClientPlugin,
+	preferred: string | undefined,
+): string {
+	const available = plugin.getAvailableAgents().map((a) => a.id);
+	if (preferred && available.includes(preferred)) return preferred;
+	return plugin.settings.defaultAgentId;
+}
+
+function AgentButtonBlockComponent({
+	plugin,
+	config,
+	mountCtx,
+}: AgentButtonBlockProps) {
+	const resolvedAgentId = useMemo(() => {
+		return resolveAgentId(plugin, config.agent);
+	}, [plugin, config.agent]);
+
+	const avatarSrc = useMemo(() => {
+		return resolveImageSrc(
+			plugin,
+			getAgentAvatarImage(plugin, resolvedAgentId),
+		);
+	}, [plugin, resolvedAgentId]);
+
+	const handleClick = useCallback(async () => {
+		try {
+			await plugin.runPromptInChat({
+				agentId: resolvedAgentId,
+				prompt: config.prompt,
+				autoSend: config.autoSend ?? false,
+				viewType: config.viewType ?? "right-pane",
+				sourcePath: mountCtx.sourcePath,
+				lineStart: mountCtx.lineStart,
+			});
+		} catch (error) {
+			console.error("[Agent Client] runPromptInChat failed:", error);
+			new Notice("Failed to open chat with prompt.");
+		}
+	}, [plugin, resolvedAgentId, config]);
+
+	return (
+		<div className="agent-client-button-block">
+			<button
+				type="button"
+				className="agent-client-button-block-button mod-cta"
+				onClick={() => void handleClick()}
+			>
+				{avatarSrc && (
+					<img
+						src={avatarSrc}
+						alt=""
+						className="agent-client-button-block-avatar"
+					/>
+				)}
+				<span className="agent-client-button-block-text">
+					{config.text}
+				</span>
+			</button>
+		</div>
+	);
+}
+
+export function mountAgentButtonBlock(
+	plugin: AgentClientPlugin,
+	el: HTMLElement,
+	config: AgentButtonBlockConfig,
+	mountCtx: AgentButtonMountContext,
+): Root {
+	const container = el.createDiv();
+	const root = createRoot(container);
+	root.render(
+		<AgentButtonBlockComponent
+			plugin={plugin}
+			config={config}
+			mountCtx={mountCtx}
+		/>,
+	);
+	return root;
+}

--- a/src/ui/ChatHeader.tsx
+++ b/src/ui/ChatHeader.tsx
@@ -1,8 +1,14 @@
 import * as React from "react";
-const { useRef, useEffect } = React;
-import { setIcon, DropdownComponent } from "obsidian";
+const { useRef, useEffect, useMemo } = React;
+import { setIcon } from "obsidian";
 import { HeaderButton } from "./shared/IconButton";
 import type { AgentDisplayInfo } from "../services/session-helpers";
+import type AgentClientPlugin from "../plugin";
+import {
+	AgentAvatar,
+	getResolvedAgentAvatarSrc,
+} from "./shared/AgentAvatar";
+import { ImageSelect, type ImageSelectOption } from "./shared/ImageSelect";
 
 // ============================================================================
 // Props Types
@@ -15,6 +21,10 @@ export interface SidebarHeaderProps {
 	variant: "sidebar";
 	/** Display name of the active agent */
 	agentLabel: string;
+	/** Active agent ID */
+	agentId: string;
+	/** Plugin instance for resolving configured agent images */
+	plugin: AgentClientPlugin;
 	/** Whether a plugin update is available */
 	isUpdateAvailable: boolean;
 	/** Callback to create a new chat session */
@@ -34,6 +44,8 @@ export interface FloatingHeaderProps {
 	variant: "floating";
 	/** Display name of the active agent */
 	agentLabel: string;
+	/** Plugin instance for resolving configured agent images */
+	plugin: AgentClientPlugin;
 	/** Available agents for switching */
 	availableAgents: AgentDisplayInfo[];
 	/** Current agent ID */
@@ -90,6 +102,55 @@ function NavActionButton({
 	);
 }
 
+function AgentSelector({
+	agentLabel,
+	plugin,
+	availableAgents,
+	currentAgentId,
+	onAgentChange,
+}: {
+	agentLabel: string;
+	plugin: AgentClientPlugin;
+	availableAgents: AgentDisplayInfo[];
+	currentAgentId: string;
+	onAgentChange: (agentId: string) => void;
+}) {
+	const agentOptions = useMemo<ImageSelectOption[]>(
+		() =>
+			availableAgents.map((agent) => ({
+				value: agent.id,
+				label: agent.displayName,
+				imageSrc: getResolvedAgentAvatarSrc(plugin, agent.id),
+			})),
+		[availableAgents, plugin],
+	);
+
+	if (availableAgents.length > 1) {
+		return (
+			<div className="agent-client-agent-selector">
+				<ImageSelect
+					options={agentOptions}
+					value={currentAgentId}
+					onChange={onAgentChange}
+					className="agent-client-agent-image-select"
+					placeholder={agentLabel}
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<span className="agent-client-agent-label">
+			<AgentAvatar
+				plugin={plugin}
+				agentId={currentAgentId}
+				className="agent-client-header-agent-avatar"
+			/>
+			{agentLabel}
+		</span>
+	);
+}
+
 // ============================================================================
 // Sidebar Header
 // ============================================================================
@@ -102,6 +163,8 @@ function NavActionButton({
  */
 function SidebarHeader({
 	agentLabel,
+	agentId,
+	plugin,
 	isUpdateAvailable,
 	onNewChat,
 	onExportChat,
@@ -112,6 +175,11 @@ function SidebarHeader({
 		<div className="nav-header agent-client-chat-view-header">
 			<div className="nav-buttons-container">
 				<span className="agent-client-chat-view-header-title">
+					<AgentAvatar
+						plugin={plugin}
+						agentId={agentId}
+						className="agent-client-header-agent-avatar"
+					/>
 					{agentLabel}
 				</span>
 				{isUpdateAvailable && (
@@ -161,6 +229,7 @@ function SidebarHeader({
  */
 function FloatingHeader({
 	agentLabel,
+	plugin,
 	availableAgents,
 	currentAgentId,
 	isUpdateAvailable,
@@ -169,85 +238,18 @@ function FloatingHeader({
 	onMinimize,
 	onClose,
 }: FloatingHeaderProps) {
-	// Refs for agent dropdown
-	const agentDropdownRef = useRef<HTMLDivElement>(null);
-	const agentDropdownInstance = useRef<DropdownComponent | null>(null);
-
-	// Stable ref for onAgentChange callback
-	const onAgentChangeRef = useRef(onAgentChange);
-	onAgentChangeRef.current = onAgentChange;
-
-	// Initialize agent dropdown
-	useEffect(() => {
-		const containerEl = agentDropdownRef.current;
-		if (!containerEl) return;
-
-		// Only show dropdown if there are multiple agents
-		if (availableAgents.length <= 1) {
-			if (agentDropdownInstance.current) {
-				containerEl.empty();
-				agentDropdownInstance.current = null;
-			}
-			return;
-		}
-
-		// Create dropdown if not exists
-		if (!agentDropdownInstance.current) {
-			const dropdown = new DropdownComponent(containerEl);
-			agentDropdownInstance.current = dropdown;
-
-			// Add options
-			for (const agent of availableAgents) {
-				dropdown.addOption(agent.id, agent.displayName);
-			}
-
-			// Set initial value
-			if (currentAgentId) {
-				dropdown.setValue(currentAgentId);
-			}
-
-			// Handle change
-			dropdown.onChange((value) => {
-				onAgentChangeRef.current?.(value);
-			});
-		}
-
-		// Cleanup on unmount or when availableAgents change
-		return () => {
-			if (agentDropdownInstance.current) {
-				containerEl.empty();
-				agentDropdownInstance.current = null;
-			}
-		};
-	}, [availableAgents]);
-
-	// Update dropdown value when currentAgentId changes
-	useEffect(() => {
-		if (agentDropdownInstance.current && currentAgentId) {
-			agentDropdownInstance.current.setValue(currentAgentId);
-		}
-	}, [currentAgentId]);
-
 	return (
 		<div
 			className={`agent-client-inline-header agent-client-inline-header-floating`}
 		>
 			<div className="agent-client-inline-header-main">
-				{availableAgents.length > 1 ? (
-					<div className="agent-client-agent-selector">
-						<div ref={agentDropdownRef} />
-						<span
-							className="agent-client-agent-selector-icon"
-							ref={(el) => {
-								if (el) setIcon(el, "chevron-down");
-							}}
-						/>
-					</div>
-				) : (
-					<span className="agent-client-agent-label">
-						{agentLabel}
-					</span>
-				)}
+				<AgentSelector
+					agentLabel={agentLabel}
+					plugin={plugin}
+					availableAgents={availableAgents}
+					currentAgentId={currentAgentId}
+					onAgentChange={onAgentChange}
+				/>
 			</div>
 			{isUpdateAvailable && (
 				<p className="agent-client-chat-view-header-update">

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -93,7 +93,7 @@ export interface ChatPanelProps {
 		sourcePath?: string;
 	};
 	onRegisterCallbacks?: (callbacks: ChatPanelCallbacks) => void;
-	/** Called when agent ID changes (sidebar only — persists in Obsidian state) */
+	/** Called when agent ID changes (sidebar only; persists in Obsidian state) */
 	onAgentIdChanged?: (agentId: string) => void;
 	/**
 	 * Called when the derived session title may have changed (sidebar only —
@@ -181,7 +181,7 @@ export function ChatPanel({
 		return process.cwd();
 	}, [plugin, workingDirectory]);
 
-	// Agent working directory — defaults to vault path.
+	// Agent working directory; defaults to vault path.
 	// Can be changed independently via "New chat in directory..." action.
 	const [agentCwd, setAgentCwd] = useState(vaultPath);
 
@@ -387,6 +387,17 @@ export function ChatPanel({
 			return handleSendMessage(content, attachments);
 		},
 		[handleSendMessage],
+	);
+
+	// Switch the view to a quick-prompt's assigned agent (fresh chat) and then
+	// auto-send the prompt once the new session is ready, reusing the same
+	// pending-auto-send drain as `agent-client:run-prompt`.
+	const handleSwitchAgentAndRun = useCallback(
+		async (nextAgentId: string, prompt: string) => {
+			await handleSwitchAgent(nextAgentId);
+			setPendingAutoSend(prompt);
+		},
+		[handleSwitchAgent],
 	);
 
 	const { handleOpenHistory } = useHistoryModal(
@@ -1319,6 +1330,7 @@ export function ChatPanel({
 			usage={session.usage}
 			supportsImages={session.promptCapabilities?.image ?? false}
 			agentId={session.agentId}
+			onSwitchAgentAndRun={handleSwitchAgentAndRun}
 			// Controlled component props (for broadcast commands)
 			inputValue={inputValue}
 			onInputChange={setInputValue}

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -41,6 +41,7 @@ import {
 	type SessionModeState,
 	type SessionModelState,
 	type SessionConfigOption,
+	type SessionInfo,
 } from "../types/session";
 import { checkAgentUpdate } from "../services/update-checker";
 import type { SessionStatus } from "../services/view-registry";
@@ -267,6 +268,18 @@ export function ChatPanel({
 		onClearMessages: agent.clearMessages,
 	});
 
+	useEffect(() => {
+		if (!settings.showRecentChatsInChat) return;
+		if (!isSessionReady || messages.length > 0) return;
+		void sessionHistory.fetchSessions(vaultPath);
+	}, [
+		settings.showRecentChatsInChat,
+		isSessionReady,
+		messages.length,
+		sessionHistory.fetchSessions,
+		vaultPath,
+	]);
+
 	// ============================================================
 	// Local State
 	// ============================================================
@@ -408,6 +421,27 @@ export function ChatPanel({
 		isSessionReady,
 		settings.debugMode,
 		setAgentCwd,
+	);
+
+	const recentChatSessions = useMemo<SessionInfo[]>(() => {
+		if (!settings.showRecentChatsInChat) return [];
+		if (messages.length > 0) return [];
+		return sessionHistory.sessions
+			.filter((item) => item.sessionId !== session.sessionId)
+			.slice(0, 5);
+	}, [
+		settings.showRecentChatsInChat,
+		messages.length,
+		sessionHistory.sessions,
+		session.sessionId,
+	]);
+
+	const handleRestoreRecentSession = useCallback(
+		async (sessionId: string, cwd: string) => {
+			setInputValue("");
+			await sessionHistory.restoreSession(sessionId, cwd);
+		},
+		[sessionHistory.restoreSession],
 	);
 
 	// ============================================================
@@ -1256,6 +1290,8 @@ export function ChatPanel({
 			<ChatHeader
 				variant="sidebar"
 				agentLabel={activeAgentLabel}
+				agentId={session.agentId}
+				plugin={plugin}
 				isUpdateAvailable={isUpdateAvailable}
 				onNewChat={() => void handleNewChatWithPersist()}
 				onExportChat={() => void handleExportChat()}
@@ -1266,6 +1302,7 @@ export function ChatPanel({
 			<ChatHeader
 				variant="floating"
 				agentLabel={activeAgentLabel}
+				plugin={plugin}
 				availableAgents={shouldShowAgentSelector ? availableAgents : []}
 				currentAgentId={session.agentId}
 				isUpdateAvailable={isUpdateAvailable}
@@ -1346,6 +1383,12 @@ export function ChatPanel({
 			geminiNotice={effectiveGeminiNotice}
 			onClearGeminiNotice={handleClearGeminiNotice}
 			messages={messages}
+			recentChatSessions={recentChatSessions}
+			onRestoreRecentSession={
+				sessionHistory.canRestore
+					? handleRestoreRecentSession
+					: undefined
+			}
 		/>
 	);
 

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -6,10 +6,12 @@ import {
 	Platform,
 	Menu,
 	setIcon,
+	TFile,
 	type MenuItem,
 } from "obsidian";
 
 import type { AttachedFile, ChatInputState } from "../types/chat";
+import type { NoteMetadata } from "../services/vault-service";
 import { isSameDirectory } from "../utils/platform";
 import { computeSessionTitle } from "../services/session-helpers";
 import { useHistoryModal } from "../hooks/useHistoryModal";
@@ -79,11 +81,17 @@ export interface ChatPanelCallbacks {
 // ============================================================================
 
 export interface ChatPanelProps {
-	variant: "sidebar" | "floating";
+	variant: "sidebar" | "floating" | "embedded";
 	viewId: string;
 	workingDirectory?: string;
 	initialAgentId?: string;
-	config?: { agent?: string; model?: string };
+	config?: {
+		agent?: string;
+		model?: string;
+		persist?: boolean;
+		noteContext?: "hosting";
+		sourcePath?: string;
+	};
 	onRegisterCallbacks?: (callbacks: ChatPanelCallbacks) => void;
 	/** Called when agent ID changes (sidebar only — persists in Obsidian state) */
 	onAgentIdChanged?: (agentId: string) => void;
@@ -198,11 +206,27 @@ export function ChatPanel({
 		errorInfo,
 	} = agent;
 
+	const pinnedActiveNote = useMemo<NoteMetadata | null>(() => {
+		if (config?.noteContext !== "hosting" || !config.sourcePath) {
+			return null;
+		}
+		const file = plugin.app.vault.getAbstractFileByPath(config.sourcePath);
+		if (!(file instanceof TFile)) return null;
+		return {
+			path: file.path,
+			name: file.basename,
+			extension: file.extension,
+			created: file.stat.ctime,
+			modified: file.stat.mtime,
+		};
+	}, [plugin, config?.noteContext, config?.sourcePath]);
+
 	const suggestions = useSuggestions(
 		vaultService,
 		plugin,
 		session.availableCommands || EMPTY_COMMANDS,
 		settings.autoMentionActiveNote,
+		pinnedActiveNote,
 	);
 
 	// Session history hook with callback for session load
@@ -252,6 +276,10 @@ export function ChatPanel({
 	const [inputValue, setInputValue] = useState("");
 	const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>([]);
 
+	// Pending auto-send queued by `agent-client:run-prompt` (drained when ready)
+	const [pendingAutoSend, setPendingAutoSend] = useState<string | null>(null);
+	const persistRestoreAttemptedRef = useRef(false);
+
 	// ============================================================
 	// Refs
 	// ============================================================
@@ -299,6 +327,7 @@ export function ChatPanel({
 		messages,
 		settings,
 		vaultPath,
+		config?.persist ? config.sourcePath : undefined,
 	);
 
 	const {
@@ -636,14 +665,14 @@ export function ChatPanel({
 		// Floating: create a shim with listener tracking
 		return {
 			app: plugin.app,
-			registerDomEvent: ((
+			registerDomEvent: (
 				target: Window | Document | HTMLElement,
 				type: string,
 				callback: EventListenerOrEventListenerObject,
 			) => {
 				target.addEventListener(type, callback);
 				registeredListenersRef.current.push({ target, type, callback });
-			}),
+			},
 		};
 	}, [viewHostProp, plugin.app]);
 
@@ -669,6 +698,35 @@ export function ChatPanel({
 		logger.log("[Debug] Starting connection setup via useSession...");
 		void agent.createSession(config?.agent || initialAgentId);
 	}, [agent.createSession, config?.agent, initialAgentId]);
+
+	useEffect(() => {
+		if (variant !== "embedded") return;
+		if (!config?.persist || !config.sourcePath) return;
+		if (!isSessionReady || !session.sessionId || !session.agentId) return;
+		if (!sessionHistory.canRestore) return;
+		if (persistRestoreAttemptedRef.current) return;
+		persistRestoreAttemptedRef.current = true;
+
+		const savedSession = plugin.settingsService
+			.getSavedSessions(session.agentId, agentCwd)
+			.find((item) => item.sourcePath === config.sourcePath);
+		if (!savedSession || savedSession.sessionId === session.sessionId) {
+			return;
+		}
+
+		void sessionHistory.restoreSession(savedSession.sessionId, agentCwd);
+	}, [
+		variant,
+		config?.persist,
+		config?.sourcePath,
+		isSessionReady,
+		session.sessionId,
+		session.agentId,
+		sessionHistory.canRestore,
+		sessionHistory.restoreSession,
+		plugin.settingsService,
+		agentCwd,
+	]);
 
 	// Apply configured model when session is ready
 	useEffect(() => {
@@ -793,7 +851,10 @@ export function ChatPanel({
 			);
 
 			// System notification on response completion
-			if (settings.enableSystemNotifications && !activeDocument.hasFocus()) {
+			if (
+				settings.enableSystemNotifications &&
+				!activeDocument.hasFocus()
+			) {
 				new Notification("Agent Client", {
 					body: `${activeAgentLabel} has completed the response.`,
 				});
@@ -990,6 +1051,27 @@ export function ChatPanel({
 				if (targetViewId && targetViewId !== viewId) return;
 				void handleExportChatRef.current();
 			}),
+
+			// Run prompt injected by quick-action button or code block.
+			// `targetViewId` filter: null/empty matches any view (used when the
+			// caller created the leaf via openNewChatViewWithAgent and cannot
+			// know the new viewId synchronously).
+			ws.on(
+				"agent-client:run-prompt",
+				(
+					targetViewId: string | null,
+					prompt: string,
+					autoSend?: boolean,
+				) => {
+					if (targetViewId && targetViewId !== viewId) return;
+					if (typeof prompt !== "string" || prompt.length === 0)
+						return;
+					setInputValue(prompt);
+					if (autoSend) {
+						setPendingAutoSend(prompt);
+					}
+				},
+			),
 		];
 
 		return () => {
@@ -1003,6 +1085,27 @@ export function ChatPanel({
 		viewId,
 		variant,
 		suggestions.mentions.toggleAutoMention,
+	]);
+
+	// ============================================================
+	// Effects - Drain pending auto-send when session becomes ready
+	// ============================================================
+	useEffect(() => {
+		if (!pendingAutoSend) return;
+		if (!isSessionReady) return;
+		if (isSending) return;
+		if (sessionHistory.loading) return;
+
+		const prompt = pendingAutoSend;
+		setPendingAutoSend(null);
+		setInputValue("");
+		void handleSendMessage(prompt);
+	}, [
+		pendingAutoSend,
+		isSessionReady,
+		isSending,
+		sessionHistory.loading,
+		handleSendMessage,
 	]);
 
 	// ============================================================
@@ -1135,6 +1238,8 @@ export function ChatPanel({
 				} as React.CSSProperties)
 			: undefined;
 
+	const shouldShowAgentSelector = variant !== "embedded" || !config?.agent;
+
 	const headerElement =
 		variant === "sidebar" ? (
 			<ChatHeader
@@ -1150,7 +1255,7 @@ export function ChatPanel({
 			<ChatHeader
 				variant="floating"
 				agentLabel={activeAgentLabel}
-				availableAgents={availableAgents}
+				availableAgents={shouldShowAgentSelector ? availableAgents : []}
 				currentAgentId={session.agentId}
 				isUpdateAvailable={isUpdateAvailable}
 				onAgentChange={(agentId) => void handleSwitchAgent(agentId)}
@@ -1251,6 +1356,25 @@ export function ChatPanel({
 					{inputAreaElement}
 				</div>
 			</>
+		);
+	}
+
+	if (variant === "embedded") {
+		return (
+			<div
+				ref={containerRef}
+				className="agent-client-chat-view-container agent-client-embedded-chat-panel"
+				style={chatFontSizeStyle}
+			>
+				<div className="agent-client-embedded-header">
+					{headerElement}
+				</div>
+				{cwdBanner}
+				<div className="agent-client-embedded-messages-container">
+					{messageListElement}
+				</div>
+				{inputAreaElement}
+			</div>
 		);
 	}
 

--- a/src/ui/CodeBlockChatView.tsx
+++ b/src/ui/CodeBlockChatView.tsx
@@ -1,0 +1,124 @@
+import * as React from "react";
+const { useEffect, useMemo } = React;
+import { createRoot, type Root } from "react-dom/client";
+
+import type AgentClientPlugin from "../plugin";
+import { ChatContextProvider } from "./ChatContext";
+import { ChatPanel } from "./ChatPanel";
+import { VaultService } from "../services/vault-service";
+import {
+	getAgentAvatarImage,
+	resolveImageSrc,
+} from "../utils/resolve-image-src";
+import type { AgentChatBlockConfig } from "../utils/agent-block-parser";
+
+export interface CodeBlockMountContext {
+	sourcePath: string;
+	blockId: string;
+	lineStart: number;
+}
+
+interface CodeBlockChatProps {
+	plugin: AgentClientPlugin;
+	config: AgentChatBlockConfig;
+	mountCtx: CodeBlockMountContext;
+}
+
+function CodeBlockChatComponent({
+	plugin,
+	config,
+	mountCtx,
+}: CodeBlockChatProps) {
+	const viewId = `code-block:${mountCtx.blockId}`;
+
+	const acpClient = useMemo(
+		() => plugin.getOrCreateAcpClient(viewId),
+		[plugin, viewId],
+	);
+
+	const vaultService = useMemo(() => new VaultService(plugin), [plugin]);
+
+	useEffect(() => {
+		const unregisterEmbeddedChat = plugin.registerEmbeddedChat({
+			viewId,
+			sourcePath: mountCtx.sourcePath,
+			lineStart: mountCtx.lineStart,
+		});
+		return () => {
+			unregisterEmbeddedChat();
+			vaultService.destroy();
+			void plugin.removeAcpClient(viewId);
+		};
+	}, [plugin, viewId, vaultService, mountCtx.sourcePath, mountCtx.lineStart]);
+
+	const contextValue = useMemo(
+		() => ({
+			plugin,
+			acpClient,
+			vaultService,
+			settingsService: plugin.settingsService,
+		}),
+		[plugin, acpClient, vaultService],
+	);
+
+	const avatarSrc = useMemo(() => {
+		return (
+			resolveImageSrc(plugin, config.image) ??
+			resolveImageSrc(
+				plugin,
+				getAgentAvatarImage(plugin, config.agent),
+			) ??
+			resolveImageSrc(plugin, plugin.settings.floatingButtonImage)
+		);
+	}, [plugin, config.image, config.agent]);
+
+	const heightStyle = config.height
+		? ({ "--ac-embedded-max-height": config.height } as React.CSSProperties)
+		: undefined;
+
+	return (
+		<div className="agent-client-code-block-chat" style={heightStyle}>
+			{avatarSrc && (
+				<div className="agent-client-code-block-chat-avatar-row">
+					<img
+						src={avatarSrc}
+						alt=""
+						className="agent-client-code-block-chat-avatar"
+					/>
+				</div>
+			)}
+			<ChatContextProvider value={contextValue}>
+				<ChatPanel
+					variant="embedded"
+					viewId={viewId}
+					initialAgentId={config.agent}
+					config={{
+						agent: config.agent,
+						model: config.model,
+						persist: config.persist,
+						noteContext: config.noteContext,
+						sourcePath: mountCtx.sourcePath,
+					}}
+				/>
+			</ChatContextProvider>
+		</div>
+	);
+}
+
+export function mountCodeBlockChat(
+	plugin: AgentClientPlugin,
+	el: HTMLElement,
+	config: AgentChatBlockConfig,
+	mountCtx: CodeBlockMountContext,
+): Root {
+	const container = el.createDiv({ cls: "agent-client-code-block-host" });
+	const root = createRoot(container);
+	root.render(
+		<CodeBlockChatComponent
+			plugin={plugin}
+			config={config}
+			mountCtx={mountCtx}
+		/>,
+	);
+	return root;
+}

--- a/src/ui/CodeBlockChatView.tsx
+++ b/src/ui/CodeBlockChatView.tsx
@@ -62,6 +62,8 @@ function CodeBlockChatComponent({
 	);
 
 	const avatarSrc = useMemo(() => {
+		if (!plugin.settings.showAgentImagesInChatInterfaces) return null;
+		if (config.showImage === false) return null;
 		return (
 			resolveImageSrc(plugin, config.image) ??
 			resolveImageSrc(
@@ -70,7 +72,13 @@ function CodeBlockChatComponent({
 			) ??
 			resolveImageSrc(plugin, plugin.settings.floatingButtonImage)
 		);
-	}, [plugin, config.image, config.agent]);
+	}, [
+		plugin,
+		config.image,
+		config.agent,
+		config.showImage,
+		plugin.settings.showAgentImagesInChatInterfaces,
+	]);
 
 	const heightStyle = config.height
 		? ({ "--ac-embedded-max-height": config.height } as React.CSSProperties)

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -3,6 +3,7 @@ const { useRef, useState, useEffect, useCallback, useMemo } = React;
 import { setIcon, Notice } from "obsidian";
 
 import type AgentClientPlugin from "../plugin";
+import type { QuickPrompt } from "../plugin";
 import type { IChatViewHost } from "./view-host";
 import type { NoteMetadata } from "../services/vault-service";
 import type {
@@ -19,6 +20,7 @@ import { ErrorBanner } from "./ErrorBanner";
 import { AttachmentStrip } from "./shared/AttachmentStrip";
 import { InputToolbar } from "./InputToolbar";
 import { getLogger } from "../utils/logger";
+import { classifyIconRef, resolveImageSrc } from "../utils/resolve-image-src";
 import type { ErrorInfo } from "../types/errors";
 import type { AgentUpdateNotification } from "../services/update-checker";
 import { useSettings } from "../hooks/useSettings";
@@ -175,6 +177,49 @@ function useInputHistory(
 }
 
 // ============================================================================
+// Quick Prompt Chip Icon
+// ============================================================================
+
+/**
+ * Renders a quick-prompt chip icon: an <img> when the configured icon is an
+ * image reference, otherwise a Lucide icon. Falls back to "sparkles" when the
+ * icon is unset or an image reference cannot be resolved.
+ */
+function QuickPromptChipIcon({
+	plugin,
+	icon,
+}: {
+	plugin: AgentClientPlugin;
+	icon?: string;
+}) {
+	const classified = useMemo(() => classifyIconRef(icon), [icon]);
+
+	if (classified?.kind === "image") {
+		const src = resolveImageSrc(plugin, classified.value);
+		if (src) {
+			return (
+				<img
+					src={src}
+					alt=""
+					className="agent-client-quick-prompt-chip-image"
+				/>
+			);
+		}
+	}
+
+	const lucideName =
+		classified?.kind === "lucide" ? classified.value : "sparkles";
+	return (
+		<span
+			className="agent-client-quick-prompt-chip-icon"
+			ref={(el) => {
+				if (el) setIcon(el, lucideName);
+			}}
+		/>
+	);
+}
+
+// ============================================================================
 // InputArea Component
 // ============================================================================
 
@@ -226,6 +271,12 @@ export interface InputAreaProps {
 	supportsImages?: boolean;
 	/** Current agent ID (used to clear images on agent switch) */
 	agentId: string;
+	/**
+	 * Switch the view to `agentId` (starting a fresh chat on that agent) and
+	 * then auto-send `prompt` once the new session is ready. Used by quick
+	 * prompts that carry an assigned agent so clicking the chip honors it.
+	 */
+	onSwitchAgentAndRun?: (agentId: string, prompt: string) => Promise<void>;
 	// Controlled component props (for broadcast commands)
 	/** Current input text value */
 	inputValue: string;
@@ -286,6 +337,7 @@ export function InputArea({
 	usage,
 	supportsImages = false,
 	agentId,
+	onSwitchAgentAndRun,
 	// Controlled component props
 	inputValue,
 	onInputChange,
@@ -307,10 +359,27 @@ export function InputArea({
 	const logger = getLogger();
 	const settings = useSettings(plugin);
 	const showEmojis = plugin.settings.displaySettings.showEmojis;
+	// Quick-prompt chips dismissed by clicking (when hideAfterClick is set).
+	// View-local and non-persistent: cleared on remount / chat reopen.
+	const [dismissedQuickPrompts, setDismissedQuickPrompts] = useState<
+		Set<string>
+	>(() => new Set());
+	const quickPrompts = useMemo(() => {
+		if (!settings.showQuickPromptsInChat) return [];
+		return plugin
+			.getQuickPrompts()
+			.filter((prompt) => !dismissedQuickPrompts.has(prompt.name));
+	}, [
+		plugin,
+		settings.showQuickPromptsInChat,
+		settings.quickPrompts,
+		dismissedQuickPrompts,
+	]);
 
 	// Unofficial Obsidian API (see src/types/obsidian-internals.d.ts)
 	const obsidianSpellcheck =
-		(plugin.app.vault.getConfig("spellcheck") as boolean | undefined) ?? true;
+		(plugin.app.vault.getConfig("spellcheck") as boolean | undefined) ??
+		true;
 
 	// Local state (hint and command are still local - not needed for broadcast)
 	const [hintText, setHintText] = useState<string | null>(null);
@@ -646,6 +715,64 @@ export function InputArea({
 		[mentions, inputValue, setTextAndFocus],
 	);
 
+	const handleSelectQuickPrompt = useCallback(
+		(prompt: QuickPrompt) => {
+			void (async () => {
+				if (prompt.hideAfterClick) {
+					setDismissedQuickPrompts((prev) => {
+						const next = new Set(prev);
+						next.add(prompt.name);
+						return next;
+					});
+				}
+				await plugin.incrementQuickPromptUsage(prompt.name);
+
+				// If the prompt is assigned to a different (valid) agent, switch
+				// the view to that agent first and let it auto-send once the
+				// fresh session is ready. Mirrors the code-block/command path.
+				const targetAgentId =
+					prompt.agentId &&
+					prompt.agentId !== agentId &&
+					plugin
+						.getAvailableAgents()
+						.some((a) => a.id === prompt.agentId)
+						? prompt.agentId
+						: null;
+				if (targetAgentId && onSwitchAgentAndRun) {
+					onInputChange("");
+					await onSwitchAgentAndRun(targetAgentId, prompt.prompt);
+					return;
+				}
+
+				if (isSessionReady && !isSending && !isRestoringSession) {
+					onInputChange("");
+					await onSendMessage(prompt.prompt);
+					return;
+				}
+
+				onInputChange(prompt.prompt);
+				window.setTimeout(() => {
+					const textarea = textareaRef.current;
+					if (textarea) {
+						textarea.focus();
+						textarea.selectionStart = prompt.prompt.length;
+						textarea.selectionEnd = prompt.prompt.length;
+					}
+				}, 0);
+			})();
+		},
+		[
+			agentId,
+			isRestoringSession,
+			isSending,
+			isSessionReady,
+			onInputChange,
+			onSendMessage,
+			onSwitchAgentAndRun,
+			plugin,
+		],
+	);
+
 	/**
 	 * Handle slash command selection from dropdown.
 	 */
@@ -979,6 +1106,28 @@ export function InputArea({
 					view={view}
 					variant={geminiNotice.variant}
 				/>
+			)}
+
+			{quickPrompts.length > 0 && (
+				<div className="agent-client-quick-prompt-strip">
+					{quickPrompts.map((prompt) => (
+						<button
+							key={prompt.name}
+							type="button"
+							className="agent-client-quick-prompt-chip"
+							title={prompt.prompt}
+							onClick={() => handleSelectQuickPrompt(prompt)}
+						>
+							<QuickPromptChipIcon
+								plugin={plugin}
+								icon={prompt.icon}
+							/>
+							<span className="agent-client-quick-prompt-chip-text">
+								{prompt.name}
+							</span>
+						</button>
+					))}
+				</div>
 			)}
 
 			{/* Mention Dropdown */}

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -12,6 +12,7 @@ import type {
 	SessionModelState,
 	SessionUsage,
 	SessionConfigOption,
+	SessionInfo,
 } from "../types/session";
 import type { AttachedFile, ChatMessage } from "../types/chat";
 import type { UseSuggestionsReturn } from "../hooks/useSuggestions";
@@ -300,6 +301,10 @@ export interface InputAreaProps {
 	onClearGeminiNotice: () => void;
 	/** Messages array for input history navigation */
 	messages: ChatMessage[];
+	/** Recent chats to render as restore shortcuts on empty chats */
+	recentChatSessions?: SessionInfo[];
+	/** Restore a recent chat by session ID and cwd */
+	onRestoreRecentSession?: (sessionId: string, cwd: string) => Promise<void>;
 }
 
 /**
@@ -354,6 +359,8 @@ export function InputArea({
 	onClearGeminiNotice,
 	// Input history
 	messages,
+	recentChatSessions,
+	onRestoreRecentSession,
 }: InputAreaProps) {
 	const { mentions, commands: slashCommands } = suggestions;
 	const logger = getLogger();
@@ -773,6 +780,13 @@ export function InputArea({
 		],
 	);
 
+	const handleRestoreRecentChat = useCallback(
+		(session: SessionInfo) => {
+			void onRestoreRecentSession?.(session.sessionId, session.cwd);
+		},
+		[onRestoreRecentSession],
+	);
+
 	/**
 	 * Handle slash command selection from dropdown.
 	 */
@@ -1108,8 +1122,32 @@ export function InputArea({
 				/>
 			)}
 
-			{quickPrompts.length > 0 && (
+			{((settings.showRecentChatsInChat &&
+				recentChatSessions &&
+				recentChatSessions.length > 0) ||
+				quickPrompts.length > 0) && (
 				<div className="agent-client-quick-prompt-strip">
+					{settings.showRecentChatsInChat &&
+						recentChatSessions?.map((session) => (
+							<button
+								key={session.sessionId}
+								type="button"
+								className="agent-client-quick-prompt-chip agent-client-recent-chat-chip"
+								title={session.title ?? session.sessionId}
+								disabled={!onRestoreRecentSession}
+								onClick={() => handleRestoreRecentChat(session)}
+							>
+								<span
+									className="agent-client-quick-prompt-chip-icon"
+									ref={(el) => {
+										if (el) setIcon(el, "history");
+									}}
+								/>
+								<span className="agent-client-quick-prompt-chip-text">
+									{session.title ?? "Untitled session"}
+								</span>
+							</button>
+						))}
 					{quickPrompts.map((prompt) => (
 						<button
 							key={prompt.name}

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -1724,6 +1724,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 				"Lucide icon name (e.g. sparkles, wand-2) or an image URL / vault path. Leave blank for the default sparkles icon.",
 			)
 			.addText((text) => {
+				// eslint-disable-next-line obsidianmd/ui/sentence-case -- Lucide icon id, not UI prose
 				text.setPlaceholder("sparkles")
 					.setValue(prompt.icon ?? "")
 					.onChange(async (value) => {

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -5,12 +5,14 @@ import {
 	DropdownComponent,
 	Platform,
 	SecretComponent,
+	Notice,
 } from "obsidian";
 import type AgentClientPlugin from "../plugin";
 import type {
 	CustomAgentSettings,
 	AgentEnvVar,
 	ChatViewLocation,
+	QuickPrompt,
 } from "../plugin";
 import { resolveCommandPath, resolveCommandPathInWsl } from "../utils/paths";
 import {
@@ -116,6 +118,21 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		// ─────────────────────────────────────────────────────────────────────
 		// Mentions
 		// ─────────────────────────────────────────────────────────────────────
+
+		new Setting(containerEl)
+			.setName("Show quick prompts in chat")
+			.setDesc(
+				"Show saved quick prompts above the message box in sidebar, floating, and embedded chats.",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.showQuickPromptsInChat)
+					.onChange(async (value) => {
+						await this.plugin.settingsService.updateSettings({
+							showQuickPromptsInChat: value,
+						});
+					}),
+			);
 
 		new Setting(containerEl).setName("Mentions").setHeading();
 
@@ -434,6 +451,12 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		// ─────────────────────────────────────────────────────────────────────
 		// Permissions
 		// ─────────────────────────────────────────────────────────────────────
+
+		new Setting(containerEl).setName("Quick prompts").setHeading();
+		new Setting(containerEl).setDesc(
+			"Saved prompts can be shown in chat views, run from the command palette, or referenced from `agent-client` button blocks with `promptName:`.",
+		);
+		this.renderQuickPrompts(containerEl);
 
 		new Setting(containerEl).setName("Permissions").setHeading();
 
@@ -1559,6 +1582,186 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		}
 
 		return normalizeEnvVars(envVars);
+	}
+
+	private renderQuickPrompts(containerEl: HTMLElement): void {
+		const prompts = this.plugin.settings.quickPrompts;
+		if (prompts.length === 0) {
+			containerEl.createEl("p", {
+				cls: "setting-item-description",
+				text: "No quick prompts saved yet.",
+			});
+		} else {
+			prompts.forEach((prompt, index) => {
+				this.renderQuickPrompt(containerEl, prompt, index);
+			});
+		}
+
+		new Setting(containerEl).addButton((button) => {
+			button
+				.setButtonText("Add quick prompt")
+				.setCta()
+				.onClick(async () => {
+					const next = [
+						...this.plugin.settings.quickPrompts,
+						{
+							name: this.generateQuickPromptName(),
+							prompt: "",
+							usageCount: 0,
+						},
+					];
+					await this.plugin.settingsService.updateSettings({
+						quickPrompts: next,
+					});
+					this.display();
+				});
+		});
+	}
+
+	private renderQuickPrompt(
+		containerEl: HTMLElement,
+		prompt: QuickPrompt,
+		index: number,
+	): void {
+		const blockEl = containerEl.createDiv({
+			cls: "agent-client-quick-prompt-setting",
+		});
+
+		const nameSetting = new Setting(blockEl)
+			.setName("Name")
+			.setDesc("Use this value in button blocks as `promptName:`.")
+			.addText((text) => {
+				text.setPlaceholder("Summarize note")
+					.setValue(prompt.name)
+					.onChange(async (value) => {
+						const name = value.trim();
+						if (!name) return;
+						const duplicate =
+							this.plugin.settings.quickPrompts.some(
+								(item, itemIndex) =>
+									itemIndex !== index && item.name === name,
+							);
+						if (duplicate) {
+							new Notice(
+								`[Agent Client] A quick prompt named "${name}" already exists.`,
+							);
+							text.setValue(prompt.name);
+							return;
+						}
+						const next = [...this.plugin.settings.quickPrompts];
+						next[index] = { ...next[index], name };
+						await this.plugin.settingsService.updateSettings({
+							quickPrompts: next,
+						});
+					});
+			});
+
+		nameSetting.addExtraButton((button) => {
+			button
+				.setIcon("trash")
+				.setTooltip("Delete quick prompt")
+				.onClick(async () => {
+					const next = [...this.plugin.settings.quickPrompts];
+					next.splice(index, 1);
+					await this.plugin.settingsService.updateSettings({
+						quickPrompts: next,
+					});
+					this.display();
+				});
+		});
+
+		new Setting(blockEl)
+			.setName("Prompt")
+			.setDesc("The text inserted into chat or sent by a button block.")
+			.addTextArea((text) => {
+				text.setPlaceholder("Summarize the active note in 3 bullets.")
+					.setValue(prompt.prompt)
+					.onChange(async (value) => {
+						const next = [...this.plugin.settings.quickPrompts];
+						next[index] = { ...next[index], prompt: value };
+						await this.plugin.settingsService.updateSettings({
+							quickPrompts: next,
+						});
+					});
+				text.inputEl.rows = 4;
+			});
+
+		new Setting(blockEl)
+			.setName("Icon")
+			.setDesc(
+				"Lucide icon name (e.g. sparkles, wand-2) or an image URL / vault path. Leave blank for the default sparkles icon.",
+			)
+			.addText((text) => {
+				text.setPlaceholder("sparkles")
+					.setValue(prompt.icon ?? "")
+					.onChange(async (value) => {
+						const icon = value.trim();
+						const next = [...this.plugin.settings.quickPrompts];
+						next[index] = {
+							...next[index],
+							icon: icon.length > 0 ? icon : undefined,
+						};
+						await this.plugin.settingsService.updateSettings({
+							quickPrompts: next,
+						});
+					});
+			});
+
+		new Setting(blockEl)
+			.setName("Default agent")
+			.setDesc("Used when a button block does not specify `agent:`.")
+			.addDropdown((dropdown) => {
+				dropdown.addOption("", "(plugin default)");
+				for (const agent of this.plugin.getAvailableAgents()) {
+					dropdown.addOption(agent.id, agent.displayName);
+				}
+				dropdown
+					.setValue(prompt.agentId ?? "")
+					.onChange(async (value) => {
+						const next = [...this.plugin.settings.quickPrompts];
+						next[index] = {
+							...next[index],
+							agentId: value.length > 0 ? value : undefined,
+						};
+						await this.plugin.settingsService.updateSettings({
+							quickPrompts: next,
+						});
+					});
+			});
+		new Setting(blockEl)
+			.setName("Hide after click")
+			.setDesc(
+				"Hide this chip once it is used, for the current chat view. Reopening the chat restores it.",
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(prompt.hideAfterClick ?? false)
+					.onChange(async (value) => {
+						const next = [...this.plugin.settings.quickPrompts];
+						next[index] = {
+							...next[index],
+							hideAfterClick: value || undefined,
+						};
+						await this.plugin.settingsService.updateSettings({
+							quickPrompts: next,
+						});
+					});
+			});
+	}
+
+	private generateQuickPromptName(): string {
+		const base = "New prompt";
+		const existing = new Set(
+			this.plugin.settings.quickPrompts.map((prompt) => prompt.name),
+		);
+		if (!existing.has(base)) return base;
+		let counter = 2;
+		let candidate = `${base} ${counter}`;
+		while (existing.has(candidate)) {
+			counter += 1;
+			candidate = `${base} ${counter}`;
+		}
+		return candidate;
 	}
 
 	/**

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -134,6 +134,38 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					}),
 			);
 
+		new Setting(containerEl)
+			.setName("Show recent chats in chat")
+			.setDesc(
+				"Show recent chat shortcuts above the message box on empty chats.",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.showRecentChatsInChat)
+					.onChange(async (value) => {
+						await this.plugin.settingsService.updateSettings({
+							showRecentChatsInChat: value,
+						});
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Show agent images")
+			.setDesc(
+				"Show configured agent avatar images in chat headers, selectors, embedded chats, buttons, and recent chat shortcuts.",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(
+						this.plugin.settings.showAgentImagesInChatInterfaces,
+					)
+					.onChange(async (value) => {
+						await this.plugin.settingsService.updateSettings({
+							showAgentImagesInChatInterfaces: value,
+						});
+					}),
+			);
+
 		new Setting(containerEl).setName("Mentions").setHeading();
 
 		new Setting(containerEl)

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -202,6 +202,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					.addOption("right-split", "Right pane (split)")
 					.addOption("editor-tab", "Editor area (tabs)")
 					.addOption("editor-split", "Editor area (split)")
+					.addOption("floating", "Floating chat")
 					.setValue(this.plugin.settings.chatViewLocation)
 					.onChange(async (value) => {
 						await this.plugin.settingsService.updateSettings({
@@ -1027,6 +1028,11 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					});
 				text.inputEl.rows = 3;
 			});
+
+		this.renderAvatarSetting(sectionEl, gemini.avatarImage, async (v) => {
+			this.plugin.settings.gemini.avatarImage = v;
+			await this.plugin.saveSettings();
+		});
 	}
 
 	private renderClaudeSettings(sectionEl: HTMLElement) {
@@ -1122,6 +1128,11 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					});
 				text.inputEl.rows = 3;
 			});
+
+		this.renderAvatarSetting(sectionEl, claude.avatarImage, async (v) => {
+			this.plugin.settings.claude.avatarImage = v;
+			await this.plugin.saveSettings();
+		});
 	}
 
 	private renderCodexSettings(sectionEl: HTMLElement) {
@@ -1217,6 +1228,11 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					});
 				text.inputEl.rows = 3;
 			});
+
+		this.renderAvatarSetting(sectionEl, codex.avatarImage, async (v) => {
+			this.plugin.settings.codex.avatarImage = v;
+			await this.plugin.saveSettings();
+		});
 	}
 
 	private renderCustomAgents(containerEl: HTMLElement) {
@@ -1363,6 +1379,11 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					});
 				text.inputEl.rows = 3;
 			});
+
+		this.renderAvatarSetting(blockEl, agent.avatarImage, async (v) => {
+			this.plugin.settings.customAgents[index].avatarImage = v;
+			await this.plugin.saveSettings();
+		});
 	}
 
 	/**
@@ -1538,5 +1559,30 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		}
 
 		return normalizeEnvVars(envVars);
+	}
+
+	/**
+	 * Shared avatar field rendered at the bottom of every agent section.
+	 */
+	private renderAvatarSetting(
+		sectionEl: HTMLElement,
+		currentValue: string | undefined,
+		onChange: (value: string | undefined) => Promise<void>,
+	): void {
+		new Setting(sectionEl)
+			.setName("Avatar image")
+			.setDesc(
+				"URL or vault path to an image. Used by embedded `agent-client` chat blocks and quick-action buttons.",
+			)
+			.addText((text) => {
+				text.setPlaceholder("https://example.com/avatar.png")
+					.setValue(currentValue ?? "")
+					.onChange(async (value) => {
+						const trimmed = value.trim();
+						await onChange(
+							trimmed.length > 0 ? trimmed : undefined,
+						);
+					});
+			});
 	}
 }

--- a/src/ui/shared/AgentAvatar.tsx
+++ b/src/ui/shared/AgentAvatar.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+const { useMemo } = React;
+import { setIcon } from "obsidian";
+
+import type AgentClientPlugin from "../../plugin";
+import {
+	getAgentAvatarImage,
+	resolveImageSrc,
+} from "../../utils/resolve-image-src";
+
+export function getResolvedAgentAvatarSrc(
+	plugin: AgentClientPlugin,
+	agentId: string | undefined,
+): string | null {
+	if (!plugin.settings.showAgentImagesInChatInterfaces) return null;
+	return resolveImageSrc(plugin, getAgentAvatarImage(plugin, agentId));
+}
+
+export function AgentAvatar({
+	plugin,
+	agentId,
+	className = "agent-client-agent-avatar",
+	fallbackIcon = "bot",
+}: {
+	plugin: AgentClientPlugin;
+	agentId: string | undefined;
+	className?: string;
+	fallbackIcon?: string;
+}) {
+	const showAgentImages = plugin.settings.showAgentImagesInChatInterfaces;
+	const src = useMemo(
+		() => getResolvedAgentAvatarSrc(plugin, agentId),
+		[plugin, agentId, showAgentImages],
+	);
+
+	if (!showAgentImages) return null;
+
+	if (src) {
+		return <img src={src} alt="" className={className} />;
+	}
+
+	return (
+		<span
+			className={`${className} agent-client-agent-avatar-fallback`}
+			ref={(el) => {
+				if (el) setIcon(el, fallbackIcon);
+			}}
+		/>
+	);
+}

--- a/src/ui/shared/ImageSelect.tsx
+++ b/src/ui/shared/ImageSelect.tsx
@@ -1,0 +1,173 @@
+import * as React from "react";
+const { useCallback, useEffect, useMemo, useRef, useState } = React;
+import { createPortal } from "react-dom";
+import { setIcon } from "obsidian";
+
+export interface ImageSelectOption {
+	value: string;
+	label: string;
+	description?: string;
+	imageSrc?: string | null;
+}
+
+export function ImageSelect({
+	options,
+	value,
+	onChange,
+	className,
+	placeholder = "Select",
+}: {
+	options: ImageSelectOption[];
+	value: string | undefined;
+	onChange: (value: string) => void;
+	className?: string;
+	placeholder?: string;
+}) {
+	const [open, setOpen] = useState(false);
+	const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({});
+	const rootRef = useRef<HTMLDivElement>(null);
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const menuRef = useRef<HTMLDivElement>(null);
+	const selected = useMemo(
+		() => options.find((option) => option.value === value) ?? options[0],
+		[options, value],
+	);
+
+	useEffect(() => {
+		const handlePointerDown = (event: PointerEvent) => {
+			const target = event.target as Node;
+			if (
+				!rootRef.current?.contains(target) &&
+				!menuRef.current?.contains(target)
+			) {
+				setOpen(false);
+			}
+		};
+		document.addEventListener("pointerdown", handlePointerDown);
+		return () => {
+			document.removeEventListener("pointerdown", handlePointerDown);
+		};
+	}, []);
+
+	const updateMenuPosition = useCallback(() => {
+		const trigger = triggerRef.current;
+		if (!trigger) return;
+
+		const rect = trigger.getBoundingClientRect();
+		setMenuStyle({
+			position: "fixed",
+			top: rect.bottom + 4,
+			left: rect.left,
+			minWidth: Math.max(rect.width, 220),
+			maxWidth: 320,
+		});
+	}, []);
+
+	useEffect(() => {
+		if (!open) return;
+
+		updateMenuPosition();
+		window.addEventListener("resize", updateMenuPosition);
+		window.addEventListener("scroll", updateMenuPosition, true);
+		return () => {
+			window.removeEventListener("resize", updateMenuPosition);
+			window.removeEventListener("scroll", updateMenuPosition, true);
+		};
+	}, [open, updateMenuPosition]);
+
+	const choose = useCallback(
+		(nextValue: string) => {
+			setOpen(false);
+			if (nextValue !== value) onChange(nextValue);
+		},
+		[onChange, value],
+	);
+
+	const stopPointerPropagation = useCallback(
+		(event: React.PointerEvent | React.MouseEvent) => {
+			event.stopPropagation();
+		},
+		[],
+	);
+
+	if (!selected) return null;
+
+	return (
+		<div
+			ref={rootRef}
+			className={`agent-client-image-select ${className ?? ""}`}
+			onMouseDown={stopPointerPropagation}
+			onPointerDown={stopPointerPropagation}
+		>
+			<button
+				ref={triggerRef}
+				type="button"
+				className="agent-client-image-select-trigger"
+				title={selected.description ?? selected.label}
+				aria-haspopup="listbox"
+				aria-expanded={open}
+				onClick={() => setOpen((current) => !current)}
+			>
+				<SelectImage option={selected} />
+				<span className="agent-client-image-select-label">
+					{selected.label || placeholder}
+				</span>
+				<span
+					className="agent-client-image-select-chevron"
+					ref={(el) => {
+						if (el) setIcon(el, "chevron-down");
+					}}
+				/>
+			</button>
+			{open &&
+				createPortal(
+					<div
+						ref={menuRef}
+						className="agent-client-image-select-menu"
+						role="listbox"
+						style={menuStyle}
+						onMouseDown={stopPointerPropagation}
+						onPointerDown={stopPointerPropagation}
+					>
+						{options.map((option) => (
+							<button
+								key={option.value}
+								type="button"
+								className={`agent-client-image-select-option ${option.value === selected.value ? "is-selected" : ""}`}
+								role="option"
+								aria-selected={option.value === selected.value}
+								title={option.description ?? option.label}
+								onClick={() => choose(option.value)}
+							>
+								<SelectImage option={option} />
+								<span className="agent-client-image-select-option-text">
+									<span className="agent-client-image-select-label">
+										{option.label}
+									</span>
+									{option.description && (
+										<span className="agent-client-image-select-description">
+											{option.description}
+										</span>
+									)}
+								</span>
+							</button>
+						))}
+					</div>,
+					document.body,
+				)}
+		</div>
+	);
+}
+
+function SelectImage({ option }: { option: ImageSelectOption }) {
+	if (option.imageSrc) {
+		return (
+			<img
+				src={option.imageSrc}
+				alt=""
+				className="agent-client-image-select-image"
+			/>
+		);
+	}
+	return null;
+}

--- a/src/utils/agent-block-parser.ts
+++ b/src/utils/agent-block-parser.ts
@@ -1,0 +1,203 @@
+/**
+ * Parser for the `agent-client` markdown code block.
+ *
+ * Pure function. No React, no Obsidian view APIs (parseYaml from obsidian
+ * is the only Obsidian import, used as a YAML utility).
+ *
+ * Fence body is parsed as YAML and dispatched by a `type` discriminator:
+ * - `chat` (default): embedded chat view
+ * - `button`: quick-action button that opens a chat with a prompt
+ */
+
+import { parseYaml } from "obsidian";
+
+export type AgentChatBlockConfig = {
+	type: "chat";
+	agent?: string;
+	model?: string;
+	/** Max height of the messages area, e.g. "400px". */
+	height?: string;
+	/** Restore the latest saved session for this note + agent. */
+	persist?: boolean;
+	/** Pin auto-mention context to the note hosting this block. */
+	noteContext?: "hosting";
+	/**
+	 * Per-block avatar override.
+	 * Accepts http(s) URL, data URL, or vault-relative path.
+	 * Falls back to the configured agent's avatarImage, then the
+	 * global floatingButtonImage.
+	 */
+	image?: string;
+};
+
+export type AgentButtonBlockConfig = {
+	type: "button";
+	text: string;
+	/** Prompt sent to the opened chat. */
+	prompt: string;
+	agent?: string;
+	/** Where to open the chat when clicked. */
+	viewType?: "right-pane" | "floating" | "editor-tab" | "embedded";
+	/** Send immediately on open. */
+	autoSend?: boolean;
+};
+
+export type AgentBlockConfig = AgentChatBlockConfig | AgentButtonBlockConfig;
+
+export type AgentBlockParseResult =
+	| { ok: true; config: AgentBlockConfig }
+	| { ok: false; error: string };
+
+const VALID_TYPES = new Set<string>(["chat", "button"]);
+const VALID_VIEW_TYPES = new Set<string>([
+	"right-pane",
+	"floating",
+	"editor-tab",
+	"embedded",
+]);
+const VALID_NOTE_CONTEXTS = new Set<string>(["hosting"]);
+
+function normalizeViewType(
+	value: string | undefined,
+): AgentButtonBlockConfig["viewType"] | undefined {
+	if (!value) return undefined;
+	if (value === "right" || value === "right-tab") return "right-pane";
+	if (value === "float" || value === "floating-chat") return "floating";
+	if (value === "tab") return "editor-tab";
+	if (value === "embed" || value === "embeddable") return "embedded";
+	return VALID_VIEW_TYPES.has(value)
+		? (value as AgentButtonBlockConfig["viewType"])
+		: undefined;
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+	return typeof value === "boolean" ? value : undefined;
+}
+
+function dedent(source: string): string {
+	const normalized = source.replace(/\r\n?/g, "\n");
+	const lines = normalized.split("\n");
+	const indents = lines
+		.filter((line) => line.trim().length > 0)
+		.map((line) => line.match(/^[ \t]*/)?.[0].length ?? 0);
+	const minIndent = indents.length > 0 ? Math.min(...indents) : 0;
+
+	if (minIndent === 0) return normalized.trim();
+
+	return lines
+		.map((line) => (line.trim().length > 0 ? line.slice(minIndent) : line))
+		.join("\n")
+		.trim();
+}
+
+function normalizeCssLength(value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	return value.replace(/^(-?\d+(?:\.\d+)?)\s+(px|em|rem|vh|vw|%)$/i, "$1$2");
+}
+
+/**
+ * Parse the fence body. An empty body yields a default `chat` block.
+ *
+ * Returns a discriminated result. Callers should render an inline error
+ * (createDiv/createSpan, never innerHTML) when ok is false.
+ */
+export function parseAgentBlock(source: string): AgentBlockParseResult {
+	const trimmed = dedent(source);
+
+	let raw: unknown;
+	if (trimmed.length === 0) {
+		raw = {};
+	} else {
+		try {
+			raw = parseYaml(trimmed);
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : String(error);
+			return { ok: false, error: `Invalid YAML: ${message}` };
+		}
+	}
+
+	if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+		return {
+			ok: false,
+			error: "Block body must be a YAML mapping (key: value pairs).",
+		};
+	}
+
+	const obj = raw as Record<string, unknown>;
+	const typeValue = asString(obj.type) ?? "chat";
+
+	if (!VALID_TYPES.has(typeValue)) {
+		return {
+			ok: false,
+			error: `Unknown type: "${typeValue}". Expected "chat" or "button".`,
+		};
+	}
+
+	if (typeValue === "chat") {
+		const rawNoteContext = asString(obj.noteContext);
+		const noteContext = rawNoteContext
+			? VALID_NOTE_CONTEXTS.has(rawNoteContext)
+				? (rawNoteContext as AgentChatBlockConfig["noteContext"])
+				: undefined
+			: undefined;
+		if (rawNoteContext && !noteContext) {
+			return {
+				ok: false,
+				error: `Unknown noteContext: "${rawNoteContext}". Expected "hosting".`,
+			};
+		}
+
+		const config: AgentChatBlockConfig = {
+			type: "chat",
+			agent: asString(obj.agent),
+			model: asString(obj.model),
+			height: normalizeCssLength(asString(obj.height)),
+			persist: asBoolean(obj.persist) ?? false,
+			noteContext,
+			image: asString(obj.image),
+		};
+		return { ok: true, config };
+	}
+
+	const text = asString(obj.text);
+	if (!text) {
+		return {
+			ok: false,
+			error: 'Button block requires a non-empty "text" field.',
+		};
+	}
+
+	const prompt = asString(obj.prompt);
+	if (!prompt) {
+		return {
+			ok: false,
+			error: 'Button block requires a non-empty "prompt" field.',
+		};
+	}
+
+	const rawViewType = asString(obj.viewType);
+	const viewType = normalizeViewType(rawViewType);
+	if (rawViewType && !viewType) {
+		return {
+			ok: false,
+			error: `Unknown viewType: "${rawViewType}". Expected "right-pane", "floating", "editor-tab", or "embedded".`,
+		};
+	}
+
+	const config: AgentButtonBlockConfig = {
+		type: "button",
+		text,
+		prompt,
+		agent: asString(obj.agent),
+		viewType: viewType ?? "right-pane",
+		autoSend: asBoolean(obj.autoSend) ?? false,
+	};
+	return { ok: true, config };
+}

--- a/src/utils/agent-block-parser.ts
+++ b/src/utils/agent-block-parser.ts
@@ -34,12 +34,18 @@ export type AgentButtonBlockConfig = {
 	type: "button";
 	text: string;
 	/** Prompt sent to the opened chat. */
-	prompt: string;
+	prompt?: string;
+	/** Name of a saved quick prompt to resolve at click time. */
+	promptName?: string;
 	agent?: string;
 	/** Where to open the chat when clicked. */
 	viewType?: "right-pane" | "floating" | "editor-tab" | "embedded";
 	/** Send immediately on open. */
 	autoSend?: boolean;
+	/** Hide the button after it is clicked (until the note is re-rendered). */
+	hideAfterClick?: boolean;
+	/** Alignment of the rendered button block within the note. */
+	align?: "left" | "center" | "right";
 };
 
 export type AgentBlockConfig = AgentChatBlockConfig | AgentButtonBlockConfig;
@@ -56,6 +62,7 @@ const VALID_VIEW_TYPES = new Set<string>([
 	"embedded",
 ]);
 const VALID_NOTE_CONTEXTS = new Set<string>(["hosting"]);
+const VALID_ALIGNMENTS = new Set<string>(["left", "center", "right"]);
 
 function normalizeViewType(
 	value: string | undefined,
@@ -175,10 +182,11 @@ export function parseAgentBlock(source: string): AgentBlockParseResult {
 	}
 
 	const prompt = asString(obj.prompt);
-	if (!prompt) {
+	const promptName = asString(obj.promptName);
+	if (!prompt && !promptName) {
 		return {
 			ok: false,
-			error: 'Button block requires a non-empty "prompt" field.',
+			error: 'Button block requires a non-empty "prompt" or "promptName" field.',
 		};
 	}
 
@@ -191,13 +199,31 @@ export function parseAgentBlock(source: string): AgentBlockParseResult {
 		};
 	}
 
+	const rawAlign = asString(obj.align);
+	const align = rawAlign
+		? VALID_ALIGNMENTS.has(rawAlign)
+			? (rawAlign as AgentButtonBlockConfig["align"])
+			: undefined
+		: undefined;
+	if (rawAlign && !align) {
+		return {
+			ok: false,
+			error: `Unknown align: "${rawAlign}". Expected "left", "center", or "right".`,
+		};
+	}
+
 	const config: AgentButtonBlockConfig = {
 		type: "button",
 		text,
 		prompt,
+		promptName,
 		agent: asString(obj.agent),
 		viewType: viewType ?? "right-pane",
 		autoSend: asBoolean(obj.autoSend) ?? false,
+		// Left undefined when unset so it can fall back to the referenced
+		// quick prompt's hideAfterClick setting at click time.
+		hideAfterClick: asBoolean(obj.hideAfterClick),
+		align: align ?? "left",
 	};
 	return { ok: true, config };
 }

--- a/src/utils/agent-block-parser.ts
+++ b/src/utils/agent-block-parser.ts
@@ -28,6 +28,8 @@ export type AgentChatBlockConfig = {
 	 * global floatingButtonImage.
 	 */
 	image?: string;
+	/** Whether to show the resolved agent image above the embedded chat. */
+	showImage?: boolean;
 };
 
 export type AgentButtonBlockConfig = {
@@ -44,6 +46,8 @@ export type AgentButtonBlockConfig = {
 	autoSend?: boolean;
 	/** Hide the button after it is clicked (until the note is re-rendered). */
 	hideAfterClick?: boolean;
+	/** Whether to show the resolved agent image inside the button. */
+	showImage?: boolean;
 	/** Alignment of the rendered button block within the note. */
 	align?: "left" | "center" | "right";
 };
@@ -85,6 +89,14 @@ function asString(value: unknown): string | undefined {
 
 function asBoolean(value: unknown): boolean | undefined {
 	return typeof value === "boolean" ? value : undefined;
+}
+
+function showImageValue(obj: Record<string, unknown>): boolean | undefined {
+	const explicit = asBoolean(obj.showImage);
+	if (typeof explicit === "boolean") return explicit;
+	const hideImage = asBoolean(obj.hideImage);
+	if (typeof hideImage === "boolean") return !hideImage;
+	return obj.image === false ? false : undefined;
 }
 
 function dedent(source: string): string {
@@ -169,6 +181,7 @@ export function parseAgentBlock(source: string): AgentBlockParseResult {
 			persist: asBoolean(obj.persist) ?? false,
 			noteContext,
 			image: asString(obj.image),
+			showImage: showImageValue(obj),
 		};
 		return { ok: true, config };
 	}
@@ -223,6 +236,7 @@ export function parseAgentBlock(source: string): AgentBlockParseResult {
 		// Left undefined when unset so it can fall back to the referenced
 		// quick prompt's hideAfterClick setting at click time.
 		hideAfterClick: asBoolean(obj.hideAfterClick),
+		showImage: showImageValue(obj),
 		align: align ?? "left",
 	};
 	return { ok: true, config };

--- a/src/utils/resolve-image-src.ts
+++ b/src/utils/resolve-image-src.ts
@@ -1,0 +1,45 @@
+/**
+ * Resolve a user-supplied image reference to a value usable in an <img src>.
+ *
+ * Accepts:
+ * - http:// or https:// URLs (returned unchanged)
+ * - data: URLs (returned unchanged)
+ * - vault-relative paths (resolved via FileSystemAdapter.getResourcePath)
+ *
+ * Returns null for empty/missing input or non-FileSystemAdapter vaults.
+ */
+
+import { FileSystemAdapter } from "obsidian";
+import type AgentClientPlugin from "../plugin";
+
+export function resolveImageSrc(
+	plugin: AgentClientPlugin,
+	value: string | undefined | null,
+): string | null {
+	if (!value) return null;
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return null;
+
+	if (/^(https?:|data:)/i.test(trimmed)) {
+		return trimmed;
+	}
+
+	const adapter = plugin.app.vault.adapter;
+	if (adapter instanceof FileSystemAdapter) {
+		return adapter.getResourcePath(trimmed);
+	}
+	return null;
+}
+
+export function getAgentAvatarImage(
+	plugin: AgentClientPlugin,
+	agentId: string | undefined,
+): string | undefined {
+	if (!agentId) return undefined;
+	const settings = plugin.settings;
+	if (agentId === settings.claude.id) return settings.claude.avatarImage;
+	if (agentId === settings.codex.id) return settings.codex.avatarImage;
+	if (agentId === settings.gemini.id) return settings.gemini.avatarImage;
+	return settings.customAgents.find((agent) => agent.id === agentId)
+		?.avatarImage;
+}

--- a/src/utils/resolve-image-src.ts
+++ b/src/utils/resolve-image-src.ts
@@ -31,6 +31,37 @@ export function resolveImageSrc(
 	return null;
 }
 
+/** Image file extensions recognized when classifying an icon reference. */
+const IMAGE_EXTENSION_RE = /\.(png|jpe?g|gif|webp|svg|bmp|ico|avif)$/i;
+
+/**
+ * Classify an icon reference as either a Lucide icon id or an image reference.
+ *
+ * Heuristic: a value that looks like an http(s)/data URL, contains a path
+ * separator, or ends in a known image extension is treated as an image;
+ * otherwise it is treated as a Lucide icon id (a kebab-case slug like
+ * "sparkles" or "wand-2"). Returns null for empty/missing input.
+ */
+export function classifyIconRef(
+	value: string | undefined | null,
+):
+	| { kind: "image"; value: string }
+	| { kind: "lucide"; value: string }
+	| null {
+	if (!value) return null;
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return null;
+
+	if (
+		/^(https?:|data:)/i.test(trimmed) ||
+		/[/\\]/.test(trimmed) ||
+		IMAGE_EXTENSION_RE.test(trimmed)
+	) {
+		return { kind: "image", value: trimmed };
+	}
+	return { kind: "lucide", value: trimmed };
+}
+
 export function getAgentAvatarImage(
 	plugin: AgentClientPlugin,
 	agentId: string | undefined,

--- a/styles.css
+++ b/styles.css
@@ -2199,48 +2199,6 @@ If your plugin does not need CSS, delete this file.
 	color: var(--interactive-accent);
 }
 
-/* ===== Code Block Chat View ===== */
-/* TODO(code-block): Styles for future code block chat view */
-.agent-client-code-block-container {
-	display: flex;
-	flex-direction: column;
-	border: 1px solid var(--background-modifier-border);
-	border-radius: 8px;
-	background: var(--background-primary);
-	overflow: hidden;
-}
-
-.agent-client-code-block-content {
-	display: flex;
-	flex-direction: column;
-	padding: 8px;
-}
-
-.agent-client-code-block-status {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 4px 8px;
-	background: var(--background-secondary);
-	border-radius: 4px;
-	margin-bottom: 4px;
-	flex-wrap: wrap;
-	gap: 8px;
-}
-
-.agent-client-code-block-status-actions {
-	display: flex;
-	align-items: center;
-	gap: 4px;
-	flex-wrap: wrap;
-}
-
-.agent-client-code-block-messages {
-	max-height: 400px;
-	overflow-y: auto;
-	margin-bottom: 8px;
-}
-
 /* ===== Agent Selector (InlineHeader) ===== */
 .agent-client-agent-selector {
 	display: inline-flex;
@@ -2304,4 +2262,161 @@ If your plugin does not need CSS, delete this file.
 .agent-client-agent-label {
 	color: var(--text-normal);
 	font-size: 12px;
+}
+
+/* ============================================================
+   Embedded agent-client code blocks
+   ============================================================ */
+
+.agent-client-code-block-error {
+	border: 1px solid var(--background-modifier-error-border, var(--text-error));
+	background: var(--background-modifier-error);
+	color: var(--text-on-accent, #fff);
+	padding: 10px 14px;
+	border-radius: 6px;
+	font-size: 0.95em;
+	margin: 4px 0;
+	font-family: var(--font-interface);
+}
+
+.agent-client-code-block-error-label {
+	font-weight: 700;
+	margin-right: 4px;
+	color: var(--text-on-accent, #fff);
+}
+
+.agent-client-code-block-error-source {
+	margin-top: 8px;
+	padding: 6px 10px;
+	background: rgba(0, 0, 0, 0.25);
+	border-radius: 4px;
+	font-family: var(--font-monospace);
+	font-size: 0.85em;
+	color: var(--text-on-accent, #fff);
+	white-space: pre-wrap;
+	word-break: break-word;
+	max-height: 200px;
+	overflow: auto;
+}
+
+.agent-client-code-block-host {
+	margin: 8px 0;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	overflow: hidden;
+	background: var(--background-primary);
+}
+
+.agent-client-code-block-chat {
+	display: flex;
+	flex-direction: column;
+	height: var(--ac-embedded-max-height, 520px);
+	min-height: 320px;
+	max-height: min(var(--ac-embedded-max-height, 520px), 80vh);
+	overflow: hidden;
+}
+
+.agent-client-code-block-chat-avatar-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-height: 40px;
+	padding: 6px 10px;
+	border-bottom: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary);
+}
+
+.agent-client-code-block-chat-avatar {
+	display: block;
+	flex: 0 0 28px;
+	width: 28px !important;
+	height: 28px !important;
+	min-width: 28px;
+	min-height: 28px;
+	max-width: 28px;
+	max-height: 28px;
+	aspect-ratio: 1 / 1;
+	border-radius: 50%;
+	object-fit: cover;
+	overflow: hidden;
+}
+
+.agent-client-embedded-chat-panel {
+	flex: 1 1 auto;
+	height: 100%;
+	min-height: 0;
+	overflow: hidden;
+	background: var(--background-primary);
+}
+
+.agent-client-embedded-header {
+	flex: 0 0 auto;
+	border-bottom: 1px solid var(--background-modifier-border);
+	background: var(--background-primary);
+}
+
+.agent-client-embedded-header .agent-client-inline-header {
+	min-height: 34px;
+	padding: 6px 10px;
+}
+
+.agent-client-embedded-messages-container {
+	flex: 1 1 auto;
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	overflow: hidden;
+}
+
+.agent-client-embedded-messages-container .agent-client-chat-view-messages {
+	flex: 1 1 auto;
+	min-height: 0;
+	padding: 12px 10px;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+}
+
+.agent-client-embedded-chat-panel .agent-client-chat-input-container {
+	flex: 0 0 auto;
+	padding: 8px 10px 10px;
+	border-top: 1px solid var(--background-modifier-border);
+	background: var(--background-primary);
+}
+
+/* ============================================================
+   Quick-action button blocks
+   ============================================================ */
+
+.agent-client-button-block {
+	display: inline-flex;
+	margin: 4px 0;
+}
+
+.agent-client-button-block-button {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 14px;
+	border-radius: 6px;
+	cursor: pointer;
+	font-weight: 500;
+}
+
+.agent-client-button-block-avatar {
+	display: block;
+	flex: 0 0 18px;
+	width: 18px !important;
+	height: 18px !important;
+	min-width: 18px;
+	min-height: 18px;
+	max-width: 18px;
+	max-height: 18px;
+	aspect-ratio: 1 / 1;
+	border-radius: 50%;
+	object-fit: cover;
+	overflow: hidden;
+}
+
+.agent-client-button-block-text {
+	white-space: nowrap;
 }

--- a/styles.css
+++ b/styles.css
@@ -531,6 +531,9 @@ If your plugin does not need CSS, delete this file.
 }
 
 .agent-client-chat-view-header-title {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
 	flex: 1 1 0;
 	min-width: 0;
 	padding-left: var(--size-4-1);
@@ -539,6 +542,31 @@ If your plugin does not need CSS, delete this file.
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.agent-client-header-agent-avatar,
+.agent-client-toolbar-agent-avatar,
+.agent-client-agent-avatar {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 18px;
+	width: 18px !important;
+	height: 18px !important;
+	border-radius: 5px;
+	object-fit: cover;
+	color: var(--text-muted);
+}
+
+.agent-client-header-agent-avatar svg,
+.agent-client-toolbar-agent-avatar svg,
+.agent-client-agent-avatar svg {
+	width: 16px;
+	height: 16px;
+}
+
+.agent-client-toolbar-agent-avatar {
+	margin-right: 2px;
 }
 
 .agent-client-chat-view-header-update {
@@ -897,6 +925,11 @@ If your plugin does not need CSS, delete this file.
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.agent-client-recent-chat-chip:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
 }
 
 .agent-client-quick-prompt-suggestion {
@@ -2339,64 +2372,149 @@ If your plugin does not need CSS, delete this file.
 .agent-client-agent-selector {
 	display: inline-flex;
 	align-items: center;
+	justify-content: flex-start;
 	padding: 0 4px;
 	border-radius: 4px;
 	cursor: pointer;
 	transition: background-color 0.1s ease;
 	height: 20px;
 	max-width: 160px;
+	width: 160px;
 }
 
 .agent-client-agent-selector:hover {
 	background-color: var(--background-modifier-hover);
 }
 
-.agent-client-agent-selector-icon {
-	display: flex;
+/* Agent label (single agent) */
+.agent-client-agent-label {
+	display: inline-flex;
 	align-items: center;
-	color: var(--text-faint);
-	margin-left: 2px;
-	order: 2;
+	gap: 6px;
+	color: var(--text-normal);
+	font-size: 12px;
 }
 
-.agent-client-agent-selector-icon svg {
+/* Image-capable selectors used where native select options cannot render avatars. */
+.agent-client-image-select {
+	position: relative;
+	min-width: 0;
+}
+
+.agent-client-agent-image-select {
+	width: 100%;
+}
+
+.agent-client-image-select-trigger {
+	display: inline-flex;
+	align-items: center;
+	justify-content: flex-start !important;
+	gap: 6px;
+	width: 100%;
+	max-width: 180px;
+	min-height: 22px;
+	padding: 0 2px !important;
+	margin: 0 !important;
+	border: none !important;
+	border-radius: 4px !important;
+	background: transparent !important;
+	box-shadow: none !important;
+	color: var(--text-normal) !important;
+	font: inherit;
+	font-size: var(--font-ui-smaller);
+	text-align: left;
+	cursor: pointer;
+}
+
+.agent-client-agent-image-select .agent-client-image-select-trigger {
+	max-width: none;
+}
+
+.agent-client-image-select-trigger:hover {
+	background: var(--background-modifier-hover) !important;
+}
+
+.agent-client-image-select-label {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	text-align: left;
+}
+
+.agent-client-image-select-chevron {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 12px;
+	margin-left: auto;
+	color: var(--text-faint);
+}
+
+.agent-client-image-select-chevron svg {
 	width: 12px;
 	height: 12px;
 }
 
-.agent-client-agent-selector select.dropdown {
-	padding: 0 !important;
-	margin: 0 !important;
+.agent-client-image-select-image {
+	flex: 0 0 18px;
+	width: 18px;
+	height: 18px;
+	border-radius: 5px;
+	object-fit: cover;
+}
+
+.agent-client-image-select-menu {
+	z-index: 1000;
+	max-height: 260px;
+	overflow-y: auto;
+	padding: 4px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+	background: var(--background-primary);
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+}
+
+.agent-client-image-select-option {
+	display: flex;
+	align-items: center;
+	justify-content: flex-start !important;
+	gap: 8px;
+	width: 100%;
+	padding: 6px 8px !important;
 	border: none !important;
-	border-radius: 0 !important;
-	background: none !important;
-	background-color: transparent !important;
-	background-image: none !important;
+	border-radius: 4px !important;
+	background: transparent !important;
 	box-shadow: none !important;
 	color: var(--text-normal) !important;
-	font-size: 12px !important;
-	cursor: pointer !important;
-	outline: none !important;
-	appearance: none !important;
-	-webkit-appearance: none !important;
-	-moz-appearance: none !important;
-	max-width: 140px;
+	text-align: left;
+	cursor: pointer;
+}
+
+.agent-client-image-select-option:hover,
+.agent-client-image-select-option.is-selected {
+	background: var(--background-modifier-hover) !important;
+}
+
+.agent-client-image-select-option-text {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	min-width: 0;
+	text-align: left;
+}
+
+.agent-client-image-select-description {
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	overflow: hidden;
 }
 
-.agent-client-agent-selector select.dropdown:hover,
-.agent-client-agent-selector select.dropdown:focus {
-	color: var(--text-normal) !important;
-	background-color: transparent !important;
-	box-shadow: none !important;
-}
-
-/* Agent label (single agent) */
-.agent-client-agent-label {
-	color: var(--text-normal);
-	font-size: 12px;
+.agent-client-config-options-container {
+	position: relative;
 }
 
 /* ============================================================
@@ -2454,26 +2572,27 @@ If your plugin does not need CSS, delete this file.
 .agent-client-code-block-chat-avatar-row {
 	display: flex;
 	align-items: center;
-	gap: 8px;
-	min-height: 40px;
-	padding: 6px 10px;
+	justify-content: center;
+	min-height: 68px;
+	padding: 10px 12px;
 	border-bottom: 1px solid var(--background-modifier-border);
 	background: var(--background-secondary);
 }
 
 .agent-client-code-block-chat-avatar {
 	display: block;
-	flex: 0 0 28px;
-	width: 28px !important;
-	height: 28px !important;
-	min-width: 28px;
-	min-height: 28px;
-	max-width: 28px;
-	max-height: 28px;
+	flex: 0 0 48px;
+	width: 48px !important;
+	height: 48px !important;
+	min-width: 48px;
+	min-height: 48px;
+	max-width: 48px;
+	max-height: 48px;
 	aspect-ratio: 1 / 1;
 	border-radius: 50%;
 	object-fit: cover;
 	overflow: hidden;
+	box-shadow: 0 0 0 2px var(--background-primary);
 }
 
 .agent-client-embedded-chat-panel {

--- a/styles.css
+++ b/styles.css
@@ -143,6 +143,14 @@ If your plugin does not need CSS, delete this file.
 	border-radius: 8px;
 }
 
+.agent-client-quick-prompt-setting {
+	padding: 12px 16px;
+	margin-bottom: 16px;
+	background-color: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+}
+
 /* ===== Loading Indicator ===== */
 .agent-client-loading-indicator {
 	display: flex;
@@ -809,6 +817,134 @@ If your plugin does not need CSS, delete this file.
 
 .agent-client-chat-input-box.agent-client-dragging-over {
 	background-color: var(--background-secondary);
+}
+
+.agent-client-quick-prompt-strip {
+	display: flex;
+	gap: 6px;
+	/* "safe" prevents the leftmost chip being clipped/unreachable when the
+	   row overflows: centers when chips fit, falls back to start otherwise. */
+	justify-content: safe center;
+	margin-bottom: 6px;
+	overflow-x: auto;
+	overflow-y: hidden;
+	padding: 2px 4px 4px;
+	/* Scrollable but with no visible scrollbar (still scrolls via wheel/trackpad). */
+	scrollbar-width: none;
+	-ms-overflow-style: none;
+}
+
+.agent-client-quick-prompt-strip::-webkit-scrollbar {
+	display: none;
+}
+
+.agent-client-quick-prompt-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	flex: 0 0 auto;
+	max-width: 260px;
+	min-height: 34px;
+	padding: 6px 12px !important;
+	border: 1px solid var(--background-modifier-border) !important;
+	border-radius: 6px !important;
+	background: var(--background-secondary) !important;
+	color: var(--text-normal) !important;
+	box-shadow: none !important;
+	font-size: var(--font-ui-medium);
+	font-weight: 500;
+	cursor: pointer;
+}
+
+.agent-client-quick-prompt-chip:hover {
+	background: var(--background-modifier-hover) !important;
+}
+
+.agent-client-quick-prompt-chip-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 16px;
+	width: 16px;
+	height: 16px;
+	color: var(--text-muted);
+}
+
+.agent-client-quick-prompt-chip-icon svg {
+	width: 16px;
+	height: 16px;
+}
+
+.agent-client-quick-prompt-chip-image {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 16px;
+	width: 16px;
+	height: 16px;
+	border-radius: 4px;
+	object-fit: cover;
+	color: var(--text-muted);
+}
+
+.agent-client-quick-prompt-chip-image svg {
+	width: 14px;
+	height: 14px;
+}
+
+.agent-client-quick-prompt-chip-text {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.agent-client-quick-prompt-suggestion {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-width: 0;
+}
+
+.agent-client-quick-prompt-suggestion-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 18px;
+	width: 18px;
+	height: 18px;
+	color: var(--text-muted);
+}
+
+.agent-client-quick-prompt-suggestion-icon svg {
+	width: 18px;
+	height: 18px;
+}
+
+.agent-client-quick-prompt-suggestion-image {
+	flex: 0 0 18px;
+	width: 18px;
+	height: 18px;
+	border-radius: 4px;
+	object-fit: cover;
+}
+
+.agent-client-quick-prompt-suggestion-text {
+	min-width: 0;
+	flex: 1 1 auto;
+}
+
+.agent-client-quick-prompt-suggestion-name {
+	font-weight: 600;
+	color: var(--text-normal);
+}
+
+.agent-client-quick-prompt-suggestion-preview {
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 /* Auto-mention inline display */
@@ -2218,7 +2354,6 @@ If your plugin does not need CSS, delete this file.
 .agent-client-agent-selector-icon {
 	display: flex;
 	align-items: center;
-	pointer-events: none;
 	color: var(--text-faint);
 	margin-left: 2px;
 	order: 2;
@@ -2388,8 +2523,20 @@ If your plugin does not need CSS, delete this file.
    ============================================================ */
 
 .agent-client-button-block {
-	display: inline-flex;
+	display: flex;
 	margin: 4px 0;
+}
+
+.agent-client-button-block-align-left {
+	justify-content: flex-start;
+}
+
+.agent-client-button-block-align-center {
+	justify-content: center;
+}
+
+.agent-client-button-block-align-right {
+	justify-content: flex-end;
 }
 
 .agent-client-button-block-button {


### PR DESCRIPTION
## Summary
Two related surface improvements:

  1. **Recent chats** quick access to recent sessions from the chat header
     ("Show recent chats in chat" setting).
  2. **Agent images** agent avatars rendered across the chat interfaces, with a
     reusable image picker for choosing them ("Show agent images" setting).

  ## Key changes
  - `src/ui/shared/AgentAvatar.tsx` shared avatar component + resolver, gated on
    `showAgentImagesInChatInterfaces`
  - `src/ui/shared/ImageSelect.tsx` portal-based image/option picker
  - `src/ui/ChatHeader.tsx` recent-chats entry point and header rework
  - `src/ui/SettingsTab.ts` "Show recent chats in chat" + "Show agent images" toggles
  - This branch also consolidates the starter-prompt code from #308 into the
    shared message flow (note the `useAgentMessages.ts` cleanup in the diff).
<img width="2880" height="1920" alt="image" src="https://github.com/user-attachments/assets/1892c5ca-ed25-4543-be46-cc61590cbb9c" />
