### PR TITLE
feat: redesign permission request options as a vertical icon list

### DIFF
--- a/src/acp/permission-handler.ts
+++ b/src/acp/permission-handler.ts
@@ -112,12 +112,10 @@ export class PermissionManager {
 
 		const normalizedOptions: PermissionOption[] = params.options.map(
 			(option) => {
-				const normalizedKind =
-					option.kind === "reject_always"
-						? "reject_once"
-						: option.kind;
-				const kind: PermissionOption["kind"] = normalizedKind
-					? normalizedKind
+				// Use the agent-provided kind as-is. Only infer from the
+				// option name when a non-conforming agent omits kind.
+				const kind: PermissionOption["kind"] = option.kind
+					? option.kind
 					: option.name.toLowerCase().includes("allow")
 						? "allow_once"
 						: "reject_once";

--- a/src/ui/PermissionBanner.tsx
+++ b/src/ui/PermissionBanner.tsx
@@ -2,11 +2,7 @@ import { getLogger } from "../utils/logger";
 import type { PermissionOption } from "../types/chat";
 import { LucideIcon } from "./shared/IconButton";
 
-/**
- * Maps permission option kind to its Lucide icon name.
- * Kind semantics are conveyed by icon shape + color (the button
- * background stays neutral for theme compatibility).
- */
+/** Kind semantics are conveyed by icon shape + color, not button background. */
 const KIND_ICONS: Record<PermissionOption["kind"], string> = {
 	allow_always: "check-check",
 	allow_once: "check",

--- a/src/ui/PermissionBanner.tsx
+++ b/src/ui/PermissionBanner.tsx
@@ -1,5 +1,18 @@
 import { getLogger } from "../utils/logger";
 import type { PermissionOption } from "../types/chat";
+import { LucideIcon } from "./shared/IconButton";
+
+/**
+ * Maps permission option kind to its Lucide icon name.
+ * Kind semantics are conveyed by icon shape + color (the button
+ * background stays neutral for theme compatibility).
+ */
+const KIND_ICONS: Record<PermissionOption["kind"], string> = {
+	allow_always: "check-check",
+	allow_once: "check",
+	reject_once: "x",
+	reject_always: "ban",
+};
 
 interface PermissionBannerProps {
 	permissionRequest: {
@@ -9,6 +22,8 @@ interface PermissionBannerProps {
 		isCancelled?: boolean;
 		isActive?: boolean;
 	};
+	/** Whether to show kind icons (follows displaySettings.showEmojis) */
+	showEmojis: boolean;
 	/** Callback to approve a permission request */
 	onApprovePermission?: (
 		requestId: string,
@@ -19,6 +34,7 @@ interface PermissionBannerProps {
 
 export function PermissionBanner({
 	permissionRequest,
+	showEmojis,
 	onApprovePermission,
 	onOptionSelected,
 }: PermissionBannerProps) {
@@ -35,7 +51,8 @@ export function PermissionBanner({
 			{permissionRequest.options.map((option) => (
 				<button
 					key={option.optionId}
-					className={`agent-client-permission-option ${option.kind ? `agent-client-permission-kind-${option.kind}` : ""}`}
+					className={`agent-client-permission-option agent-client-permission-kind-${option.kind}`}
+					title={option.name}
 					onClick={() => {
 						if (onOptionSelected) {
 							onOptionSelected(option.optionId);
@@ -53,7 +70,15 @@ export function PermissionBanner({
 						}
 					}}
 				>
-					{option.name}
+					{showEmojis && (
+						<LucideIcon
+							name={KIND_ICONS[option.kind]}
+							className="agent-client-permission-option-icon"
+						/>
+					)}
+					<span className="agent-client-permission-option-label">
+						{option.name}
+					</span>
 				</button>
 			))}
 		</div>

--- a/src/ui/ToolCallBlock.tsx
+++ b/src/ui/ToolCallBlock.tsx
@@ -175,6 +175,7 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 						...permissionRequest,
 						selectedOptionId: selectedOptionId,
 					}}
+					showEmojis={showEmojis}
 					onApprovePermission={onApprovePermission}
 					onOptionSelected={setSelectedOptionId}
 				/>

--- a/styles.css
+++ b/styles.css
@@ -413,82 +413,85 @@ If your plugin does not need CSS, delete this file.
 	font-weight: bold;
 }
 
-/* Permission Request */
+/* ===== Permission Request (vertical option list) ===== */
+/* Mirrors .agent-client-tool-call-diff: full-bleed block inside the
+   tool call with a 1px border container. Kind colors live on the icon,
+   not the button background (theme compatibility). */
 .agent-client-message-permission-request {
 	display: flex;
-	flex-wrap: wrap;
-	gap: 8px;
-	justify-content: flex-end;
-	padding: 6px 0;
-	margin-top: 4px;
+	flex-direction: column;
+	margin-top: 8px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	overflow: hidden;
 }
 
-/* ===== Permission Request Buttons ===== */
-.agent-client-permission-option {
-	padding: 8px 16px !important;
-	border: 1px solid var(--background-modifier-border) !important;
-	border-radius: 6px !important;
-	background-color: var(--background-primary) !important;
-	color: var(--text-normal) !important;
+.agent-client-message-permission-request .agent-client-permission-option {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	padding: 8px 12px;
+	border: none;
+	border-radius: 0;
+	background-color: var(--background-primary);
+	box-shadow: none;
+	color: var(--text-normal);
 	cursor: pointer;
 	font-size: 13px;
 	font-weight: 500;
-	transition: all 0.2s ease;
-	min-width: 80px;
-	text-align: center;
-	opacity: 1;
+	text-align: left;
 }
 
-.agent-client-permission-option.agent-client-selected {
-	background-color: var(--interactive-accent) !important;
-	color: white !important;
-	font-weight: 600;
+.agent-client-message-permission-request
+	.agent-client-permission-option
+	+ .agent-client-permission-option {
+	border-top: 1px solid var(--background-modifier-border);
 }
 
-.agent-client-permission-option.agent-client-disabled {
-	background-color: var(--background-modifier-border) !important;
-	color: var(--text-muted) !important;
-	cursor: not-allowed !important;
+.agent-client-message-permission-request .agent-client-permission-option:hover {
+	background-color: var(--background-modifier-hover);
 }
 
-.agent-client-permission-option.agent-client-disabled:not(
-		.agent-client-selected
-	) {
-	opacity: 0.5;
+.agent-client-message-permission-request
+	.agent-client-permission-option:focus-visible {
+	outline: 2px solid var(--interactive-accent);
+	outline-offset: -2px;
 }
 
-/* Special kinds */
-.agent-client-permission-option.agent-client-permission-kind-allow_always:not(
-		.agent-client-selected
-	):not(.agent-client-disabled) {
-	background-color: var(--color-green) !important;
-	color: white !important;
-	border-color: var(--color-green) !important;
+.agent-client-permission-option-icon {
+	display: flex;
+	align-items: center;
+	flex-shrink: 0;
 }
 
-.agent-client-permission-option.agent-client-permission-kind-reject_once:not(
-		.agent-client-selected
-	):not(.agent-client-disabled) {
-	background-color: var(--color-red) !important;
-	color: white !important;
-	border-color: var(--color-red) !important;
+.agent-client-permission-option-icon svg {
+	width: 14px;
+	height: 14px;
 }
 
-.agent-client-permission-option.agent-client-permission-kind-allow_once:not(
-		.agent-client-selected
-	):not(.agent-client-disabled) {
-	background-color: var(--color-orange) !important;
-	color: white !important;
-	border-color: var(--color-orange) !important;
+.agent-client-permission-option-label {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
-/* Normal option button hover (no kind specified) */
-.agent-client-permission-option:not(
-		.agent-client-permission-kind-allow_always
-	):not(.agent-client-permission-kind-reject_once):not(
-		.agent-client-permission-kind-allow_once
-	):not(.agent-client-disabled):not(.agent-client-selected):hover {
-	background-color: var(--background-modifier-hover) !important;
+/* Kind colors (icon only) */
+.agent-client-permission-kind-allow_always
+	.agent-client-permission-option-icon {
+	color: var(--color-green);
+}
+
+.agent-client-permission-kind-allow_once .agent-client-permission-option-icon {
+	color: var(--color-orange);
+}
+
+.agent-client-permission-kind-reject_once .agent-client-permission-option-icon,
+.agent-client-permission-kind-reject_always
+	.agent-client-permission-option-icon {
+	color: var(--color-red);
 }
 
 /* ===== Chat View Components ===== */


### PR DESCRIPTION
## Description

Permission request buttons are currently a right-aligned horizontal row with solid color-coded backgrounds. This layout has several problems:

- Button positions and sizes shift depending on option name length and view width (the sidebar is ~300px wide), so the row wraps unpredictably and is easy to misclick
- Long option names overflow the buttons
- The solid `--color-green/red/orange` + white text backgrounds clash with many themes and require 11 `!important` declarations to maintain

This PR replaces the row with full-width option buttons stacked vertically inside a thin bordered container, matching the styling of diff blocks within tool calls.

### Before / After

| | Before | After |
|---|---|---|
| Layout | Right-aligned `flex-wrap` row | Full-width rows stacked vertically, divider between rows |
| Kind indication | Solid button background color | Colored Lucide icon at the left of each row |
| Long names | Overflow | Single-line ellipsis + full text via `title` tooltip |
| Hover | Per-kind rules with 5-deep `:not()` chains | Neutral `--background-modifier-hover` (theme-respecting) |

### Kind → icon mapping

| kind | Icon | Color |
|---|---|---|
| `allow_always` | `check-check` | green |
| `allow_once` | `check` | orange |
| `reject_once` | `x` | red |
| `reject_always` | `ban` | red |

Icons follow the existing `displaySettings.showEmojis` setting, same as the other tool call icons (text-only rows when disabled).

### Behavior change: `reject_always` is no longer normalized

`PermissionManager` previously remapped `reject_always` → `reject_once`, a leftover from the old design having only three color styles. The agent-provided kind is now passed through as-is so "reject always" options keep their meaning (the name-based inference fallback for agents that omit `kind` remains).

Minor intended side effect: the "Reject active permission" hotkey prefers `["reject_once", "reject_always"]` in order, so when an agent offers both, the hotkey now picks the less destructive `reject_once` instead of whichever reject option came first in the array.

### How it works

- `PermissionBanner` renders each option as a full-width `<button>` with a `LucideIcon` + ellipsized label. The kind→icon mapping is a `Record<PermissionOption["kind"], string>`, so the compiler enforces exhaustiveness if the kind union ever grows. `showEmojis` is passed as a prop from `ToolCallBlock` (same pattern as `ErrorBanner`), keeping the component plugin-independent.
- The container mirrors `.agent-client-tool-call-diff` (1px border, 4px radius, `overflow: hidden`, 8px top margin) so permission lists and diffs share the same visual grammar inside tool calls.
- Selection semantics are unchanged: options keep the agent-provided order, clicking still hides the banner optimistically via the existing `selectedOptionId` local state, and a rejected call still shows the `x` (failed) status icon on the tool call header.
- `:focus-visible` uses an inset outline (`outline-offset: -2px`) so keyboard focus stays visible despite the container's `overflow: hidden`.
- All `!important` declarations are removed; specificity is handled structurally with compound selectors. The unreachable `.agent-client-selected` / `.agent-client-disabled` permission styles (dead since the banner unmounts on selection) are deleted.

## Related issue

N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: macOS

## Screenshots

<img width="386" height="334" alt="image" src="https://github.com/user-attachments/assets/03716c23-6a52-48ef-a0e6-7760be42a3d4" />
