### PR TITLE
fix: fall back to known install paths when shell lookup fails in auto…

### DIFF
--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,5 +1,7 @@
 import { execFile } from "child_process";
 import { Platform } from "obsidian";
+import { existsSync } from "fs";
+import { join } from "path";
 import { buildWslShellWrapper, getLoginShell } from "./platform";
 
 /**
@@ -7,6 +9,29 @@ import { buildWslShellWrapper, getLoginShell } from "./platform";
  */
 export function isAbsolutePath(path: string): boolean {
 	return path.startsWith("/") || /^[A-Za-z]:[\\/]/.test(path);
+}
+
+/**
+ * Fallback path resolution for when `which` returns nothing.
+ * On macOS, GUI-launched apps (Finder/Dock) inherit a reduced PATH that
+ * excludes Homebrew's bin directory (/opt/homebrew/bin on Apple Silicon),
+ * so `which` can fail even when the command is installed. Checks common
+ * install directories directly to cover that case.
+ *
+ * @param command - Command name (e.g. "node", "codex-acp")
+ * @returns Absolute path string, or null if not found in known directories
+ */
+function findInKnownPaths(command: string): string | null {
+	const dirs = Platform.isMacOS
+		? ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"]
+		: ["/usr/local/bin", "/usr/bin", "/bin"];
+
+	for (const dir of dirs) {
+		const candidate = join(dir, command);
+		if (existsSync(candidate)) return candidate;
+	}
+
+	return null;
 }
 
 /**
@@ -50,11 +75,15 @@ export function resolveCommandPath(command: string): Promise<string | null> {
 				{ timeout: 5000 },
 				(err, stdout) => {
 					if (err) {
-						resolve(null);
+						resolve(findInKnownPaths(trimmed));
 						return;
 					}
 					const resolved = stdout.split("\n")[0].trim();
-					resolve(resolved.length > 0 ? resolved : null);
+					resolve(
+						resolved.length > 0
+							? resolved
+							: findInKnownPaths(trimmed),
+					);
 				},
 			);
 		}


### PR DESCRIPTION
## Description

On macOS Silicon, the "Auto-detect" button for the Node.js / agent paths returns "Not found" even when the binary is installed (e.g. `/opt/homebrew/bin/node`). Only manually entering the absolute path works.

The root cause is in `resolveCommandPath`, which resolves bare command names by running `which` through a login shell. When Obsidian is launched from Finder/Dock rather than a terminal, the spawned process inherits a reduced PATH that excludes Homebrew's path (/opt/homebrew/bin) so `which node` returns nothing even though the binary exists on disk. Confirmed locally: `zsh -l -c "which node"` resolves from Terminal but returns nothing in the GUI-launched app environment.

This change adds a fallback: when the shell lookup fails or returns empty, it checks common install directories directly on the filesystem, which doesn't depend on PATH. The `which` lookup stays primary and the fallback only runs when it fails, so a successful resolution is never overridden. macOS checks `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, `/bin`; Linux checks `/usr/local/bin`, `/usr/bin`, `/bin`. 

Linuxbrew (/home/linuxbrew/.linuxbrew/bin) is not included since I couldn't test it, but it's a straightforward addition if wanted. Windows (`where`) and WSL resolution are unchanged.

## Related issue

Related to #302. That issue, which I submitted, showed a perpetual "Connecting to Codex…" state, which traces back to this path-resolution failure. This PR addresses the resolution cause. It does not add timeout or error feedback for the case where a configured-but-broken path hangs the connection, which is a separate improvement that I might open its own PR for. 

For context on how this manifested in #302: my PATH defaulted to a stale Node v18 install at `/usr/local/bin/node`, and this was the path I provided/was auto-detected (`/opt/homebrew/bin` had Node v24). After removing the stale version, I tried auto detection but the path resolution kept coming back empty: the working Node at `/opt/homebrew/bin/node` was invisible because that directory isn't on the GUI-launched PATH. Both states are the same underlying issue: resolution can't see `/opt/homebrew/bin`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes 
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- OS: macOS (Apple Silicon)

## Screenshots

None attached