### PR TITLE
feat: add Mistral Vibe as a built-in agent provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Client Plugin - LLM Developer Guide
 
 ## Overview
-Obsidian plugin for AI agent interaction (Claude Code, Codex, Gemini CLI, custom agents) via ACP.
+Obsidian plugin for AI agent interaction (Claude Code, Codex, Gemini CLI, Mistral Vibe, custom agents) via ACP.
 
 **Tech**: React 19, TypeScript, Obsidian API, Agent Client Protocol (ACP)
 
@@ -12,7 +12,7 @@ src/
 ├── types/                       # Type definitions (no logic, no dependencies)
 │   ├── chat.ts                  # ChatMessage, MessageContent, PromptContent, AttachedFile, ActivePermission
 │   ├── session.ts               # ChatSession, SessionUpdate (12-type union), SessionInfo, Capabilities
-│   ├── agent.ts                 # AgentConfig, agent settings (Claude/Codex/Gemini/Custom)
+│   ├── agent.ts                 # AgentConfig, agent settings (Claude/Codex/Gemini/Mistral Vibe/Custom)
 │   └── errors.ts                # AcpError, ProcessError, ErrorInfo
 ├── acp/                         # ACP protocol (SDK dependency confined here)
 │   ├── acp-client.ts            # Process lifecycle, UI-facing API (AcpClient class)
@@ -323,6 +323,7 @@ interface ISettingsAccess {
 - Claude Code: `@agentclientprotocol/claude-agent-acp` (ANTHROPIC_API_KEY)
 - Codex: `@zed-industries/codex-acp` (OPENAI_API_KEY)
 - Gemini CLI: `@google/gemini-cli` (GEMINI_API_KEY)
+- Mistral Vibe: `mistral-vibe` (MISTRAL_API_KEY)
 - Custom: Any ACP-compatible agent
 
 ---

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="https://www.buymeacoffee.com/rait09" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" width="180" height="50" ></a>
 </p>
 
-AIエージェント（Claude Code、Codex、Gemini CLI）をObsidianに直接統合。Vault内からAIアシスタントとチャットできます。
+AIエージェント（Claude Code、Codex、Gemini CLI、Mistral Vibe）をObsidianに直接統合。Vault内からAIアシスタントとチャットできます。
 
 このプラグインは、Zed の [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/agent-client-protocol) で構築されています。
 
@@ -27,7 +27,7 @@ https://github.com/user-attachments/assets/1c538349-b3fb-44dd-a163-7331cbca7824
 - **ノートメンション**: `@ノート名`でノートを参照
 - **画像添付**: チャットに画像をペーストまたはドラッグ&ドロップ
 - **スラッシュコマンド**: エージェントが提供する`/`コマンドを使用
-- **マルチエージェント**: Claude Code、Codex、Gemini CLI、カスタムエージェントを切り替え
+- **マルチエージェント**: Claude Code、Codex、Gemini CLI、Mistral Vibe、カスタムエージェントを切り替え
 - **マルチセッション**: 複数のエージェントを別々のビューで同時実行
 - **フローティングチャット**: 素早くアクセスできる折りたたみ可能なチャットウィンドウ
 - **モード・モデル切り替え**: チャット画面からAIモデルやエージェントモードを変更
@@ -96,7 +96,8 @@ https://github.com/user-attachments/assets/1c538349-b3fb-44dd-a163-7331cbca7824
 - [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html)
 - [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html)
 - [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html)
-- [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)（OpenCode、Qwen Code、Kiro、Mistral Vibeなど）
+- [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html)
+- [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)（OpenCode、Qwen Code、Kiroなど）
 
 **[ドキュメント全文](https://rait-09.github.io/obsidian-agent-client/)**
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://www.buymeacoffee.com/rait09" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" width="180" height="50" ></a>
 </p>
 
-Bring AI agents (Claude Code, Codex, Gemini CLI) directly into Obsidian. Chat with your AI assistant right from your vault.
+Bring AI agents (Claude Code, Codex, Gemini CLI, Mistral Vibe) directly into Obsidian. Chat with your AI assistant right from your vault.
 
 Built on [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/agent-client-protocol) by Zed.
 
@@ -31,7 +31,7 @@ https://github.com/user-attachments/assets/1c538349-b3fb-44dd-a163-7331cbca7824
 - **Note Mentions**: Reference your notes with `@notename` syntax
 - **Image Attachments**: Paste or drag-and-drop images into the chat
 - **Slash Commands**: Use `/` commands provided by your agent
-- **Multi-Agent Support**: Switch between Claude Code, Codex, Gemini CLI, and custom agents
+- **Multi-Agent Support**: Switch between Claude Code, Codex, Gemini CLI, Mistral Vibe, and custom agents
 - **Multi-Session**: Run multiple agents simultaneously in separate views
 - **Floating Chat**: A persistent, collapsible chat window for quick access
 - **Mode & Model Switching**: Change AI models and agent modes from the chat
@@ -100,7 +100,8 @@ Open a terminal (Terminal on macOS/Linux, PowerShell on Windows) and run the fol
 - [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html)
 - [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html)
 - [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html)
-- [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html) (OpenCode, Qwen Code, Kiro, Mistral Vibe, etc.)
+- [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html)
+- [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html) (OpenCode, Qwen Code, Kiro, etc.)
 
 **[Full Documentation](https://rait-09.github.io/obsidian-agent-client/)**
 

--- a/docs/agent-setup/index.md
+++ b/docs/agent-setup/index.md
@@ -9,6 +9,7 @@ Agent Client supports multiple AI agents through the [Agent Client Protocol (ACP
 | [Claude Code](./claude-code) | Anthropic | `@agentclientprotocol/claude-agent-acp` |
 | [Codex](./codex) | OpenAI | `@zed-industries/codex-acp` |
 | [Gemini CLI](./gemini-cli) | Google | `@google/gemini-cli` |
+| [Mistral Vibe](./mistral-vibe) | Mistral AI | `mistral-vibe` |
 | [Custom Agents](./custom-agents) | Various | Any ACP-compatible agent |
 
 ## Common Setup Steps

--- a/docs/agent-setup/mistral-vibe.md
+++ b/docs/agent-setup/mistral-vibe.md
@@ -1,0 +1,67 @@
+# Mistral Vibe Setup
+
+Mistral Vibe is Mistral AI's coding agent. It communicates via ACP through the `vibe-acp` command.
+
+## Install and Configure
+
+Open a terminal (Terminal on macOS/Linux, PowerShell on Windows) and run the following commands.
+
+1. Install Mistral Vibe:
+
+```bash
+curl -LsSf https://mistral.ai/vibe/install.sh | bash
+```
+
+2. Find the installation path:
+
+::: code-group
+
+```bash [macOS/Linux]
+which vibe-acp
+# Example output: /Users/username/.local/bin/vibe-acp
+```
+
+```cmd [Windows]
+where.exe vibe-acp
+```
+
+:::
+
+3. Open **Settings → Agent Client**. The default command (`vibe-acp`) works in many cases. If the agent is not found automatically, set the **Mistral Vibe path** to the path found above, or click **Auto-detect**.
+
+## Authentication
+
+Choose one of the following methods:
+
+### Option A: Mistral Account Login (Interactive)
+
+If you have a Mistral account and prefer not to use an API key:
+
+1. Run Vibe in your terminal:
+
+```bash
+vibe
+```
+
+2. Follow the setup wizard to choose your authentication method.
+
+3. In **Settings → Agent Client**, leave the **API key field empty**.
+
+### Option B: Mistral API Key
+
+If you prefer to use an API key for authentication:
+
+1. Get your API key from the [Mistral Console](https://console.mistral.ai/)
+2. Enter the API key in **Settings → Agent Client → Mistral Vibe → API key**
+
+::: tip If the key isn't picked up
+If authentication still fails, set the key on the Vibe side instead: run `vibe --setup` in your terminal and configure your API key (it's stored in `~/.vibe/config.toml`). Then leave the **API key field empty** in Agent Client.
+:::
+
+## Verify Setup
+
+1. Click the robot icon in the ribbon or use the command palette: **"Open chat view"**
+2. Switch to Mistral Vibe from the agent dropdown in the chat header
+3. Try sending a message to verify the connection
+
+Having issues? See [Troubleshooting](/help/troubleshooting).

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -37,13 +37,14 @@ import {
 	GeminiAgentSettings,
 	ClaudeAgentSettings,
 	CodexAgentSettings,
+	MistralVibeAgentSettings,
 	CustomAgentSettings,
 } from "./types/agent";
 import type { SavedSessionInfo } from "./types/session";
 import { initializeLogger } from "./utils/logger";
 
 // Re-export for backward compatibility
-export type { AgentEnvVar, CustomAgentSettings };
+export type { AgentEnvVar, MistralVibeAgentSettings, CustomAgentSettings };
 
 /**
  * Send message shortcut configuration.
@@ -69,6 +70,7 @@ export interface AgentClientPluginSettings {
 	gemini: GeminiAgentSettings;
 	claude: ClaudeAgentSettings;
 	codex: CodexAgentSettings;
+	mistralVibe: MistralVibeAgentSettings;
 	customAgents: CustomAgentSettings[];
 	/** Default agent ID for new views (renamed from activeAgentId for multi-session) */
 	defaultAgentId: string;
@@ -142,6 +144,14 @@ const DEFAULT_SETTINGS: AgentClientPluginSettings = {
 		apiKey: "",
 		command: "gemini",
 		args: ["--experimental-acp"],
+		env: [],
+	},
+	mistralVibe: {
+		id: "vibe-acp",
+		displayName: "Mistral Vibe",
+		apiKey: "",
+		command: "vibe-acp",
+		args: [],
 		env: [],
 	},
 	customAgents: [],
@@ -632,6 +642,12 @@ export default class AgentClientPlugin extends Plugin {
 				displayName:
 					this.settings.gemini.displayName || this.settings.gemini.id,
 			},
+			{
+				id: this.settings.mistralVibe.id,
+				displayName:
+					this.settings.mistralVibe.displayName ||
+					this.settings.mistralVibe.id,
+			},
 			...this.settings.customAgents.map((agent) => ({
 				id: agent.id,
 				displayName: agent.displayName || agent.id,
@@ -834,6 +850,7 @@ export default class AgentClientPlugin extends Plugin {
 		const rc = obj(raw.claude) ?? {};
 		const rk = obj(raw.codex) ?? {};
 		const rg = obj(raw.gemini) ?? {};
+		const rmv = obj(raw.mistralVibe) ?? {};
 		const re = obj(raw.exportSettings) ?? {};
 		const rd = obj(raw.displaySettings) ?? {};
 
@@ -851,6 +868,7 @@ export default class AgentClientPlugin extends Plugin {
 			D.claude.id,
 			D.codex.id,
 			D.gemini.id,
+			D.mistralVibe.id,
 			...customAgents.map((a) => a.id),
 		];
 		const rawDefaultId =
@@ -895,6 +913,14 @@ export default class AgentClientPlugin extends Plugin {
 						? sanitizeArgs(rg.args)
 						: D.gemini.args,
 				env: normalizeEnvVars(rg.env),
+			},
+			mistralVibe: {
+				id: D.mistralVibe.id,
+				displayName: str(rmv.displayName, D.mistralVibe.displayName),
+				apiKey: str(rmv.apiKey, D.mistralVibe.apiKey),
+				command: str(rmv.command, "") || D.mistralVibe.command,
+				args: sanitizeArgs(rmv.args),
+				env: normalizeEnvVars(rmv.env),
 			},
 			customAgents,
 			defaultAgentId,
@@ -1116,6 +1142,7 @@ export default class AgentClientPlugin extends Plugin {
 		ids.add(this.settings.claude.id);
 		ids.add(this.settings.codex.id);
 		ids.add(this.settings.gemini.id);
+		ids.add(this.settings.mistralVibe.id);
 		for (const agent of this.settings.customAgents) {
 			if (agent.id && agent.id.length > 0) {
 				ids.add(agent.id);

--- a/src/services/session-helpers.ts
+++ b/src/services/session-helpers.ts
@@ -9,6 +9,7 @@ import type {
 	ClaudeAgentSettings,
 	GeminiAgentSettings,
 	CodexAgentSettings,
+	MistralVibeAgentSettings,
 } from "../types/agent";
 import type { ChatSession } from "../types/session";
 import { toAgentConfig } from "./settings-normalizer";
@@ -59,6 +60,11 @@ export function getAvailableAgentsFromSettings(
 			id: settings.gemini.id,
 			displayName: settings.gemini.displayName || settings.gemini.id,
 		},
+		{
+			id: settings.mistralVibe.id,
+			displayName:
+				settings.mistralVibe.displayName || settings.mistralVibe.id,
+		},
 		...settings.customAgents.map((agent) => ({
 			id: agent.id,
 			displayName: agent.displayName || agent.id,
@@ -102,6 +108,9 @@ export function findAgentSettings(
 	}
 	if (agentId === settings.gemini.id) {
 		return settings.gemini;
+	}
+	if (agentId === settings.mistralVibe.id) {
+		return settings.mistralVibe;
 	}
 	// Search in custom agents
 	const customAgent = settings.customAgents.find(
@@ -149,6 +158,16 @@ export function buildAgentConfigWithApiKey(
 			env: {
 				...baseConfig.env,
 				GEMINI_API_KEY: geminiSettings.apiKey,
+			},
+		};
+	}
+	if (agentId === settings.mistralVibe.id) {
+		const mistralSettings = agentSettings as MistralVibeAgentSettings;
+		return {
+			...baseConfig,
+			env: {
+				...baseConfig.env,
+				MISTRAL_API_KEY: mistralSettings.apiKey,
 			},
 		};
 	}

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -84,6 +84,16 @@ export interface CodexAgentSettings extends BaseAgentSettings {
 }
 
 /**
+ * Configuration for Mistral Vibe agent.
+ *
+ * Extends base settings with Mistral-specific requirements.
+ */
+export interface MistralVibeAgentSettings extends BaseAgentSettings {
+	/** Mistral API key (MISTRAL_API_KEY) */
+	apiKey: string;
+}
+
+/**
  * Configuration for custom ACP-compatible agents.
  *
  * Uses only the base settings, allowing users to configure

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -500,6 +500,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		this.renderClaudeSettings(containerEl);
 		this.renderCodexSettings(containerEl);
 		this.renderGeminiSettings(containerEl);
+		this.renderMistralVibeSettings(containerEl);
 
 		new Setting(containerEl).setName("Custom agents").setHeading();
 
@@ -783,6 +784,11 @@ export class AgentClientSettingTab extends PluginSettingTab {
 				this.plugin.settings.gemini.displayName ||
 					this.plugin.settings.gemini.id,
 			),
+			toOption(
+				this.plugin.settings.mistralVibe.id,
+				this.plugin.settings.mistralVibe.displayName ||
+					this.plugin.settings.mistralVibe.id,
+			),
 		];
 		for (const agent of this.plugin.settings.customAgents) {
 			if (agent.id && agent.id.length > 0) {
@@ -1029,6 +1035,87 @@ export class AgentClientSettingTab extends PluginSettingTab {
 			});
 	}
 
+	private renderMistralVibeSettings(sectionEl: HTMLElement) {
+		const mistralVibe = this.plugin.settings.mistralVibe;
+
+		new Setting(sectionEl)
+			.setName(mistralVibe.displayName || "Mistral Vibe")
+			.setHeading();
+
+		new Setting(sectionEl)
+			.setName("API key")
+			.setDesc(
+				"Mistral API key. Required if not logging in with a Mistral account. (Stored as plain text)",
+			)
+			.addText((text) => {
+				text.setPlaceholder("Enter your Mistral API key")
+					.setValue(mistralVibe.apiKey)
+					.onChange(async (value) => {
+						this.plugin.settings.mistralVibe.apiKey = value.trim();
+						await this.plugin.saveSettings();
+					});
+				text.inputEl.type = "password";
+			});
+
+		const vibePathSetting = new Setting(sectionEl)
+			.setName("Path")
+			.setDesc(
+				'Command name or path to vibe-acp. Use just "vibe-acp" to let the login shell resolve it, or enter an absolute path.',
+			)
+			.addText((text) => {
+				text.setPlaceholder("vibe-acp")
+					.setValue(mistralVibe.command)
+					.onChange(async (value) => {
+						this.plugin.settings.mistralVibe.command = value.trim();
+						await this.plugin.saveSettings();
+					});
+			});
+		this.addAutoDetectButton(
+			vibePathSetting,
+			"vibe-acp",
+			async (path) => {
+				this.plugin.settings.mistralVibe.command = path;
+				await this.plugin.saveSettings();
+			},
+		);
+		this.addInstallHintCustom(
+			sectionEl,
+			"curl -LsSf https://mistral.ai/vibe/install.sh | bash",
+		);
+
+		new Setting(sectionEl)
+			.setName("Arguments")
+			.setDesc(
+				"Enter one argument per line. Leave empty to run without arguments.",
+			)
+			.addTextArea((text) => {
+				text.setPlaceholder("")
+					.setValue(this.formatArgs(mistralVibe.args))
+					.onChange(async (value) => {
+						this.plugin.settings.mistralVibe.args =
+							this.parseArgs(value);
+						await this.plugin.saveSettings();
+					});
+				text.inputEl.rows = 3;
+			});
+
+		new Setting(sectionEl)
+			.setName("Environment variables")
+			.setDesc(
+				"Enter KEY=VALUE pairs, one per line. MISTRAL_API_KEY is derived from the field above.",
+			)
+			.addTextArea((text) => {
+				text.setPlaceholder("")
+					.setValue(this.formatEnv(mistralVibe.env))
+					.onChange(async (value) => {
+						this.plugin.settings.mistralVibe.env =
+							this.parseEnv(value);
+						await this.plugin.saveSettings();
+					});
+				text.inputEl.rows = 3;
+			});
+	}
+
 	private renderCustomAgents(containerEl: HTMLElement) {
 		if (this.plugin.settings.customAgents.length === 0) {
 			containerEl.createEl("p", {
@@ -1228,6 +1315,31 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	 */
 	private addInstallHint(containerEl: HTMLElement, npmPackage: string): void {
 		const command = `npm install -g ${npmPackage}@latest`;
+		const frag = createFragment();
+		frag.appendText("Not installed? Run in terminal: ");
+		frag.createEl("code", { text: command });
+		new Setting(containerEl).setDesc(frag).addButton((btn) => {
+			btn.setButtonText("Copy").onClick(() => {
+				void navigator.clipboard.writeText(command).then(
+					() => {
+						btn.setButtonText("Copied!");
+						window.setTimeout(() => {
+							btn.setButtonText("Copy");
+						}, 1500);
+					},
+					() => undefined,
+				);
+			});
+		});
+	}
+
+	/**
+	 * Renders a copyable install command hint below a Path setting (custom command).
+	 */
+	private addInstallHintCustom(
+		containerEl: HTMLElement,
+		command: string,
+	): void {
 		const frag = createFragment();
 		frag.appendText("Not installed? Run in terminal: ");
 		frag.createEl("code", { text: command });


### PR DESCRIPTION
## Description

Add first-party support for Mistral Vibe (vibe-acp) alongside Claude Code, Codex, and Gemini CLI. Includes settings UI with API key, path auto-detect, and a curl-based install hint.

## Related issue

Closes #313

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Mistral Vibe 2.14.1
- OS: macOS 26.5

## Screenshots

### Config 

<img width="920" height="680" alt="Screenshot 2026-06-09 at 07 22 09" src="https://github.com/user-attachments/assets/bf5f6624-155c-4233-a7cb-9a94a6f6e61f" />
<img width="916" height="678" alt="Screenshot 2026-06-09 at 07 21 57" src="https://github.com/user-attachments/assets/9cc35796-646e-4094-a796-4c51b611e713" />

### Usage

<img width="406" height="331" alt="Screenshot 2026-06-09 at 07 23 26" src="https://github.com/user-attachments/assets/47ec63d4-61cf-413d-a2cd-fb049bffef0f" />

