### PR TITLE
feat(session-manager): show full title and agent name on hover

### DIFF
--- a/src/ui/SessionManagerView.tsx
+++ b/src/ui/SessionManagerView.tsx
@@ -124,8 +124,18 @@ const SessionItem = React.memo(function SessionItem({
 			>
 				<SessionStatusIcon status={status} />
 				<div className="tree-item-inner agent-client-session-item-text">
-					<div className="agent-client-session-item-title">{title}</div>
-					<div className="agent-client-session-item-agent">{agentName}</div>
+					<div
+						className="agent-client-session-item-title"
+						aria-label={title}
+					>
+						{title}
+					</div>
+					<div
+						className="agent-client-session-item-agent"
+						aria-label={agentName}
+					>
+						{agentName}
+					</div>
 				</div>
 				<button
 					ref={moreRef}


### PR DESCRIPTION
## Description

In the Session Manager, long session titles and agent names are truncated with an ellipsis, with no way to read the full text. This adds an `aria-label` carrying the full text to both the title and agent-name elements, so hovering shows Obsidian's native tooltip with the untruncated text.

This mirrors the existing approach used by the context-usage indicator (`InputToolbar`) and the toolbar/icon buttons (`aria-label`). No CSS/layout changes — the chat itself stays non-horizontally-scrollable.

## Related issue

Closes #324

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed (N/A — small UI affordance)

## Testing environment

- Agent: N/A (UI-only, not agent-specific)
- OS: macOS (Obsidian 1.12.7)

## Screenshots

Hover a truncated session title / agent name in the Session Manager → the full text appears as a tooltip. (Verified working.)
