### PR TITLE
fix(markdown): make wide display math horizontally scrollable

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1320,7 +1320,10 @@ If your plugin does not need CSS, delete this file.
 .agent-client-markdown-text-renderer.markdown-rendered pre,
 .agent-client-markdown-text-renderer.markdown-rendered table,
 .agent-client-markdown-text-renderer.markdown-rendered .mermaid,
-.agent-client-markdown-text-renderer.markdown-rendered svg {
+.agent-client-markdown-text-renderer.markdown-rendered svg,
+.agent-client-markdown-text-renderer.markdown-rendered .math-block,
+.agent-client-markdown-text-renderer.markdown-rendered
+	mjx-container[display="true"] {
 	overflow-x: auto;
 	display: block;
 }


### PR DESCRIPTION
## Description

Long display math (`$$...$$`) rendered wider than the chat would overflow and get clipped by the message container (`overflow-x: hidden`), with no way to scroll — so part of the equation was unreadable.

This adds display-math to the existing "wide block content scrolls within its own block" opt-in list (alongside `pre` / `table` / `.mermaid` / `svg`), so a wide equation scrolls horizontally on its own while the chat overall stays non-horizontally-scrollable. Both the Obsidian wrapper (`.math-block`) and the MathJax block container (`mjx-container[display="true"]`) are added — mirroring how Mermaid opts in both its wrapper (`.mermaid`) and inner `svg`. Block-only: inline math is untouched.

## Related issue

Closes #322

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed (N/A — CSS-only)

## Testing environment

- Agent: N/A (CSS/rendering, not agent-specific)
- OS: macOS (Obsidian 1.12.7)

## Screenshots

A wide `$$...$$` equation now scrolls horizontally within its own block; inline math, code blocks, tables, and Mermaid are unaffected. (Verified working.)
