### PR TITLE
fix(permission): clear stuck permission buttons after canceling a response

### DIFF
--- a/src/hooks/useAgentMessages.ts
+++ b/src/hooks/useAgentMessages.ts
@@ -194,13 +194,15 @@ export function useAgentMessages(
 		pendingUpdatesRef.current = [];
 		flushScheduledRef.current = false;
 
-		// Streaming deltas are dropped; terminal permission updates (which carry
-		// `permissionRequest`) are still applied so `findActivePermission` stops
-		// returning the cancelled/answered request.
+		// Streaming deltas are dropped; only terminal permission updates
+		// (cancelled or answered) are applied so `findActivePermission` stops
+		// returning the request. Active/pending permission updates are not
+		// replayed, so a cancel can never re-surface an active banner.
 		const permissionUpdates = queued.filter(
 			(u) =>
 				(u.type === "tool_call" || u.type === "tool_call_update") &&
-				u.permissionRequest !== undefined,
+				(u.permissionRequest?.isCancelled === true ||
+					u.permissionRequest?.selectedOptionId !== undefined),
 		);
 		if (permissionUpdates.length > 0) {
 			setMessages((prev) => {

--- a/src/hooks/useAgentMessages.ts
+++ b/src/hooks/useAgentMessages.ts
@@ -183,10 +183,39 @@ export function useAgentMessages(
 		ignoreUpdatesRef.current = ignore;
 	}, []);
 
-	/** Discard any pending RAF updates and reset the streaming flag. */
+	/**
+	 * Cancel-time cleanup. Discards in-flight streaming updates so they don't
+	 * bleed into the next reply (#200), but still applies any queued permission
+	 * lifecycle updates (cancel/response) so the permission banner clears
+	 * instead of staying stuck (#326).
+	 */
 	const clearPendingUpdates = useCallback((): void => {
+		const queued = pendingUpdatesRef.current;
 		pendingUpdatesRef.current = [];
 		flushScheduledRef.current = false;
+
+		// Streaming deltas are dropped; terminal permission updates (which carry
+		// `permissionRequest`) are still applied so `findActivePermission` stops
+		// returning the cancelled/answered request.
+		const permissionUpdates = queued.filter(
+			(u) =>
+				(u.type === "tool_call" || u.type === "tool_call_update") &&
+				u.permissionRequest !== undefined,
+		);
+		if (permissionUpdates.length > 0) {
+			setMessages((prev) => {
+				let result = prev;
+				for (const update of permissionUpdates) {
+					result = applySingleUpdate(
+						result,
+						update,
+						toolCallIndexRef.current,
+					);
+				}
+				return result;
+			});
+		}
+
 		setIsSending(false);
 	}, []);
 


### PR DESCRIPTION
## Description

When a permission request was showing and the response was canceled (Stop), the permission buttons stayed on screen; the same race could make them reappear after pressing an option and then stopping.

`cancelOperation` runs `await cancel(); clearPendingUpdates()`. `cancelAll()` emits the `tool_call_update` that marks the request `isActive: false` / `isCancelled` into the RAF batch, but `clearPendingUpdates()` then emptied the whole queue before the flush — so `findActivePermission()` kept returning the request and the banner stayed (deterministic: the `await` continuation runs before the next animation frame).

Fix: on cancel, still drop in-flight streaming deltas (so they don't bleed into the next reply — #200), but **apply** the queued permission-lifecycle updates (the `tool_call_update`s carrying `permissionRequest`) before clearing, so the banner clears. The "reappear after responding" variant is fixed by the same change.

## Related issue

Closes #326

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed (N/A)

## Testing environment

- Agent: Claude Code
- OS: macOS (Obsidian 1.12.7)

## Screenshots

Verified: (1) Stop while permission buttons show → they clear; (2) respond then Stop → no reappearance; (3) Stop mid-stream → next reply is clean (no #200 regression); (4) normal approve/reject and auto-allow unchanged.
