### PR TITLE
fix(session-manager): update focus highlight when switching chat tabs

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -381,6 +381,19 @@ export default class AgentClientPlugin extends Plugin {
 				this._acpClients.clear();
 			}),
 		);
+
+		// Keep the focused chat view in sync when the active leaf changes
+		// (e.g. clicking a chat tab in the tab bar). ChatPanel's DOM
+		// focus/click listeners only fire on interaction inside the view, so a
+		// tab-bar switch would otherwise leave the Session Manager highlight on
+		// the previous view until the user clicks into the new one.
+		this.registerEvent(
+			this.app.workspace.on("active-leaf-change", (leaf) => {
+				if (leaf?.view instanceof ChatView) {
+					this.setLastActiveChatViewId(leaf.view.viewId);
+				}
+			}),
+		);
 	}
 
 	onunload() {


### PR DESCRIPTION
## Description

The Session Manager's focus highlight didn't follow when switching chat tabs via Obsidian's tab bar — it only updated after clicking inside the newly active view.

Focus tracking was driven only by DOM `focus`/`click` listeners on the view container (`ChatPanel`), which don't fire when you click a tab header (outside the container). This adds a `workspace.on("active-leaf-change")` handler in the plugin that calls `setLastActiveChatViewId(leaf.view.viewId)` when the newly active leaf is a `ChatView`, so the highlight follows tab switches immediately.

The existing DOM listeners are kept (they cover floating chats, which aren't leaves, and intra-view clicks). Both paths funnel into the same idempotent `viewRegistry.setFocused`, and the `instanceof ChatView` check means notes / the Session Manager view itself don't change which chat is focused.

## Related issue

Closes #323

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed (N/A)

## Testing environment

- Agent: Claude Code
- OS: macOS (Obsidian 1.12.7)

## Screenshots

Verified: (1) switching chat tabs via the tab bar moves the Session Manager highlight immediately; (2) activating a note keeps the last chat highlighted; (3) selecting from the Session Manager and intra-view clicks still work; (4) floating chat focus unchanged.
