### PR TITLE
fix(chat): persist trailing message chunks after a turn ends

### DIFF
--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -725,19 +725,43 @@ export function ChatPanel({
 	const sessionRef = useRef(session);
 	const autoExportRef = useRef(autoExportIfEnabled);
 	const closeSessionRef = useRef(agent.closeSession);
+	const saveSessionMessagesRef = useRef(sessionHistory.saveSessionMessages);
+	// True once the user has actually run a turn in THIS session. The
+	// trailing-chunk re-save and close-time flush are armed only after a real
+	// turn, so messages that were merely loaded/replayed are never re-saved
+	// (which would bump updatedAt and corrupt "last used" ordering). (#320 review)
+	const sentThisSessionRef = useRef(false);
+	// Reference identity of the messages array last persisted to disk. Used to
+	// de-duplicate the turn-end save, the trailing-chunk re-save, and the
+	// close-time flush.
+	const lastSavedMessagesRef = useRef<ChatMessage[] | null>(null);
 	messagesRef.current = messages;
 	sessionRef.current = session;
 	autoExportRef.current = autoExportIfEnabled;
 	closeSessionRef.current = agent.closeSession;
+	saveSessionMessagesRef.current = sessionHistory.saveSessionMessages;
 
 	// Cleanup on unmount only - auto-export and close session
 	useEffect(() => {
 		return () => {
 			logger.log("[ChatPanel] Cleanup: auto-export and close session");
+			// Flush trailing-chunk content the debounced save may not have
+			// persisted yet (view closed within the debounce window). Only when a
+			// real turn ran this session and there is unsaved content. (#320 review)
+			const latest = messagesRef.current;
+			const sid = sessionRef.current.sessionId;
+			if (
+				sentThisSessionRef.current &&
+				sid &&
+				latest.length > 0 &&
+				lastSavedMessagesRef.current !== latest
+			) {
+				saveSessionMessagesRef.current(sid, latest);
+			}
 			void (async () => {
 				await autoExportRef.current(
 					"closeChat",
-					messagesRef.current,
+					latest,
 					sessionRef.current,
 				);
 				await closeSessionRef.current();
@@ -778,9 +802,13 @@ export function ChatPanel({
 	// Effects - Save Session Messages on Turn End
 	// ============================================================
 	const prevIsSendingRef = useRef<boolean>(false);
-	// Reference identity of the messages array last persisted to disk. Used to
-	// de-duplicate the turn-end save and the trailing-chunk re-save below.
-	const lastSavedMessagesRef = useRef<ChatMessage[] | null>(null);
+
+	// Re-loading/switching sessions disarms the trailing-chunk save & flush, so
+	// freshly loaded/replayed messages are never re-saved (which would bump
+	// updatedAt and corrupt "last used" ordering). (#320 review)
+	useEffect(() => {
+		sentThisSessionRef.current = false;
+	}, [session.sessionId]);
 
 	useEffect(() => {
 		const wasSending = prevIsSendingRef.current;
@@ -793,6 +821,7 @@ export function ChatPanel({
 			session.sessionId &&
 			messages.length > 0
 		) {
+			sentThisSessionRef.current = true;
 			lastSavedMessagesRef.current = messages;
 			sessionHistory.saveSessionMessages(session.sessionId, messages);
 			logger.log(
@@ -823,6 +852,7 @@ export function ChatPanel({
 	useEffect(() => {
 		const sessionId = session.sessionId;
 		if (isSending || !sessionId || messages.length === 0) return;
+		if (!sentThisSessionRef.current) return;
 		if (lastSavedMessagesRef.current === messages) return;
 		const timer = window.setTimeout(() => {
 			lastSavedMessagesRef.current = messages;

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -9,7 +9,7 @@ import {
 	type MenuItem,
 } from "obsidian";
 
-import type { AttachedFile, ChatInputState } from "../types/chat";
+import type { AttachedFile, ChatInputState, ChatMessage } from "../types/chat";
 import { isSameDirectory } from "../utils/platform";
 import { computeSessionTitle } from "../services/session-helpers";
 import { useHistoryModal } from "../hooks/useHistoryModal";
@@ -119,6 +119,9 @@ interface AppWithSettings {
 // ============================================================================
 // ChatPanel Component
 // ============================================================================
+
+/** Debounce (ms) for re-saving when trailing chunks arrive after a turn ends (#320). */
+const TRAILING_SAVE_DEBOUNCE_MS = 800;
 
 /**
  * Core chat panel component that encapsulates all chat logic.
@@ -775,6 +778,9 @@ export function ChatPanel({
 	// Effects - Save Session Messages on Turn End
 	// ============================================================
 	const prevIsSendingRef = useRef<boolean>(false);
+	// Reference identity of the messages array last persisted to disk. Used to
+	// de-duplicate the turn-end save and the trailing-chunk re-save below.
+	const lastSavedMessagesRef = useRef<ChatMessage[] | null>(null);
 
 	useEffect(() => {
 		const wasSending = prevIsSendingRef.current;
@@ -787,6 +793,7 @@ export function ChatPanel({
 			session.sessionId &&
 			messages.length > 0
 		) {
+			lastSavedMessagesRef.current = messages;
 			sessionHistory.saveSessionMessages(session.sessionId, messages);
 			logger.log(
 				`[ChatPanel] Session messages saved: ${session.sessionId}`,
@@ -807,6 +814,26 @@ export function ChatPanel({
 		settings.enableSystemNotifications,
 		activeAgentLabel,
 		logger,
+	]);
+
+	// Some agents (e.g. OpenCode) emit trailing message chunks *after* end_turn,
+	// so the turn-end save above runs before they arrive and the persisted copy
+	// is truncated. Re-save when messages change while idle, debounced so rapid
+	// trailing updates coalesce into a single write (avoids racing the file). (#320)
+	useEffect(() => {
+		const sessionId = session.sessionId;
+		if (isSending || !sessionId || messages.length === 0) return;
+		if (lastSavedMessagesRef.current === messages) return;
+		const timer = window.setTimeout(() => {
+			lastSavedMessagesRef.current = messages;
+			sessionHistory.saveSessionMessages(sessionId, messages);
+		}, TRAILING_SAVE_DEBOUNCE_MS);
+		return () => window.clearTimeout(timer);
+	}, [
+		isSending,
+		session.sessionId,
+		messages,
+		sessionHistory.saveSessionMessages,
 	]);
 
 	// ============================================================


### PR DESCRIPTION
## Description

Reopening a saved conversation could show the last reply truncated. Some agents (e.g. OpenCode) emit trailing `agent_message_chunk`s *after* `end_turn`; the existing save fired only on the `isSending: true → false` transition, so those late chunks made it into the live view but not the saved `sessions/{id}.json`.

This adds a debounced re-save: when messages change while idle (`isSending === false`), it persists again after a short quiet period. A `lastSavedMessagesRef` de-dups against the turn-end save (no double write), an `isSending` guard avoids per-chunk saves during streaming, and the debounce coalesces rapid trailing updates into a single write (the storage layer overwrites the whole file with no internal queue, so concurrent writes could otherwise race). The immediate turn-end save is kept, so a quick close still persists the bulk.

## Related issue

Closes #320

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed (N/A)

## Testing environment

- Agent: OpenCode (repro), Claude Code (regression)
- OS: macOS (Obsidian 1.12.7)

## Screenshots

Verified: with OpenCode, a reply that emits chunks after `end_turn` is now saved in full — reopening from history shows the complete last reply (previously truncated). Normal agents and quick re-sends unaffected.
