### PR TITLE
feat(session): persist and restore all config options, not just model/mode

### DIFF
--- a/src/hooks/useAgentSession.ts
+++ b/src/hooks/useAgentSession.ts
@@ -32,6 +32,7 @@ import {
 import {
 	applyLegacyValue,
 	tryRestoreConfigOption,
+	restoreSavedConfigOptions,
 	restoreLegacyConfig,
 } from "../services/session-state";
 
@@ -236,6 +237,12 @@ export function useAgentSession(
 
 				if (sessionResult.configOptions && sessionResult.sessionId) {
 					let configOptions = sessionResult.configOptions;
+					configOptions = await restoreSavedConfigOptions(
+						agentClient,
+						sessionResult.sessionId,
+						configOptions,
+						settings.lastUsedConfigOptions[agentId],
+					);
 					configOptions = await tryRestoreConfigOption(
 						agentClient,
 						sessionResult.sessionId,
@@ -366,6 +373,12 @@ export function useAgentSession(
 
 			if (configOptions && sessionId) {
 				let restored = configOptions;
+				restored = await restoreSavedConfigOptions(
+					agentClient,
+					sessionId,
+					restored,
+					settings.lastUsedConfigOptions[agentId],
+				);
 				restored = await tryRestoreConfigOption(
 					agentClient,
 					sessionId,
@@ -502,23 +515,36 @@ export function useAgentSession(
 				const changedOption = updatedOptions.find(
 					(o) => o.id === configId,
 				);
-				if (changedOption?.category === "model" && s.agentId) {
+				if (changedOption && s.agentId) {
 					const currentSettings = settingsAccess.getSnapshot();
-					void settingsAccess.updateSettings({
-						lastUsedModels: {
-							...currentSettings.lastUsedModels,
-							[s.agentId]: value,
-						},
-					});
-				}
-				if (changedOption?.category === "mode" && s.agentId) {
-					const currentSettings = settingsAccess.getSnapshot();
-					void settingsAccess.updateSettings({
-						lastUsedModes: {
-							...currentSettings.lastUsedModes,
-							[s.agentId]: value,
-						},
-					});
+					if (changedOption.category === "model") {
+						void settingsAccess.updateSettings({
+							lastUsedModels: {
+								...currentSettings.lastUsedModels,
+								[s.agentId]: value,
+							},
+						});
+					} else if (changedOption.category === "mode") {
+						void settingsAccess.updateSettings({
+							lastUsedModes: {
+								...currentSettings.lastUsedModes,
+								[s.agentId]: value,
+							},
+						});
+					} else {
+						const allOptions =
+							currentSettings.lastUsedConfigOptions;
+						const agentOptions = allOptions[s.agentId] ?? {};
+						void settingsAccess.updateSettings({
+							lastUsedConfigOptions: {
+								...allOptions,
+								[s.agentId]: {
+									...agentOptions,
+									[configId]: value,
+								},
+							},
+						});
+					}
 				}
 			} catch (error) {
 				getLogger().error("Failed to set config option:", error);

--- a/src/hooks/useAgentSession.ts
+++ b/src/hooks/useAgentSession.ts
@@ -531,7 +531,10 @@ export function useAgentSession(
 								[s.agentId]: value,
 							},
 						});
-					} else {
+					} else if (
+						configId !== "__proto__" &&
+						configId !== "constructor"
+					) {
 						const allOptions =
 							currentSettings.lastUsedConfigOptions;
 						const agentOptions = allOptions[s.agentId] ?? {};

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -34,6 +34,7 @@ import {
 	enumVal,
 	obj,
 	strRecord,
+	nestedStrRecord,
 	xyPoint,
 } from "./services/settings-normalizer";
 import {
@@ -126,6 +127,8 @@ export interface AgentClientPluginSettings {
 	lastUsedModels: Record<string, string>;
 	// Last used mode per agent (agentId → modeId)
 	lastUsedModes: Record<string, string>;
+	// Last used non-model/mode config options per agent (agentId → {optionId → value})
+	lastUsedConfigOptions: Record<string, Record<string, string>>;
 	// Floating chat settings
 	enableFloatingChat: boolean;
 	floatingButtonImage: string;
@@ -198,6 +201,7 @@ const DEFAULT_SETTINGS: AgentClientPluginSettings = {
 	savedSessions: [],
 	lastUsedModels: {},
 	lastUsedModes: {},
+	lastUsedConfigOptions: {},
 	enableFloatingChat: false,
 	floatingButtonImage: "",
 	floatingWindowSize: { width: 400, height: 500 },
@@ -1121,6 +1125,7 @@ export default class AgentClientPlugin extends Plugin {
 				: D.savedSessions,
 			lastUsedModels: strRecord(raw.lastUsedModels),
 			lastUsedModes: strRecord(raw.lastUsedModes),
+			lastUsedConfigOptions: nestedStrRecord(raw.lastUsedConfigOptions),
 			// Migration: enableFloatingChat ← showFloatingButton (old name)
 			enableFloatingChat: bool(
 				raw.enableFloatingChat,

--- a/src/services/session-state.ts
+++ b/src/services/session-state.ts
@@ -74,6 +74,45 @@ export async function tryRestoreConfigOption(
 }
 
 /**
+ * Restore saved config option values by option id (non-legacy config options;
+ * model/mode use the category-based path above + lastUsedModels/lastUsedModes).
+ * Applies each saved value that still maps to a currently-available choice;
+ * unknown ids and stale/unavailable values are skipped. Mirrors the validation
+ * in tryRestoreConfigOption but keyed by id instead of category.
+ */
+export async function restoreSavedConfigOptions(
+	agentClient: AcpClient,
+	sessionId: string,
+	configOptions: SessionConfigOption[],
+	savedById: Record<string, string> | undefined,
+): Promise<SessionConfigOption[]> {
+	if (!savedById) return configOptions;
+
+	let result = configOptions;
+	for (const [optionId, savedValue] of Object.entries(savedById)) {
+		const option = result.find((o) => o.id === optionId);
+		if (!option) continue;
+		if (savedValue === option.currentValue) continue;
+		if (
+			!flattenConfigSelectOptions(option.options).some(
+				(o) => o.value === savedValue,
+			)
+		)
+			continue;
+		try {
+			result = await agentClient.setSessionConfigOption(
+				sessionId,
+				optionId,
+				savedValue,
+			);
+		} catch {
+			// Keep current value on failure.
+		}
+	}
+	return result;
+}
+
+/**
  * Restore last used mode/model via legacy APIs.
  * Only called when configOptions is not available.
  *

--- a/src/services/settings-normalizer.ts
+++ b/src/services/settings-normalizer.ts
@@ -255,7 +255,12 @@ export function nestedStrRecord(
 	const o = obj(raw);
 	if (!o) return result;
 	for (const [key, value] of Object.entries(o)) {
-		if (typeof key === "string" && key.length > 0) {
+		if (
+			typeof key === "string" &&
+			key.length > 0 &&
+			key !== "__proto__" &&
+			key !== "constructor"
+		) {
 			result[key] = strRecord(value);
 		}
 	}

--- a/src/services/settings-normalizer.ts
+++ b/src/services/settings-normalizer.ts
@@ -247,6 +247,21 @@ export function strRecord(raw: unknown): Record<string, string> {
 	return result;
 }
 
+/** Normalize a nested string record, e.g. agentId → { optionId → value }. */
+export function nestedStrRecord(
+	raw: unknown,
+): Record<string, Record<string, string>> {
+	const result: Record<string, Record<string, string>> = {};
+	const o = obj(raw);
+	if (!o) return result;
+	for (const [key, value] of Object.entries(o)) {
+		if (typeof key === "string" && key.length > 0) {
+			result[key] = strRecord(value);
+		}
+	}
+	return result;
+}
+
 /** Extract an {x, y} point, or return null if invalid */
 export function xyPoint(raw: unknown): { x: number; y: number } | null {
 	const o = obj(raw);


### PR DESCRIPTION
## Description

The plugin remembered the last-used model and mode per agent and restored them in new sessions, but other dynamic config options (e.g. reasoning effort) were not persisted — they reset to the agent's default each session.

This adds a per-agent `lastUsedConfigOptions` store (keyed by option id) and persists/restores every config option:

- **Save** (`setConfigOption`): `category: "model"` → `lastUsedModels`, `"mode"` → `lastUsedModes` (unchanged), everything else → `lastUsedConfigOptions[agentId][optionId]`. Each option is saved in exactly one place.
- **Restore** (both session-establishment paths — `createSession` and `updateSessionFromLoad`): a new id-keyed `restoreSavedConfigOptions` applies saved values, validating each is still an available choice (skips unknown ids / stale values); the existing model/mode category restore is kept.

Model/mode keep their existing stores for backward compatibility (the legacy modes/models API shares them, and existing saved values have no option id to migrate). Existing users with no `lastUsedConfigOptions` normalize to `{}` — model/mode behavior is unchanged.

## Related issue

Closes #325

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed (N/A)

## Testing environment

- Agent: Claude Code
- OS: macOS (Obsidian 1.12.7)

## Screenshots

Verified: changing a non-model/mode option (reasoning effort) persists and is restored in new sessions; model/mode restore unchanged; clearing the saved settings cleanly falls back to agent defaults (no crash).
