### PR TITLE
fix(chat): preserve scroll position across chat tab switches (#321)

### DIFF
--- a/src/ui/MessageList.tsx
+++ b/src/ui/MessageList.tsx
@@ -157,11 +157,15 @@ export function MessageList({
 		return isNearBottom;
 	}, []);
 
-	// Reset scroll state when messages are cleared (new chat)
+	// Reset scroll state and drop the per-message size cache when messages are
+	// cleared (new chat / restore / fork / restart all funnel through an empty
+	// array first). Prevents stale msgId→height entries from accumulating
+	// across sessions in this long-lived view. (#321)
 	useEffect(() => {
 		if (messages.length === 0) {
 			setIsAtBottom(true);
 			isAtBottomRef.current = true;
+			sizeCacheRef.current.clear();
 		}
 	}, [messages.length]);
 

--- a/src/ui/MessageList.tsx
+++ b/src/ui/MessageList.tsx
@@ -9,6 +9,13 @@ import { setIcon } from "obsidian";
 import { MessageBubble } from "./MessageBubble";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
+// How long (ms) after a tab is re-shown we refuse to shrink measured item
+// sizes. Right after re-show the items briefly re-measure small while their
+// markdown re-lays-out; recording those shrinks collapses the virtualizer's
+// total size, which clamps scrollTop to 0 and loses the position. Riding out
+// this window keeps total stable so the scroll position is preserved. (#321)
+const SHOW_SETTLE_MS = 500;
+
 /**
  * Props for MessageList component
  */
@@ -66,6 +73,16 @@ export function MessageList({
 	const [isAtBottom, setIsAtBottom] = useState(true);
 	const isAtBottomRef = useRef(true);
 	const prevIsSendingRef = useRef(false);
+	// Last measured height per message id. Used to keep the virtualizer's total
+	// size stable while the tab is hidden (display:none) so scrollTop isn't
+	// clamped to 0 and the position survives a tab switch. (#321)
+	const sizeCacheRef = useRef<Map<string, number>>(new Map());
+	// Whether the view was last seen hidden (display:none), and the end of the
+	// post-show "settle" window during which we refuse to shrink the size cache
+	// (see SHOW_SETTLE_MS). Together these suppress the transient total-size
+	// collapse that would otherwise clamp scrollTop to 0 on re-show. (#321)
+	const wasHiddenRef = useRef(false);
+	const settleUntilRef = useRef(0);
 
 	// ============================================================
 	// Virtualizer
@@ -75,6 +92,40 @@ export function MessageList({
 		getScrollElement: () => containerRef.current,
 		estimateSize: () => 80,
 		overscan: 5,
+		getItemKey: (index) => messages[index]?.id ?? String(index),
+		measureElement: (element) => {
+			const el = element as HTMLElement;
+			const id = el.getAttribute("data-msg-id");
+			const cached = id ? sizeCacheRef.current.get(id) : undefined;
+			// Hidden (display:none): the item is detached from layout
+			// (offsetParent === null) and would measure 0. Remember we were
+			// hidden and return the last known size so the total size doesn't
+			// collapse on the hidden side. (#321)
+			if (el.offsetParent === null) {
+				wasHiddenRef.current = true;
+				return cached || 80;
+			}
+			// First measure after re-show: open the settle window. Opening it
+			// here (rather than from a separate observer) makes this very call
+			// guarded too, regardless of observer firing order. (#321)
+			if (wasHiddenRef.current) {
+				wasHiddenRef.current = false;
+				settleUntilRef.current = performance.now() + SHOW_SETTLE_MS;
+			}
+			const measured = el.getBoundingClientRect().height;
+			// Inside the settle window, never shrink: return the larger of the
+			// fresh and cached heights and don't record it, so getTotalSize()
+			// stays stable and scrollTop isn't clamped to 0 on re-show. Genuine
+			// shrinks are accepted again once the window expires. (#321)
+			if (
+				cached !== undefined &&
+				performance.now() < settleUntilRef.current
+			) {
+				return Math.max(measured, cached);
+			}
+			if (id && measured > 0) sizeCacheRef.current.set(id, measured);
+			return measured || cached || 80;
+		},
 	});
 
 	// Suppress scroll position correction when user has scrolled up.
@@ -203,6 +254,7 @@ export function MessageList({
 							key={message.id}
 							ref={virtualizer.measureElement}
 							data-index={virtualItem.index}
+							data-msg-id={message.id}
 							className="agent-client-virtual-item"
 							style={{
 								position: "absolute",


### PR DESCRIPTION
## Description

When several Agent Client chats are open as separate tabs in one pane, switching away from a tab and back lost that tab's scroll position — the view jumped noticeably upward (not always to the very top; the distance varied with message heights).

Inactive tabs are hidden via `display:none` and the React tree stays mounted (`onClose()` isn't called on tab switch), so the `@tanstack/react-virtual` virtualizer persists. On re-show, items briefly re-measure **small** while their markdown re-lays-out; `measureElement` recorded those transient heights, which collapsed `getTotalSize()` → `maxScroll` dropped to ~0 → the browser **clamped `scrollTop` to 0**. The total recovered ~150ms later but nothing restored the scroll, leaving the tab near the top.

The fix hardens `measureElement` to suppress the collapse at its source — no save/restore, no programmatic re-scroll:

- `getItemKey: (i) => messages[i].id` keys the measurement cache by message id, not index.
- A per-message-id size cache; on the hidden side (`offsetParent === null`) it returns the last known size so total never collapses while hidden.
- On the first measure after a hide→show transition it opens a short **settle window** (`SHOW_SETTLE_MS = 500ms`); during it, `measureElement` returns `Math.max(measured, cached)` without recording, so a transient small measurement can't shrink the cache. `getTotalSize()` stays stable, `scrollTop` is never clamped, and the position is preserved **to the pixel**. Genuine shrinks are accepted again once the window expires.

The window is opened from inside `measureElement` (not a separate observer) so the very first post-show measurement is already guarded, regardless of observer firing order. Because the fix never issues a programmatic scroll, there are no races with the existing auto-scroll / `isAtBottom` logic. Scope is `src/ui/MessageList.tsx` only — no changes to `ChatView`/view interfaces, so both the sidebar and floating variants benefit.

## Related issue

Closes #321

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed (N/A)

## Testing environment

- Agent: N/A (multi-tab chat view / virtualizer behavior, not agent-specific)
- OS: macOS (Obsidian 1.12.7)

## Screenshots

Verified with 2 chat tabs, switching A↔B: position is preserved in both the **at-bottom** and **mid-scroll** cases (runtime diagnostics confirmed `getTotalSize()` no longer collapses — e.g. it stayed at 1943 instead of dropping to ~200 — and `scrollTop` is retained). Auto-scroll on new messages, smooth scroll on send, the scroll-to-bottom button, and the empty state are all unaffected.