### PR TITLE
fix: evict the least recently used saved session instead of the oldest inserted

### DIFF
--- a/src/services/session-storage.ts
+++ b/src/services/session-storage.ts
@@ -51,6 +51,31 @@ interface SessionStorageSettingsAccess {
 /** Maximum number of saved sessions to keep */
 const MAX_SAVED_SESSIONS = 50;
 
+/**
+ * Evict the least-recently-used entries (oldest updatedAt) until the list
+ * fits the cap. Reads and the UI order by updatedAt, so eviction must use the
+ * same axis — a positional pop() would drop an old-inserted entry that is
+ * still in active use. Eviction removes only the index entry: the transcript
+ * file under sessions/ is intentionally kept as an archive.
+ */
+function evictLeastRecentlyUsed(
+	sessions: SavedSessionInfo[],
+	cap: number,
+): void {
+	while (sessions.length > cap) {
+		let oldest = 0;
+		for (let i = 1; i < sessions.length; i++) {
+			if (
+				new Date(sessions[i].updatedAt).getTime() <
+				new Date(sessions[oldest].updatedAt).getTime()
+			) {
+				oldest = i;
+			}
+		}
+		sessions.splice(oldest, 1);
+	}
+}
+
 export class SessionStorage {
 	private plugin: AgentClientPlugin;
 	private settingsAccess: SessionStorageSettingsAccess;
@@ -105,9 +130,7 @@ export class SessionStorage {
 				sessions[existingIndex] = sessionInfo;
 			} else {
 				sessions.unshift(sessionInfo);
-				if (sessions.length > MAX_SAVED_SESSIONS) {
-					sessions.pop();
-				}
+				evictLeastRecentlyUsed(sessions, MAX_SAVED_SESSIONS);
 			}
 
 			await this.settingsAccess.updateSettings({
@@ -223,6 +246,7 @@ export class SessionStorage {
 					createdAt: new Date().toISOString(),
 					updatedAt: new Date().toISOString(),
 				});
+				evictLeastRecentlyUsed(sessions, MAX_SAVED_SESSIONS);
 			} else {
 				return;
 			}

--- a/test/session-storage.test.ts
+++ b/test/session-storage.test.ts
@@ -217,3 +217,93 @@ describe("SessionStorage — non-embedded saves keep sessionId fallback", () => 
 		expect(adapter.remove).not.toHaveBeenCalled();
 	});
 });
+
+describe("SessionStorage — cap eviction is LRU by updatedAt, not insertion order", () => {
+	const CAP = 50;
+	const iso = (minute: number) =>
+		new Date(Date.UTC(2026, 0, 1, 0, minute)).toISOString();
+
+	/**
+	 * Seed a full list whose array position is INVERSE to recency of use:
+	 * index 0 (newest inserted) has the OLDEST updatedAt, the tail (oldest
+	 * inserted) has the NEWEST. A positional pop() would evict the tail —
+	 * the most recently used entry.
+	 */
+	const seedInverse = (count: number) =>
+		Array.from({ length: count }, (_, i) =>
+			makeSession({ sessionId: `s${i}`, updatedAt: iso(i) }),
+		);
+
+	it("evicts the entry with the oldest updatedAt when the cap is exceeded", async () => {
+		const { storage, state, adapter } = makeStorage();
+		state.savedSessions = seedInverse(CAP);
+
+		await storage.saveSession(
+			makeSession({ sessionId: "brand-new", updatedAt: iso(1000) }),
+		);
+
+		expect(state.savedSessions).toHaveLength(CAP);
+		// s0 sits at the array head (newest inserted) but is the least
+		// recently used — it must be the one to go.
+		expect(state.savedSessions.some((s) => s.sessionId === "s0")).toBe(
+			false,
+		);
+		expect(
+			state.savedSessions.some((s) => s.sessionId === "brand-new"),
+		).toBe(true);
+		// Eviction removes the index entry only — never a transcript file.
+		expect(adapter.remove).not.toHaveBeenCalled();
+	});
+
+	it("keeps an oldest-inserted entry that is still in recent use (DATA-2)", async () => {
+		const { storage, state } = makeStorage();
+		state.savedSessions = seedInverse(CAP);
+
+		await storage.saveSession(
+			makeSession({ sessionId: "brand-new", updatedAt: iso(1000) }),
+		);
+
+		// The tail entry (oldest inserted, newest updatedAt) survives; the old
+		// positional pop() would have dropped exactly this one.
+		expect(
+			state.savedSessions.some((s) => s.sessionId === `s${CAP - 1}`),
+		).toBe(true);
+	});
+
+	it("trims multiple entries in LRU order when the list is already over the cap", async () => {
+		const { storage, state } = makeStorage();
+		// e.g. data.json hand-edited or written by a future version.
+		state.savedSessions = seedInverse(CAP + 2);
+
+		await storage.saveSession(
+			makeSession({ sessionId: "brand-new", updatedAt: iso(1000) }),
+		);
+
+		expect(state.savedSessions).toHaveLength(CAP);
+		for (const evicted of ["s0", "s1", "s2"]) {
+			expect(
+				state.savedSessions.some((s) => s.sessionId === evicted),
+			).toBe(false);
+		}
+	});
+
+	it("enforces the cap on updateSessionTitle's createIfMissing path too", async () => {
+		const { storage, state } = makeStorage();
+		state.savedSessions = seedInverse(CAP);
+
+		await storage.updateSessionTitle("brand-new", "created by rename", {
+			agentId: "claude",
+			cwd: "/vault",
+		});
+
+		expect(state.savedSessions).toHaveLength(CAP);
+		expect(
+			state.savedSessions.some((s) => s.sessionId === "brand-new"),
+		).toBe(true);
+		// The created entry's updatedAt is "now" (far newer than the seeds),
+		// so the least recently used seed is the one evicted.
+		expect(state.savedSessions.some((s) => s.sessionId === "s0")).toBe(
+			false,
+		);
+	});
+});


### PR DESCRIPTION
## Description

The saved-session list in `data.json` is capped at 50 entries, but the cap evicted by **array position** (`pop()` the tail = oldest *inserted*), while every reader — the history list, Session Manager ordering, and the embedded-block restore lookup — orders by `updatedAt` (last activity). In-place updates never reorder the array, so a long-lived but actively used session sits at the tail indefinitely: once the list hits 50, saving a new session could silently drop an entry that was shown at the very top of the history list, including an embedded persist block's conversation mapping.

This PR makes eviction use the same axis as the readers: the entry with the **oldest `updatedAt`** (least recently used) is evicted. It also enforces the cap on `updateSessionTitle`'s `createIfMissing` insert, which previously slipped past it.

Eviction removes only the index entry in `data.json` — transcript files under `sessions/` are intentionally kept as an archive. A follow-up PR will embed the session metadata into those transcript files so that evicted sessions remain fully self-contained.

Surfaced during the review follow-up of #341.

### Tests

Four unit tests added (113 passing): oldest-`updatedAt` entry is evicted regardless of array position; an oldest-inserted but recently used entry survives (the exact case the old `pop()` broke); multiple entries are trimmed in LRU order when the list is already over the cap; the `createIfMissing` path respects the cap. Eviction is asserted to never delete a transcript file.

## Related issue

None (follow-up to #341).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [ ] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: N/A (storage-layer change, covered by unit tests)
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session history now keeps the most recently updated items when the saved sessions limit is reached.
  * Adding or updating a session title now consistently respects the session cap.
  * Transcript archive files are left untouched during session cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->