### PR TITLE
feat: embed session metadata in transcript files (self-contained archive)

### DIFF
--- a/src/services/session-storage.ts
+++ b/src/services/session-storage.ts
@@ -326,53 +326,64 @@ export class SessionStorage {
 
 	/**
 	 * Save message history for a session.
+	 *
+	 * Runs inside sessionLock: the transcript file has TWO writers (this
+	 * turn-end save and updateSessionTitle's title sync, both full-file
+	 * rewrites), so writes must serialize or a rename racing a turn end could
+	 * overwrite newer messages with the older array it read. As a bonus, the
+	 * snapshot below is taken after any queued rename, so it sees the fresh
+	 * title.
 	 */
 	async saveSessionMessages(
 		sessionId: string,
 		agentId: string,
 		messages: ChatMessage[],
 	): Promise<void> {
-		await this.ensureSessionsDir();
+		this.sessionLock = this.sessionLock.then(async () => {
+			await this.ensureSessionsDir();
 
-		// Self-contained archive: snapshot the index entry into the file so an
-		// evicted session keeps its handle (cwd/title/embedId/timestamps) for
-		// future search/restore. If the entry is already gone (evicted while
-		// the session stayed open), carry the previous snapshot over from the
-		// existing file instead of dropping it on rewrite.
-		const entry = (
-			this.settingsAccess.getSnapshot().savedSessions || []
-		).find((s) => s.sessionId === sessionId);
-		const meta = entry
-			? {
-					cwd: entry.cwd,
-					title: entry.title,
-					embedId: entry.embedId,
-					createdAt: entry.createdAt,
-					updatedAt: entry.updatedAt,
-				}
-			: await this.readExistingMeta(sessionId);
+			// Self-contained archive: snapshot the index entry into the file
+			// so an evicted session keeps its handle (cwd/title/embedId/
+			// timestamps) for future search/restore. If the entry is already
+			// gone (evicted while the session stayed open), carry the previous
+			// snapshot over from the existing file instead of dropping it on
+			// rewrite.
+			const entry = (
+				this.settingsAccess.getSnapshot().savedSessions || []
+			).find((s) => s.sessionId === sessionId);
+			const meta = entry
+				? {
+						cwd: entry.cwd,
+						title: entry.title,
+						embedId: entry.embedId,
+						createdAt: entry.createdAt,
+						updatedAt: entry.updatedAt,
+					}
+				: await this.readExistingMeta(sessionId);
 
-		const serialized = messages.map((msg) => ({
-			...msg,
-			timestamp: msg.timestamp.toISOString(),
-		}));
+			const serialized = messages.map((msg) => ({
+				...msg,
+				timestamp: msg.timestamp.toISOString(),
+			}));
 
-		const data = {
-			version: 1,
-			sessionId,
-			agentId,
-			// undefined values are dropped by JSON.stringify, so absent fields
-			// (e.g. no title yet) never appear as null in the file.
-			...meta,
-			messages: serialized,
-			savedAt: new Date().toISOString(),
-		};
+			const data = {
+				version: 1,
+				sessionId,
+				agentId,
+				// undefined values are dropped by JSON.stringify, so absent
+				// fields (e.g. no title yet) never appear as null in the file.
+				...meta,
+				messages: serialized,
+				savedAt: new Date().toISOString(),
+			};
 
-		const filePath = this.getSessionFilePath(sessionId);
-		await this.plugin.app.vault.adapter.write(
-			filePath,
-			JSON.stringify(data, null, 2),
-		);
+			const filePath = this.getSessionFilePath(sessionId);
+			await this.plugin.app.vault.adapter.write(
+				filePath,
+				JSON.stringify(data, null, 2),
+			);
+		});
+		await this.sessionLock;
 	}
 
 	/**

--- a/src/services/session-storage.ts
+++ b/src/services/session-storage.ts
@@ -26,6 +26,19 @@ interface SessionMessagesFile {
 	version: number;
 	sessionId: string;
 	agentId: string;
+	/**
+	 * Snapshot of the session's index entry (data.json row) as of the last
+	 * save. Makes the transcript self-contained: a session evicted from the
+	 * capped index keeps its handle — where to reopen it (cwd), its display
+	 * name (title), its owning embed block (embedId) — for future
+	 * search/restore. Absent in files written before this feature. The index
+	 * entry stays authoritative while it exists; this is a copy.
+	 */
+	cwd?: string;
+	title?: string;
+	embedId?: string;
+	createdAt?: string;
+	updatedAt?: string;
 	messages: Array<{
 		id: string;
 		role: "user" | "assistant";
@@ -254,6 +267,11 @@ export class SessionStorage {
 			await this.settingsAccess.updateSettings({
 				savedSessions: sessions,
 			});
+
+			// Keep the transcript's title snapshot in sync (best-effort;
+			// covers the rename-then-never-continue case where no turn-end
+			// save would refresh it).
+			await this.syncTranscriptTitle(sessionId, newTitle);
 		});
 		await this.sessionLock;
 	}
@@ -316,6 +334,24 @@ export class SessionStorage {
 	): Promise<void> {
 		await this.ensureSessionsDir();
 
+		// Self-contained archive: snapshot the index entry into the file so an
+		// evicted session keeps its handle (cwd/title/embedId/timestamps) for
+		// future search/restore. If the entry is already gone (evicted while
+		// the session stayed open), carry the previous snapshot over from the
+		// existing file instead of dropping it on rewrite.
+		const entry = (
+			this.settingsAccess.getSnapshot().savedSessions || []
+		).find((s) => s.sessionId === sessionId);
+		const meta = entry
+			? {
+					cwd: entry.cwd,
+					title: entry.title,
+					embedId: entry.embedId,
+					createdAt: entry.createdAt,
+					updatedAt: entry.updatedAt,
+				}
+			: await this.readExistingMeta(sessionId);
+
 		const serialized = messages.map((msg) => ({
 			...msg,
 			timestamp: msg.timestamp.toISOString(),
@@ -325,6 +361,9 @@ export class SessionStorage {
 			version: 1,
 			sessionId,
 			agentId,
+			// undefined values are dropped by JSON.stringify, so absent fields
+			// (e.g. no title yet) never appear as null in the file.
+			...meta,
 			messages: serialized,
 			savedAt: new Date().toISOString(),
 		};
@@ -380,6 +419,69 @@ export class SessionStorage {
 				`[SessionStorage] Failed to load session messages: ${error}`,
 			);
 			return null;
+		}
+	}
+
+	/**
+	 * Carry-over: read the metadata snapshot from an existing transcript file.
+	 * Used when the index entry was evicted while the session stayed open, so
+	 * a rewrite does not drop the previously saved handle.
+	 */
+	private async readExistingMeta(
+		sessionId: string,
+	): Promise<
+		Partial<
+			Pick<
+				SessionMessagesFile,
+				"cwd" | "title" | "embedId" | "createdAt" | "updatedAt"
+			>
+		>
+	> {
+		const filePath = this.getSessionFilePath(sessionId);
+		const adapter = this.plugin.app.vault.adapter;
+		try {
+			if (!(await adapter.exists(filePath))) return {};
+			const data = JSON.parse(
+				await adapter.read(filePath),
+			) as SessionMessagesFile;
+			if (!data || typeof data !== "object") return {};
+			return {
+				cwd: data.cwd,
+				title: data.title,
+				embedId: data.embedId,
+				createdAt: data.createdAt,
+				updatedAt: data.updatedAt,
+			};
+		} catch {
+			return {};
+		}
+	}
+
+	/**
+	 * Best-effort: patch the title snapshot inside an existing transcript file
+	 * so a rename stays visible in the archive even if the session is never
+	 * continued (no turn-end save would refresh it). The index entry is
+	 * authoritative while it exists; failures are silently ignored and the
+	 * snapshot self-heals on the next turn-end save.
+	 */
+	private async syncTranscriptTitle(
+		sessionId: string,
+		newTitle: string,
+	): Promise<void> {
+		const filePath = this.getSessionFilePath(sessionId);
+		const adapter = this.plugin.app.vault.adapter;
+		try {
+			if (!(await adapter.exists(filePath))) return;
+			const data = JSON.parse(
+				await adapter.read(filePath),
+			) as SessionMessagesFile;
+			if (!data || typeof data !== "object") return;
+			data.title = newTitle;
+			await adapter.write(filePath, JSON.stringify(data, null, 2));
+		} catch (error) {
+			getLogger().debug(
+				`[SessionStorage] Failed to sync transcript title: ${error}`,
+			);
 		}
 	}
 

--- a/test/session-storage.test.ts
+++ b/test/session-storage.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { SessionStorage } from "../src/services/session-storage";
 import type { SavedSessionInfo } from "../src/types/session";
+import type { ChatMessage } from "../src/types/chat";
 
 // SessionStorage only needs a tiny slice of the plugin (vault adapter +
 // configDir) and a {getSnapshot, updateSettings} settings access. We stub both
@@ -31,12 +32,22 @@ function makeSession(
 
 function makeStorage() {
 	const state: StorageState = { savedSessions: [], windowsWslMode: false };
-	const existing = new Set<string>();
+	// Map-backed in-memory FS: path → file content.
+	const files = new Map<string, string>();
 	const adapter = {
-		exists: vi.fn(async (p: string) => existing.has(p)),
+		exists: vi.fn(async (p: string) => files.has(p)),
 		remove: vi.fn(async (p: string) => {
-			existing.delete(p);
+			files.delete(p);
 		}),
+		read: vi.fn(async (p: string) => {
+			const content = files.get(p);
+			if (content === undefined) throw new Error(`ENOENT: ${p}`);
+			return content;
+		}),
+		write: vi.fn(async (p: string, content: string) => {
+			files.set(p, content);
+		}),
+		mkdir: vi.fn(async () => {}),
 	};
 	const plugin = {
 		app: { vault: { configDir: CONFIG_DIR, adapter } },
@@ -53,7 +64,7 @@ function makeStorage() {
 			typeof SessionStorage
 		>[1],
 	);
-	return { storage, state, adapter, existing };
+	return { storage, state, adapter, files };
 }
 
 describe("SessionStorage — getSavedSessionByEmbedId (#5/#11)", () => {
@@ -96,11 +107,11 @@ describe("SessionStorage — getSavedSessionByEmbedId (#5/#11)", () => {
 
 describe("SessionStorage — embedded persist sessions accumulate (no dedup/delete)", () => {
 	it("keeps a block's past conversations in history and never deletes a transcript", async () => {
-		const { storage, state, adapter, existing } = makeStorage();
+		const { storage, state, adapter, files } = makeStorage();
 		state.savedSessions = [
 			makeSession({ sessionId: "s1", embedId: "blk1" }),
 		];
-		existing.add(filePath("s1"));
+		files.set(filePath("s1"), "{}");
 
 		await storage.saveSession(
 			makeSession({ sessionId: "s2", embedId: "blk1" }),
@@ -116,7 +127,7 @@ describe("SessionStorage — embedded persist sessions accumulate (no dedup/dele
 	});
 
 	it("keeps the old-agent conversation when the block switches agents (restore uses newest)", async () => {
-		const { storage, state, adapter, existing } = makeStorage();
+		const { storage, state, adapter, files } = makeStorage();
 		state.savedSessions = [
 			makeSession({
 				sessionId: "s1",
@@ -125,7 +136,7 @@ describe("SessionStorage — embedded persist sessions accumulate (no dedup/dele
 				updatedAt: "2026-01-01T00:00:00.000Z",
 			}),
 		];
-		existing.add(filePath("s1"));
+		files.set(filePath("s1"), "{}");
 
 		await storage.saveSession(
 			makeSession({
@@ -305,5 +316,171 @@ describe("SessionStorage — cap eviction is LRU by updatedAt, not insertion ord
 		expect(state.savedSessions.some((s) => s.sessionId === "s0")).toBe(
 			false,
 		);
+	});
+});
+
+describe("SessionStorage — transcript metadata snapshot (self-contained archive)", () => {
+	const makeMessage = (text: string): ChatMessage => ({
+		id: "m1",
+		role: "user",
+		content: [{ type: "text", text }],
+		timestamp: new Date("2026-03-01T00:00:00.000Z"),
+	});
+	const parseFile = (files: Map<string, string>, sessionId: string) =>
+		JSON.parse(files.get(filePath(sessionId)) as string) as Record<
+			string,
+			unknown
+		>;
+
+	it("snapshots the index entry (cwd/title/embedId/timestamps) into the file", async () => {
+		const { storage, state, files } = makeStorage();
+		state.savedSessions = [
+			makeSession({
+				sessionId: "s1",
+				embedId: "blk1",
+				title: "My chat",
+				cwd: "/custom/dir",
+				createdAt: "2026-01-01T00:00:00.000Z",
+				updatedAt: "2026-02-01T00:00:00.000Z",
+			}),
+		];
+
+		await storage.saveSessionMessages("s1", "claude", [makeMessage("hi")]);
+
+		const data = parseFile(files, "s1");
+		expect(data.cwd).toBe("/custom/dir");
+		expect(data.title).toBe("My chat");
+		expect(data.embedId).toBe("blk1");
+		expect(data.createdAt).toBe("2026-01-01T00:00:00.000Z");
+		expect(data.updatedAt).toBe("2026-02-01T00:00:00.000Z");
+	});
+
+	it("omits absent optional fields instead of writing null", async () => {
+		const { storage, state, files } = makeStorage();
+		// No title, no embedId on the index entry.
+		state.savedSessions = [makeSession({ sessionId: "s1" })];
+
+		await storage.saveSessionMessages("s1", "claude", [makeMessage("hi")]);
+
+		const data = parseFile(files, "s1");
+		expect("title" in data).toBe(false);
+		expect("embedId" in data).toBe(false);
+		expect(data.cwd).toBe("/vault");
+	});
+
+	it("carries the previous snapshot over when the index entry is gone", async () => {
+		const { storage, state, files } = makeStorage();
+		files.set(
+			filePath("s1"),
+			JSON.stringify({
+				version: 1,
+				sessionId: "s1",
+				agentId: "claude",
+				cwd: "/old/dir",
+				title: "Evicted chat",
+				embedId: "blk1",
+				createdAt: "2026-01-01T00:00:00.000Z",
+				updatedAt: "2026-02-01T00:00:00.000Z",
+				messages: [],
+				savedAt: "2026-02-01T00:00:00.000Z",
+			}),
+		);
+		state.savedSessions = []; // index entry evicted while session open
+
+		await storage.saveSessionMessages("s1", "claude", [
+			makeMessage("more"),
+		]);
+
+		const data = parseFile(files, "s1");
+		expect(data.cwd).toBe("/old/dir");
+		expect(data.title).toBe("Evicted chat");
+		expect(data.embedId).toBe("blk1");
+		// ...while the messages are the fresh in-memory ones.
+		expect(data.messages as unknown[]).toHaveLength(1);
+	});
+
+	it("still loads messages from a pre-feature file without a snapshot", async () => {
+		const { storage, files } = makeStorage();
+		files.set(
+			filePath("legacy"),
+			JSON.stringify({
+				version: 1,
+				sessionId: "legacy",
+				agentId: "claude",
+				messages: [
+					{
+						id: "m1",
+						role: "user",
+						content: [{ type: "text", text: "old" }],
+						timestamp: "2026-01-01T00:00:00.000Z",
+					},
+				],
+				savedAt: "2026-01-01T00:00:00.000Z",
+			}),
+		);
+
+		const messages = await storage.loadSessionMessages("legacy");
+		expect(messages).toHaveLength(1);
+		expect(messages?.[0].timestamp).toBeInstanceOf(Date);
+	});
+});
+
+describe("SessionStorage — rename syncs the transcript's title snapshot", () => {
+	it("patches the title in the file and leaves everything else intact", async () => {
+		const { storage, state, files } = makeStorage();
+		state.savedSessions = [
+			makeSession({ sessionId: "s1", title: "old title" }),
+		];
+		files.set(
+			filePath("s1"),
+			JSON.stringify({
+				version: 1,
+				sessionId: "s1",
+				agentId: "claude",
+				cwd: "/vault",
+				title: "old title",
+				messages: [
+					{
+						id: "m1",
+						role: "user",
+						content: [{ type: "text", text: "hello" }],
+						timestamp: "2026-01-01T00:00:00.000Z",
+					},
+				],
+				savedAt: "2026-01-01T00:00:00.000Z",
+			}),
+		);
+
+		await storage.updateSessionTitle("s1", "renamed");
+
+		const data = JSON.parse(files.get(filePath("s1")) as string) as Record<
+			string,
+			unknown
+		>;
+		expect(data.title).toBe("renamed");
+		expect(data.messages as unknown[]).toHaveLength(1);
+		expect(data.cwd).toBe("/vault");
+		expect(data.savedAt).toBe("2026-01-01T00:00:00.000Z");
+	});
+
+	it("is a no-op when no transcript file exists", async () => {
+		const { storage, state, files } = makeStorage();
+		state.savedSessions = [makeSession({ sessionId: "s1", title: "old" })];
+
+		await storage.updateSessionTitle("s1", "renamed");
+
+		expect(state.savedSessions[0].title).toBe("renamed");
+		expect(files.has(filePath("s1"))).toBe(false);
+	});
+
+	it("silently skips a corrupt file while the rename itself succeeds", async () => {
+		const { storage, state, files } = makeStorage();
+		state.savedSessions = [makeSession({ sessionId: "s1", title: "old" })];
+		files.set(filePath("s1"), "not json");
+
+		await storage.updateSessionTitle("s1", "renamed");
+
+		expect(state.savedSessions[0].title).toBe("renamed");
+		expect(files.get(filePath("s1"))).toBe("not json");
 	});
 });

--- a/test/session-storage.test.ts
+++ b/test/session-storage.test.ts
@@ -483,4 +483,63 @@ describe("SessionStorage — rename syncs the transcript's title snapshot", () =
 		expect(state.savedSessions[0].title).toBe("renamed");
 		expect(files.get(filePath("s1"))).toBe("not json");
 	});
+
+	it("a rename racing a turn-end save cannot clobber the newer messages", async () => {
+		const { storage, state, files, adapter } = makeStorage();
+		state.savedSessions = [
+			makeSession({ sessionId: "s1", title: "old title" }),
+		];
+		files.set(
+			filePath("s1"),
+			JSON.stringify({
+				version: 1,
+				sessionId: "s1",
+				agentId: "claude",
+				title: "old title",
+				messages: [],
+				savedAt: "2026-01-01T00:00:00.000Z",
+			}),
+		);
+
+		// Gate the rename's file write (the first write in this test) so the
+		// turn-end save is issued while the rename is mid-flight — the exact
+		// interleaving that used to let the rename's stale full-file rewrite
+		// land last and erase the newer messages.
+		let openGate!: () => void;
+		const gate = new Promise<void>((resolve) => (openGate = resolve));
+		let gated = false;
+		adapter.write.mockImplementation(async (p: string, content: string) => {
+			if (!gated) {
+				gated = true;
+				await gate;
+			}
+			files.set(p, content);
+		});
+
+		const rename = storage.updateSessionTitle("s1", "renamed");
+		// Let the rename reach its (gated) file write.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		const save = storage.saveSessionMessages("s1", "claude", [
+			{
+				id: "m1",
+				role: "user",
+				content: [{ type: "text", text: "newest" }],
+				timestamp: new Date("2026-03-01T00:00:00.000Z"),
+			},
+		]);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		openGate();
+		await Promise.all([rename, save]);
+
+		// The save serializes behind the rename on the session lock, so the
+		// final file carries BOTH the new title and the newer messages.
+		const data = JSON.parse(files.get(filePath("s1")) as string) as Record<
+			string,
+			unknown
+		>;
+		expect(data.title).toBe("renamed");
+		expect(data.messages as unknown[]).toHaveLength(1);
+	});
 });


### PR DESCRIPTION
## Description

A transcript file under `sessions/` only carried `sessionId` / `agentId` / `messages`, so a session evicted from the capped `data.json` index lost its handle: no `cwd` to reopen it with, no display title (user renames especially — they exist nowhere else), no owning embed block (`embedId`), no creation time. Vaults already hold such orphaned transcripts — readable, but hard to reuse.

This PR snapshots the session's index entry (`cwd` / `title` / `embedId` / `createdAt` / `updatedAt`) into the transcript file on every turn-end save, making the archive **self-contained**: an evicted session keeps everything needed to list, search, and restore it in the future. The index entry stays authoritative while it exists; the snapshot is a copy taken at the last save.

Details:

- **Carry-over**: if the index entry is already gone (evicted while the session stayed open), the previous snapshot is read back from the existing file instead of being dropped by the wholesale rewrite.
- **Rename sync**: `updateSessionTitle` also patches the file's title snapshot (best-effort, silently skipped on error), covering the rename-then-never-continue case that no turn-end save would refresh.
- Absent optional fields are omitted rather than written as `null`, the file format `version` stays `1`, and pre-feature files without a snapshot still load (backward compatible both ways).
- In WSL mode the snapshot's `cwd` is the already-normalized WSL path: it copies the index entry, which `saveSession` converts at write time.

Follow-up to #343; together they make eviction lose nothing: the index rotates by least-recently-used, and the full conversation plus its handle survives on disk.

### Tests

Seven unit tests added (120 passing): the snapshot is written from the index entry; absent optional fields don't appear in the file; carry-over preserves the snapshot after eviction; a pre-feature file still loads; a rename patches only the title (messages and the rest intact); rename is a no-op without a file; a corrupt file is skipped while the rename itself succeeds. The test stub's adapter grows a Map-backed in-memory FS (`read` / `write` / `mkdir`).

## Related issue

None (follow-up to #343).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session transcripts now include an optional snapshot of key session metadata for better context when index data changes over time.

* **Bug Fixes**
  * Saved transcript metadata is preserved when current session index details are unavailable.
  * Session renames now attempt to synchronize the transcript’s saved title without interrupting rename behavior.
  * Transcript loading and updates remain compatible with older transcript formats and fail gracefully on missing or unreadable/corrupt files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->