### PR TITLE
ci: make lint green and run the test suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   lint-test-build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  lint-and-build:
+  lint-test-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,10 @@ jobs:
         run: npm ci
 
       - name: Lint
-        run: npx eslint src/
+        run: npm run lint
+
+      - name: Test
+        run: npm test
 
       - name: Build
         run: npm run build

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,9 @@ export default defineConfig([
 			"@typescript-eslint/no-unused-vars": ["error", { args: "none" }],
 			"@typescript-eslint/ban-ts-comment": "off",
 			"@typescript-eslint/no-empty-function": "off",
+			// Brand/agent names routinely trip this and the PR template already
+			// treats those hits as acceptable — keep them visible, don't fail.
+			"obsidianmd/ui/sentence-case": "warn",
 		},
 	},
 ]);

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -342,6 +342,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 								autoCollapseDiffs: value,
 							},
 						});
+						// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
 						this.display();
 					}),
 			);
@@ -491,6 +492,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.promptInjection.enabled = value;
 						await this.plugin.saveSettings();
+						// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
 						this.display();
 					}),
 			);
@@ -563,6 +565,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 							await this.plugin.settingsService.updateSettings({
 								windowsWslMode: value,
 							});
+							// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
 							this.display(); // Refresh to show/hide distribution setting
 						}),
 				);
@@ -684,6 +687,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 								includeImages: value,
 							},
 						});
+						// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
 						this.display();
 					}),
 			);
@@ -716,6 +720,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 										| "base64",
 								},
 							});
+							// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
 							this.display();
 						}),
 				);
@@ -1247,6 +1252,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					});
 					this.plugin.ensureDefaultAgentId();
 					await this.flushSettings();
+					// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
 					this.display();
 				});
 		});
@@ -1296,6 +1302,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					this.plugin.settings.customAgents.splice(index, 1);
 					this.plugin.ensureDefaultAgentId();
 					await this.flushSettings();
+					// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
 					this.display();
 				});
 		});
@@ -1488,6 +1495,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 							: await resolveCommandPath(commandName);
 						if (found) {
 							await onResolved(found);
+							// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
 							this.display();
 						} else {
 							btn.setButtonText("Not found");

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -30,6 +30,16 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		this.plugin = plugin;
 	}
 
+	/**
+	 * Re-renders the settings tab. Wraps the deprecated display() call so the
+	 * suppression lives in one place until Obsidian 1.13 leaves Catalyst beta
+	 * and the tab can migrate to getSettingDefinitions().
+	 */
+	private refreshDisplay(): void {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
+		this.display();
+	}
+
 	display(): void {
 		const { containerEl } = this;
 
@@ -342,8 +352,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 								autoCollapseDiffs: value,
 							},
 						});
-						// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
-						this.display();
+						this.refreshDisplay();
 					}),
 			);
 
@@ -492,8 +501,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.promptInjection.enabled = value;
 						await this.plugin.saveSettings();
-						// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
-						this.display();
+						this.refreshDisplay();
 					}),
 			);
 
@@ -565,8 +573,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 							await this.plugin.settingsService.updateSettings({
 								windowsWslMode: value,
 							});
-							// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
-							this.display(); // Refresh to show/hide distribution setting
+							this.refreshDisplay(); // Refresh to show/hide distribution setting
 						}),
 				);
 
@@ -687,8 +694,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 								includeImages: value,
 							},
 						});
-						// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
-						this.display();
+						this.refreshDisplay();
 					}),
 			);
 
@@ -720,8 +726,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 										| "base64",
 								},
 							});
-							// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
-							this.display();
+							this.refreshDisplay();
 						}),
 				);
 
@@ -1252,8 +1257,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					});
 					this.plugin.ensureDefaultAgentId();
 					await this.flushSettings();
-					// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
-					this.display();
+					this.refreshDisplay();
 				});
 		});
 	}
@@ -1302,8 +1306,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					this.plugin.settings.customAgents.splice(index, 1);
 					this.plugin.ensureDefaultAgentId();
 					await this.flushSettings();
-					// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
-					this.display();
+					this.refreshDisplay();
 				});
 		});
 
@@ -1495,8 +1498,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 							: await resolveCommandPath(commandName);
 						if (found) {
 							await onResolved(found);
-							// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
-							this.display();
+							this.refreshDisplay();
 						} else {
 							btn.setButtonText("Not found");
 							window.setTimeout(() => {


### PR DESCRIPTION
## Description

CI has been red on every recent PR: the lint step exits non-zero because of two long-standing error classes. This PR makes the pipeline meaningful again, in three parts:

- **`obsidianmd/ui/sentence-case` → warning.** Brand and agent names routinely trip this rule, and the PR template already declares those hits acceptable. They stay visible in lint output but no longer fail it.
- **`display()` deprecation suppressed per call site.** `SettingTab.display()` is deprecated in favor of `getSettingDefinitions()`, but that API ships in Obsidian 1.13 — currently a Catalyst-only beta. Migrating now would force `minAppVersion` past what regular users run, so `display()` remains the only settings-render API available to this plugin. The eight call sites carry individual `eslint-disable-next-line` comments (with the migration note), keeping the rule active so any *other* deprecated API use still fails.
- **CI updates.** The lint step now runs `npm run lint` (matching local usage and covering `test/`, which contains real suites now), and a `npm test` step runs the vitest suite (121 tests) before the build.

This PR itself runs under the updated workflow, so its checks demonstrate the result.

## Related issue

None.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [ ] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: N/A (lint config, comments, and CI workflow only — no runtime change)
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy sentence-case lint warnings for brand and agent names.
  * Improved settings UI updating by centralizing the refresh behavior, preserving correct re-renders after changes while avoiding deprecation-related lint noise.
* **Tests**
  * Updated the CI pipeline to run lint (`npm run lint`) and tests (`npm test`) explicitly before building, with clearer step separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->