### PR TITLE
refactor: drive preset agents from a static registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ src/
 ├── types/                       # Type definitions (no logic, no dependencies)
 │   ├── chat.ts                  # ChatMessage, MessageContent, PromptContent, AttachedFile, ActivePermission
 │   ├── session.ts               # ChatSession, SessionUpdate (12-type union), SessionInfo, Capabilities
-│   ├── agent.ts                 # AgentConfig, agent settings (Claude/Codex/Gemini/Mistral Vibe/Custom)
+│   ├── agent.ts                 # BaseAgentSettings, PresetAgentUserSettings, CustomAgentSettings
 │   └── errors.ts                # AcpError, ProcessError, ErrorInfo
 ├── acp/                         # ACP protocol (SDK dependency confined here)
 │   ├── acp-client.ts            # Process lifecycle, UI-facing API (AcpClient class)
@@ -24,8 +24,9 @@ src/
 │   ├── vault-service.ts         # Vault access + fuzzy search + CM6 selection tracking
 │   ├── settings-service.ts      # Reactive settings store (observer pattern only)
 │   ├── session-storage.ts       # Session metadata + message file I/O (sessions/*.json)
-│   ├── settings-normalizer.ts   # Settings validation helpers (str, bool, num, enumVal, etc.)
-│   ├── session-helpers.ts       # Agent config building, API key injection (pure functions)
+│   ├── preset-agents.ts         # Static registry of preset (built-in) agents (PRESET_AGENTS)
+│   ├── settings-normalizer.ts   # Settings validation helpers + presetAgents normalization/migration
+│   ├── session-helpers.ts       # Agent enumeration/resolution, API key injection (pure functions)
 │   ├── session-state.ts         # Session state updates (legacy mode/model, config restore)
 │   ├── message-state.ts         # Message array transforms (upsert, merge, streaming apply)
 │   ├── message-sender.ts        # Prompt preparation + sending (pure functions)
@@ -175,8 +176,9 @@ FloatingChatView uses `onRegisterExpanded` callback (not CustomEvent) for expand
 **VaultService**: Vault access + file index + fuzzy search + CM6 selection tracking
 **SettingsService**: Reactive settings store (observer pattern for useSyncExternalStore). Session storage delegated to SessionStorage.
 **SessionStorage**: Session metadata CRUD (in plugin settings) + message file I/O (sessions/*.json)
-**settings-normalizer**: Validation helpers (str, bool, num, enumVal, obj, strRecord, xyPoint) + toAgentConfig + parseChatFontSize
-**session-helpers**: Pure functions — buildAgentConfigWithApiKey, findAgentSettings, getAvailableAgents
+**preset-agents**: Static registry (`PRESET_AGENTS`) of preset agent definitions — identity, spawn defaults, legacy data.json migration keys, API-key wiring, install hints, settings-UI copy. User overrides live in `settings.presetAgents[presetId]`
+**settings-normalizer**: Validation helpers (str, bool, num, enumVal, obj, strRecord, xyPoint) + toAgentConfig + parseChatFontSize + normalizePresetAgents (legacy data.json migration; secret-storage side effects injected via ApiKeyMigrator)
+**session-helpers**: Pure functions — buildAgentConfigWithApiKey, findAgentSettings, getAvailableAgentsFromSettings (single enumeration implementation; plugin.getAvailableAgents delegates here)
 **session-state**: Pure functions — applyLegacyValue, tryRestoreConfigOption, restoreLegacyConfig
 **message-state**: Pure functions — applySingleUpdate, applyUpsertToolCall, mergeToolCallContent, findActivePermission, selectOption
 **message-sender**: Pure functions — preparePrompt (embedded context vs XML text, shared helpers), sendPreparedPrompt (auth retry)
@@ -284,18 +286,19 @@ interface ISettingsAccess {
 5. Pass state/callbacks to child components as props
 6. Wrap return object in `useMemo` if passed as dependency to other hooks
 
-### Add Agent Type
-1. Add settings type in `types/agent.ts`
-2. Add config, defaults, normalization, and legacy-key migration in `plugin.ts`
-   (interface, `DEFAULT_SETTINGS`, `loadSettings`, `getAvailableAgents`, `collectAvailableAgentIds`)
-3. Add agent listing + API key injection in `services/session-helpers.ts`
-   (`getAvailableAgentsFromSettings`, `findAgentSettings`, `buildAgentConfigWithApiKey`)
-4. Update `ui/SettingsTab.ts` for configuration UI
-   (render section, `getAgentOptions`, `generateCustomAgentDisplayName`)
-5. Update `ui/ChatPanel.tsx`
-   (`activeAgentLabel`, `selectChatPanelSettings` + `chatPanelSettingsEqual`)
-6. Add docs: `docs/agent-setup/<agent>.md` + mentions in agent-setup index,
-   quick-start, docs index, FAQ, troubleshooting, ACP support, context files
+### Add Preset Agent
+1. Add one entry to `PRESET_AGENTS` in `services/preset-agents.ts`
+   (presetId, defaults, optional apiKey wiring, install hint, settings copy, docsPage).
+   Settings storage, enumeration, API key injection, and the settings UI are all
+   registry-driven — no per-agent code elsewhere.
+2. Add docs — the full file list (do not shorten it; every past addition that
+   skipped one needed a follow-up commit):
+   `docs/agent-setup/<agent>.md` (new page), `docs/.vitepress/config.mts` (sidebar),
+   `docs/index.md`, `docs/agent-setup/index.md`, `docs/getting-started/index.md`,
+   `docs/getting-started/quick-start.md`, `docs/help/faq.md`,
+   `docs/help/troubleshooting.md`, `docs/reference/acp-support.md`,
+   `docs/usage/context-files.md`, `README.md`, `README.ja.md`,
+   and the Agents list at the bottom of this file
 
 ### Modify Message Types
 1. Update `ChatMessage`/`MessageContent` in `types/chat.ts`

--- a/src/acp/acp-client.ts
+++ b/src/acp/acp-client.ts
@@ -196,12 +196,15 @@ export class AcpClient {
 
 		// Resolve API key secret just before spawn so the latest value is used.
 		// Custom agents don't set config.apiKey and inject keys via env directly.
+		// Skip empty values (e.g. the secret was deleted from the Keychain):
+		// exporting ANTHROPIC_API_KEY="" etc. can break account-based logins.
 		if (config.apiKey) {
-			const secretValue =
-				this.plugin.app.secretStorage.getSecret(
-					config.apiKey.secretId,
-				) ?? "";
-			baseEnv[config.apiKey.envVarName] = secretValue;
+			const secretValue = this.plugin.app.secretStorage.getSecret(
+				config.apiKey.secretId,
+			);
+			if (secretValue) {
+				baseEnv[config.apiKey.envVarName] = secretValue;
+			}
 		}
 
 		// In WSL mode, forward the configured env var NAMES into WSL via WSLENV
@@ -416,21 +419,24 @@ export class AcpClient {
 		try {
 			this.logger.log("[AcpClient] Starting ACP initialization...");
 
-			const initResult = await this.connection.agent.request("initialize", {
-				protocolVersion: acp.PROTOCOL_VERSION,
-				clientCapabilities: {
-					fs: {
-						readTextFile: false,
-						writeTextFile: false,
+			const initResult = await this.connection.agent.request(
+				"initialize",
+				{
+					protocolVersion: acp.PROTOCOL_VERSION,
+					clientCapabilities: {
+						fs: {
+							readTextFile: false,
+							writeTextFile: false,
+						},
+						terminal: true,
 					},
-					terminal: true,
+					clientInfo: {
+						name: "obsidian-agent-client",
+						title: "Agent Client for Obsidian",
+						version: this.plugin.manifest.version,
+					},
 				},
-				clientInfo: {
-					name: "obsidian-agent-client",
-					title: "Agent Client for Obsidian",
-					version: this.plugin.manifest.version,
-				},
-			});
+			);
 
 			this.logger.log(
 				`[AcpClient] ✅ Connected to agent (protocol v${initResult.protocolVersion})`,
@@ -547,10 +553,13 @@ export class AcpClient {
 				`[AcpClient] Sending prompt with ${content.length} content blocks`,
 			);
 
-			const promptResult = await connection.agent.request("session/prompt", {
-				sessionId: sessionId,
-				prompt: acpContent,
-			});
+			const promptResult = await connection.agent.request(
+				"session/prompt",
+				{
+					sessionId: sessionId,
+					prompt: acpContent,
+				},
+			);
 
 			this.logger.log(
 				`[AcpClient] Agent completed with: ${promptResult.stopReason}`,

--- a/src/hooks/useAgentSession.ts
+++ b/src/hooks/useAgentSession.ts
@@ -206,7 +206,6 @@ export function useAgentSession(
 				}
 
 				const agentConfig = buildAgentConfigWithApiKey(
-					settings,
 					agentSettings,
 					agentId,
 					effectiveCwd,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -32,10 +32,12 @@ import {
 import { AgentClientSettingTab } from "./ui/SettingsTab";
 import { AcpClient } from "./acp/acp-client";
 import {
-	sanitizeArgs,
-	normalizeEnvVars,
 	normalizeCustomAgent,
 	ensureUniqueCustomAgentIds,
+	normalizePresetAgents,
+	defaultPresetAgentSettings,
+	resolveDefaultAgentId,
+	type ApiKeyMigrator,
 	parseChatFontSize,
 	str,
 	bool,
@@ -46,19 +48,18 @@ import {
 	nestedStrRecord,
 	xyPoint,
 } from "./services/settings-normalizer";
+import { PRESET_AGENTS } from "./services/preset-agents";
+import { getAvailableAgentsFromSettings } from "./services/session-helpers";
 import {
 	AgentEnvVar,
-	GeminiAgentSettings,
-	ClaudeAgentSettings,
-	CodexAgentSettings,
-	MistralVibeAgentSettings,
+	PresetAgentUserSettings,
 	CustomAgentSettings,
 } from "./types/agent";
 import type { SavedSessionInfo } from "./types/session";
 import { initializeLogger, getLogger } from "./utils/logger";
 
 // Re-export for backward compatibility
-export type { AgentEnvVar, MistralVibeAgentSettings, CustomAgentSettings };
+export type { AgentEnvVar, PresetAgentUserSettings, CustomAgentSettings };
 
 /**
  * Generate a short, device-neutral block id for persist embedded chats.
@@ -91,10 +92,13 @@ export type ChatViewLocation =
 	| "editor-split";
 
 export interface AgentClientPluginSettings {
-	gemini: GeminiAgentSettings;
-	claude: ClaudeAgentSettings;
-	codex: CodexAgentSettings;
-	mistralVibe: MistralVibeAgentSettings;
+	/**
+	 * Per-preset user overrides, keyed by presetId (see
+	 * services/preset-agents.ts for the static registry). Normalization
+	 * guarantees an entry for every registry preset; unknown keys written by
+	 * a newer plugin version are preserved but never enumerated.
+	 */
+	presetAgents: Record<string, PresetAgentUserSettings>;
 	customAgents: CustomAgentSettings[];
 	/** Default agent ID for new views (renamed from activeAgentId for multi-session) */
 	defaultAgentId: string;
@@ -159,40 +163,14 @@ export interface AgentClientPluginSettings {
 }
 
 const DEFAULT_SETTINGS: AgentClientPluginSettings = {
-	claude: {
-		id: "claude-code-acp",
-		displayName: "Claude Code",
-		apiKeySecretId: "",
-		command: "claude-agent-acp",
-		args: [],
-		env: [],
-	},
-	codex: {
-		id: "codex-acp",
-		displayName: "Codex",
-		apiKeySecretId: "",
-		command: "codex-acp",
-		args: [],
-		env: [],
-	},
-	gemini: {
-		id: "gemini-cli",
-		displayName: "Gemini CLI",
-		apiKeySecretId: "",
-		command: "gemini",
-		args: ["--experimental-acp"],
-		env: [],
-	},
-	mistralVibe: {
-		id: "mistral-vibe",
-		displayName: "Mistral Vibe",
-		apiKeySecretId: "",
-		command: "vibe-acp",
-		args: [],
-		env: [],
-	},
+	presetAgents: Object.fromEntries(
+		PRESET_AGENTS.map((def) => [
+			def.presetId,
+			defaultPresetAgentSettings(def),
+		]),
+	),
 	customAgents: [],
-	defaultAgentId: "claude-code-acp",
+	defaultAgentId: PRESET_AGENTS[0].presetId,
 	autoAllowPermissions: false,
 	autoMentionActiveNote: true,
 	enableSystemNotifications: true,
@@ -1123,36 +1101,11 @@ export default class AgentClientPlugin extends Plugin {
 	}
 
 	/**
-	 * Get all available agents (built-in + custom)
+	 * Get all available agents (preset + custom). Delegates to the single
+	 * enumeration implementation in session-helpers.
 	 */
 	getAvailableAgents(): Array<{ id: string; displayName: string }> {
-		return [
-			{
-				id: this.settings.claude.id,
-				displayName:
-					this.settings.claude.displayName || this.settings.claude.id,
-			},
-			{
-				id: this.settings.codex.id,
-				displayName:
-					this.settings.codex.displayName || this.settings.codex.id,
-			},
-			{
-				id: this.settings.gemini.id,
-				displayName:
-					this.settings.gemini.displayName || this.settings.gemini.id,
-			},
-			{
-				id: this.settings.mistralVibe.id,
-				displayName:
-					this.settings.mistralVibe.displayName ||
-					this.settings.mistralVibe.id,
-			},
-			...this.settings.customAgents.map((agent) => ({
-				id: agent.id,
-				displayName: agent.displayName || agent.id,
-			})),
-		];
+		return getAvailableAgentsFromSettings(this.settings);
 	}
 
 	/**
@@ -1347,118 +1300,60 @@ export default class AgentClientPlugin extends Plugin {
 		const D = DEFAULT_SETTINGS;
 		let migratedSecrets = false;
 
-		// Extract agent sub-objects
-		const rc = obj(raw.claude) ?? {};
-		const rk = obj(raw.codex) ?? {};
-		const rg = obj(raw.gemini) ?? {};
-		const rmv = obj(raw.mistralVibe) ?? {};
+		// Extract settings sub-objects
 		const re = obj(raw.exportSettings) ?? {};
 		const rd = obj(raw.displaySettings) ?? {};
 
-		// Normalize custom agents
+		// Normalize custom agents. Preset ids are reserved: a custom that
+		// collides with one has always been dead weight (preset-first
+		// resolution), so suffix-renaming it changes no session behavior.
 		const customAgents = Array.isArray(raw.customAgents)
 			? ensureUniqueCustomAgentIds(
 					raw.customAgents.map((a: unknown) =>
 						normalizeCustomAgent(obj(a) ?? {}),
 					),
+					PRESET_AGENTS.map((def) => def.presetId),
 				)
 			: [];
 
 		// Migration: defaultAgentId ← activeAgentId (old name)
 		const availableAgentIds = [
-			D.claude.id,
-			D.codex.id,
-			D.gemini.id,
-			D.mistralVibe.id,
+			...PRESET_AGENTS.map((def) => def.presetId),
 			...customAgents.map((a) => a.id),
 		];
-		const rawDefaultId =
-			str(raw.defaultAgentId, "") || str(raw.activeAgentId, "");
 		const defaultAgentId =
-			rawDefaultId && availableAgentIds.includes(rawDefaultId)
-				? rawDefaultId
-				: availableAgentIds[0] || D.claude.id;
+			resolveDefaultAgentId(raw, availableAgentIds) ||
+			PRESET_AGENTS[0].presetId;
+
+		// Secret-storage side effects (writes + Notices) are injected into the
+		// pure normalizer; called only for presets with apiKey.legacy wiring.
+		const migrateApiKey: ApiKeyMigrator = ({
+			def,
+			current,
+			legacyPlain,
+		}) => {
+			const legacy = def.apiKey?.legacy;
+			if (!legacy) {
+				return current;
+			}
+			return this.migrateLegacyApiKey(
+				legacy.defaultSecretId,
+				legacy.fallbackSecretId,
+				current,
+				legacyPlain,
+				legacy.noticeLabel,
+				() => {
+					migratedSecrets = true;
+				},
+			);
+		};
 
 		this.settings = {
-			claude: {
-				id: D.claude.id, // Fixed — never from raw
-				displayName: str(rc.displayName, D.claude.displayName),
-				apiKeySecretId: this.migrateLegacyApiKey(
-					"claude-api-key",
-					"agent-client-claude-api-key",
-					str(rc.apiKeySecretId, D.claude.apiKeySecretId),
-					str(rc.apiKey, ""),
-					"Claude",
-					() => {
-						migratedSecrets = true;
-					},
-				),
-				// Migration: claude.command ← claudeCodeAcpCommandPath (old name)
-				command:
-					str(rc.command, "") ||
-					str(raw.claudeCodeAcpCommandPath, "") ||
-					D.claude.command,
-				args: sanitizeArgs(rc.args),
-				env: normalizeEnvVars(rc.env),
-			},
-			codex: {
-				id: D.codex.id,
-				displayName: str(rk.displayName, D.codex.displayName),
-				apiKeySecretId: this.migrateLegacyApiKey(
-					"openai-api-key",
-					"agent-client-openai-api-key",
-					str(rk.apiKeySecretId, D.codex.apiKeySecretId),
-					str(rk.apiKey, ""),
-					"Codex",
-					() => {
-						migratedSecrets = true;
-					},
-				),
-				command: str(rk.command, "") || D.codex.command,
-				args: sanitizeArgs(rk.args),
-				env: normalizeEnvVars(rk.env),
-			},
-			gemini: {
-				id: D.gemini.id,
-				displayName: str(rg.displayName, D.gemini.displayName),
-				apiKeySecretId: this.migrateLegacyApiKey(
-					"gemini-api-key",
-					"agent-client-gemini-api-key",
-					str(rg.apiKeySecretId, D.gemini.apiKeySecretId),
-					str(rg.apiKey, ""),
-					"Gemini",
-					() => {
-						migratedSecrets = true;
-					},
-				),
-				// Migration: gemini.command ← geminiCommandPath (old name)
-				command:
-					str(rg.command, "") ||
-					str(raw.geminiCommandPath, "") ||
-					D.gemini.command,
-				args:
-					sanitizeArgs(rg.args).length > 0
-						? sanitizeArgs(rg.args)
-						: D.gemini.args,
-				env: normalizeEnvVars(rg.env),
-			},
-			mistralVibe: {
-				id: D.mistralVibe.id,
-				displayName: str(rmv.displayName, D.mistralVibe.displayName),
-				apiKeySecretId: this.migrateLegacyApiKey(
-					"mistral-api-key",
-					"agent-client-mistral-api-key",
-					str(rmv.apiKeySecretId, D.mistralVibe.apiKeySecretId),
-					str(rmv.apiKey, ""),
-					"Mistral Vibe",
-					() => {
-						migratedSecrets = true;
-					},
-				),
-				command: str(rmv.command, "") || D.mistralVibe.command,
-				args: sanitizeArgs(rmv.args),
-				env: normalizeEnvVars(rmv.env),
-			},
+			presetAgents: normalizePresetAgents(
+				raw,
+				PRESET_AGENTS,
+				migrateApiKey,
+			),
 			customAgents,
 			defaultAgentId,
 			autoAllowPermissions: bool(
@@ -1754,7 +1649,7 @@ export default class AgentClientPlugin extends Plugin {
 	ensureDefaultAgentId(): void {
 		const availableIds = this.collectAvailableAgentIds();
 		if (availableIds.length === 0) {
-			this.settings.defaultAgentId = DEFAULT_SETTINGS.claude.id;
+			this.settings.defaultAgentId = PRESET_AGENTS[0].presetId;
 			return;
 		}
 		if (!availableIds.includes(this.settings.defaultAgentId)) {
@@ -1764,11 +1659,7 @@ export default class AgentClientPlugin extends Plugin {
 
 	private collectAvailableAgentIds(): string[] {
 		const ids = new Set<string>();
-		ids.add(this.settings.claude.id);
-		ids.add(this.settings.codex.id);
-		ids.add(this.settings.gemini.id);
-		ids.add(this.settings.mistralVibe.id);
-		for (const agent of this.settings.customAgents) {
+		for (const agent of this.getAvailableAgents()) {
 			if (agent.id && agent.id.length > 0) {
 				ids.add(agent.id);
 			}

--- a/src/services/preset-agents.ts
+++ b/src/services/preset-agents.ts
@@ -1,0 +1,204 @@
+/**
+ * Static registry of preset (built-in) agents.
+ *
+ * Each entry is code-shipped metadata: identity, spawn defaults, legacy
+ * data.json migration keys, API-key wiring, install hints, and settings-UI
+ * copy. User overrides live in `settings.presetAgents[presetId]` and are
+ * produced by `normalizePresetAgents` (settings-normalizer.ts).
+ *
+ * Adding a preset agent = adding one entry here + a docs page
+ * (see AGENTS.md "Add Agent Type").
+ */
+
+/** Legacy plaintext-key → secret-storage migration wiring (original presets only). */
+export interface PresetAgentApiKeyLegacy {
+	/** Preferred secret id to create on migration. */
+	defaultSecretId: string;
+	/** Fallback secret id when the preferred one is taken by another value. */
+	fallbackSecretId: string;
+	/**
+	 * Agent name used inside the migration Notices. Kept explicit because it
+	 * historically differs from defaultDisplayName ("Claude" vs "Claude Code",
+	 * "Gemini" vs "Gemini CLI") and deriving it would change user-facing text.
+	 */
+	noticeLabel: string;
+}
+
+/** API-key injection wiring. Absent = the agent has no API key row (login-only). */
+export interface PresetAgentApiKey {
+	/** Environment variable the resolved secret is injected as at spawn time. */
+	envVarName: string;
+	/** Description shown under the "API key" setting. */
+	settingDesc: string;
+	/** Present only for presets that ever stored a plaintext key in data.json. */
+	legacy?: PresetAgentApiKeyLegacy;
+}
+
+/** Copyable install hint(s) shown under the Path setting. */
+export interface PresetAgentInstallHint {
+	default: string;
+	/** Shown instead of `default` on native Windows (WSL mode keeps `default`). */
+	nativeWindows?: string;
+}
+
+/** Per-preset settings-screen copy that deviates from the shared template. */
+export interface PresetAgentSettingsCopy {
+	/** Description of the Path setting. */
+	pathDesc: string;
+	/** Appended verbatim to the shared Arguments description. */
+	argsDescSuffix?: string;
+	/** Inserted between the shared env intro and the derived-API-key sentence. */
+	envDescExtra?: string;
+	/** Placeholder for the Environment variables textarea. */
+	envPlaceholder?: string;
+}
+
+/**
+ * Static, code-shipped definition of a preset agent. Users never edit this;
+ * their overrides live in settings.presetAgents[presetId].
+ */
+export interface PresetAgentDefinition {
+	/**
+	 * Stable id — the agentId AND the presetAgents record key. The stored
+	 * entry's inner `id` is force-synced to this (never read from data.json).
+	 */
+	presetId: string;
+	defaultDisplayName: string;
+	defaultCommand: string;
+	/**
+	 * Default args. Normalization falls back to these whenever the stored
+	 * args sanitize to empty (historic Gemini behavior, generalized — for
+	 * presets with non-empty defaults the args are effectively unclearable).
+	 */
+	defaultArgs: string[];
+	/** data.json 旧形式 per-agent sub-object key (original four presets only). */
+	legacySettingsKey?: "claude" | "codex" | "gemini" | "mistralVibe";
+	/** data.json 旧形式 top-level command-path key (claude / gemini only). */
+	legacyCommandPathKey?: string;
+	apiKey?: PresetAgentApiKey;
+	installHint: PresetAgentInstallHint;
+	settingsCopy: PresetAgentSettingsCopy;
+	/** Page name under docs/agent-setup/ (for setup-guide references). */
+	docsPage: string;
+}
+
+export const PRESET_AGENTS: readonly PresetAgentDefinition[] = [
+	{
+		presetId: "claude-code-acp",
+		defaultDisplayName: "Claude Code",
+		defaultCommand: "claude-agent-acp",
+		defaultArgs: [],
+		legacySettingsKey: "claude",
+		legacyCommandPathKey: "claudeCodeAcpCommandPath",
+		apiKey: {
+			envVarName: "ANTHROPIC_API_KEY",
+			settingDesc:
+				"Anthropic API key. Required if not logging in with an Anthropic account. Select from Obsidian's Keychain or create a new secret.",
+			legacy: {
+				defaultSecretId: "claude-api-key",
+				fallbackSecretId: "agent-client-claude-api-key",
+				noticeLabel: "Claude",
+			},
+		},
+		installHint: {
+			default:
+				"npm install -g @agentclientprotocol/claude-agent-acp@latest",
+		},
+		settingsCopy: {
+			pathDesc:
+				'Command name or path to claude-agent-acp. Use just "claude-agent-acp" to let the login shell resolve it, or enter an absolute path.',
+		},
+		docsPage: "claude-code",
+	},
+	{
+		presetId: "codex-acp",
+		defaultDisplayName: "Codex",
+		defaultCommand: "codex-acp",
+		defaultArgs: [],
+		legacySettingsKey: "codex",
+		apiKey: {
+			envVarName: "OPENAI_API_KEY",
+			settingDesc:
+				"OpenAI API key. Required if not logging in with an OpenAI account. Select from Obsidian's Keychain or create a new secret.",
+			legacy: {
+				defaultSecretId: "openai-api-key",
+				fallbackSecretId: "agent-client-openai-api-key",
+				noticeLabel: "Codex",
+			},
+		},
+		installHint: {
+			default: "npm install -g @zed-industries/codex-acp@latest",
+		},
+		settingsCopy: {
+			pathDesc:
+				'Command name or path to codex-acp. Use just "codex-acp" to let the login shell resolve it, or enter an absolute path.',
+		},
+		docsPage: "codex",
+	},
+	{
+		presetId: "gemini-cli",
+		defaultDisplayName: "Gemini CLI",
+		defaultCommand: "gemini",
+		defaultArgs: ["--experimental-acp"],
+		legacySettingsKey: "gemini",
+		legacyCommandPathKey: "geminiCommandPath",
+		apiKey: {
+			envVarName: "GEMINI_API_KEY",
+			settingDesc:
+				"Gemini API key. Required if not logging in with a Google account. Select from Obsidian's Keychain or create a new secret.",
+			legacy: {
+				defaultSecretId: "gemini-api-key",
+				fallbackSecretId: "agent-client-gemini-api-key",
+				noticeLabel: "Gemini",
+			},
+		},
+		installHint: {
+			default: "npm install -g @google/gemini-cli@latest",
+		},
+		settingsCopy: {
+			pathDesc:
+				'Command name or path to the Gemini CLI. Use just "gemini" to let the login shell resolve it, or enter an absolute path for a specific version.',
+			argsDescSuffix:
+				'(Currently, the Gemini CLI requires the "--experimental-acp" option.)',
+			envDescExtra: "Required to authenticate with Vertex AI.",
+			envPlaceholder: "GOOGLE_CLOUD_PROJECT=...",
+		},
+		docsPage: "gemini-cli",
+	},
+	{
+		presetId: "mistral-vibe",
+		defaultDisplayName: "Mistral Vibe",
+		defaultCommand: "vibe-acp",
+		defaultArgs: [],
+		legacySettingsKey: "mistralVibe",
+		apiKey: {
+			envVarName: "MISTRAL_API_KEY",
+			settingDesc:
+				"Mistral API key. Required if not logging in with a Mistral account. Select from Obsidian's Keychain or create a new secret.",
+			legacy: {
+				defaultSecretId: "mistral-api-key",
+				fallbackSecretId: "agent-client-mistral-api-key",
+				noticeLabel: "Mistral Vibe",
+			},
+		},
+		installHint: {
+			default: "curl -LsSf https://mistral.ai/vibe/install.sh | bash",
+			nativeWindows:
+				'powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"; uv tool install mistral-vibe',
+		},
+		settingsCopy: {
+			pathDesc:
+				'Command name or path to vibe-acp. Use just "vibe-acp" to let the login shell resolve it, or enter an absolute path.',
+		},
+		docsPage: "mistral-vibe",
+	},
+];
+
+/**
+ * The Gemini preset id, referenced by the time-boxed Gemini CLI deprecation
+ * notice (Google retires account login on June 18, 2026). Deliberately a
+ * standalone constant instead of a registry field: the notice is temporary
+ * and should be deleted together with this constant's references, without
+ * leaving a dead field in the permanent registry schema.
+ */
+export const GEMINI_PRESET_ID = "gemini-cli";

--- a/src/services/preset-agents.ts
+++ b/src/services/preset-agents.ts
@@ -7,7 +7,7 @@
  * produced by `normalizePresetAgents` (settings-normalizer.ts).
  *
  * Adding a preset agent = adding one entry here + a docs page
- * (see AGENTS.md "Add Agent Type").
+ * (see AGENTS.md "Add Preset Agent").
  */
 
 /** Legacy plaintext-key → secret-storage migration wiring (original presets only). */

--- a/src/services/session-helpers.ts
+++ b/src/services/session-helpers.ts
@@ -6,14 +6,12 @@
 import type { AgentClientPluginSettings } from "../plugin";
 import type {
 	BaseAgentSettings,
-	ClaudeAgentSettings,
-	GeminiAgentSettings,
-	CodexAgentSettings,
-	MistralVibeAgentSettings,
+	PresetAgentUserSettings,
 } from "../types/agent";
 import type { ChatSession, SavedSessionInfo } from "../types/session";
 import type { ChatMessage } from "../types/chat";
 import { toAgentConfig } from "./settings-normalizer";
+import { PRESET_AGENTS } from "./preset-agents";
 import { truncateTitle } from "../utils/text";
 import type { AgentUpdateNotification } from "./update-checker";
 
@@ -40,33 +38,27 @@ export interface AgentDisplayInfo {
  * Get the default agent ID from settings (for new views).
  */
 export function getDefaultAgentId(settings: AgentClientPluginSettings): string {
-	return settings.defaultAgentId || settings.claude.id;
+	return settings.defaultAgentId || PRESET_AGENTS[0].presetId;
 }
 
 /**
  * Get list of all available agents from settings.
+ *
+ * The single enumeration implementation (plugin.getAvailableAgents delegates
+ * here): registry-ordered presets first, then custom agents. Unknown
+ * presetAgents entries (version skew) are deliberately not enumerated.
  */
 export function getAvailableAgentsFromSettings(
 	settings: AgentClientPluginSettings,
 ): AgentDisplayInfo[] {
 	return [
-		{
-			id: settings.claude.id,
-			displayName: settings.claude.displayName || settings.claude.id,
-		},
-		{
-			id: settings.codex.id,
-			displayName: settings.codex.displayName || settings.codex.id,
-		},
-		{
-			id: settings.gemini.id,
-			displayName: settings.gemini.displayName || settings.gemini.id,
-		},
-		{
-			id: settings.mistralVibe.id,
-			displayName:
-				settings.mistralVibe.displayName || settings.mistralVibe.id,
-		},
+		...PRESET_AGENTS.map((def) => {
+			const preset = settings.presetAgents[def.presetId];
+			return {
+				id: def.presetId,
+				displayName: preset?.displayName || def.presetId,
+			};
+		}),
 		...settings.customAgents.map((agent) => ({
 			id: agent.id,
 			displayName: agent.displayName || agent.id,
@@ -97,22 +89,21 @@ export function getCurrentAgent(
 
 /**
  * Find agent settings by ID from plugin settings.
+ *
+ * Presets resolve before custom agents (a custom sharing a preset id has
+ * never been reachable). The preset lookup is gated on registry membership
+ * so preserved unknown presetAgents entries (version skew) never shadow a
+ * same-id custom agent.
  */
 export function findAgentSettings(
 	settings: AgentClientPluginSettings,
 	agentId: string,
 ): BaseAgentSettings | null {
-	if (agentId === settings.claude.id) {
-		return settings.claude;
-	}
-	if (agentId === settings.codex.id) {
-		return settings.codex;
-	}
-	if (agentId === settings.gemini.id) {
-		return settings.gemini;
-	}
-	if (agentId === settings.mistralVibe.id) {
-		return settings.mistralVibe;
+	if (PRESET_AGENTS.some((def) => def.presetId === agentId)) {
+		const preset = settings.presetAgents[agentId];
+		if (preset) {
+			return preset;
+		}
 	}
 	// Search in custom agents
 	const customAgent = settings.customAgents.find(
@@ -122,59 +113,31 @@ export function findAgentSettings(
 }
 
 /**
- * Build AgentConfig with API key injection intent for known agents.
+ * Build AgentConfig with API key injection intent for preset agents.
  *
- * For built-in agents, attaches an `apiKey` intent (secretId + envVarName)
- * to the config. AcpClient.initialize() resolves the secret value from
- * Obsidian's secret storage just before spawn.
+ * For presets with API-key wiring in the registry, attaches an `apiKey`
+ * intent (secretId + envVarName) to the config. AcpClient.initialize()
+ * resolves the secret value from Obsidian's secret storage just before
+ * spawn.
  *
- * Custom agents pass through unchanged (they manage env vars directly).
+ * Custom agents (and presets without an apiKey registry entry) pass through
+ * unchanged (they manage env vars directly).
  */
 export function buildAgentConfigWithApiKey(
-	settings: AgentClientPluginSettings,
 	agentSettings: BaseAgentSettings,
 	agentId: string,
 	workingDirectory: string,
 ) {
 	const baseConfig = toAgentConfig(agentSettings, workingDirectory);
 
-	if (agentId === settings.claude.id) {
-		const claudeSettings = agentSettings as ClaudeAgentSettings;
+	const def = PRESET_AGENTS.find((d) => d.presetId === agentId);
+	if (def?.apiKey) {
+		const presetSettings = agentSettings as PresetAgentUserSettings;
 		return {
 			...baseConfig,
 			apiKey: {
-				secretId: claudeSettings.apiKeySecretId,
-				envVarName: "ANTHROPIC_API_KEY",
-			},
-		};
-	}
-	if (agentId === settings.codex.id) {
-		const codexSettings = agentSettings as CodexAgentSettings;
-		return {
-			...baseConfig,
-			apiKey: {
-				secretId: codexSettings.apiKeySecretId,
-				envVarName: "OPENAI_API_KEY",
-			},
-		};
-	}
-	if (agentId === settings.gemini.id) {
-		const geminiSettings = agentSettings as GeminiAgentSettings;
-		return {
-			...baseConfig,
-			apiKey: {
-				secretId: geminiSettings.apiKeySecretId,
-				envVarName: "GEMINI_API_KEY",
-			},
-		};
-	}
-	if (agentId === settings.mistralVibe.id) {
-		const mistralSettings = agentSettings as MistralVibeAgentSettings;
-		return {
-			...baseConfig,
-			apiKey: {
-				secretId: mistralSettings.apiKeySecretId,
-				envVarName: "MISTRAL_API_KEY",
+				secretId: presetSettings.apiKeySecretId,
+				envVarName: def.apiKey.envVarName,
 			},
 		};
 	}

--- a/src/services/session-helpers.ts
+++ b/src/services/session-helpers.ts
@@ -131,15 +131,20 @@ export function buildAgentConfigWithApiKey(
 	const baseConfig = toAgentConfig(agentSettings, workingDirectory);
 
 	const def = PRESET_AGENTS.find((d) => d.presetId === agentId);
+	// Skip the wiring entirely when no secret is configured (account-based
+	// logins): attaching an empty secretId would export an empty env var
+	// (e.g. ANTHROPIC_API_KEY="") into the agent process.
 	if (def?.apiKey) {
 		const presetSettings = agentSettings as PresetAgentUserSettings;
-		return {
-			...baseConfig,
-			apiKey: {
-				secretId: presetSettings.apiKeySecretId,
-				envVarName: def.apiKey.envVarName,
-			},
-		};
+		if (presetSettings.apiKeySecretId) {
+			return {
+				...baseConfig,
+				apiKey: {
+					secretId: presetSettings.apiKeySecretId,
+					envVarName: def.apiKey.envVarName,
+				},
+			};
+		}
 	}
 
 	// Custom agents — no API key injection

--- a/src/services/settings-normalizer.ts
+++ b/src/services/settings-normalizer.ts
@@ -6,8 +6,12 @@
  */
 
 import type { AgentEnvVar, CustomAgentSettings } from "../plugin";
-import type { BaseAgentSettings } from "../types/agent";
+import type {
+	BaseAgentSettings,
+	PresetAgentUserSettings,
+} from "../types/agent";
 import type { AgentConfig } from "../acp/acp-client";
+import type { PresetAgentDefinition } from "./preset-agents";
 
 // ============================================================================
 // Display Settings
@@ -142,11 +146,14 @@ export const normalizeCustomAgent = (
 	};
 };
 
-// Ensure custom agent IDs are unique within the collection
+// Ensure custom agent IDs are unique within the collection. `reservedIds`
+// (e.g. all preset ids) seed the collision set: a custom colliding with a
+// reserved id is suffix-renamed the same way as a custom-custom duplicate.
 export const ensureUniqueCustomAgentIds = (
 	agents: CustomAgentSettings[],
+	reservedIds: readonly string[] = [],
 ): CustomAgentSettings[] => {
-	const seen = new Set<string>();
+	const seen = new Set<string>(reservedIds);
 	return agents.map((agent) => {
 		const base =
 			agent.id && agent.id.trim().length > 0
@@ -161,6 +168,135 @@ export const ensureUniqueCustomAgentIds = (
 		seen.add(candidate);
 		return { ...agent, id: candidate };
 	});
+};
+
+/**
+ * Resolve the stored default agent id from raw data.json contents.
+ * Migration: defaultAgentId ← activeAgentId (old name). Ids not present in
+ * `availableAgentIds` fall back to the first available id ("" if none).
+ */
+export const resolveDefaultAgentId = (
+	raw: Record<string, unknown>,
+	availableAgentIds: readonly string[],
+): string => {
+	const rawDefaultId =
+		str(raw.defaultAgentId, "") || str(raw.activeAgentId, "");
+	return rawDefaultId && availableAgentIds.includes(rawDefaultId)
+		? rawDefaultId
+		: availableAgentIds[0] || "";
+};
+
+// ============================================================================
+// Preset Agent Normalization
+// ============================================================================
+
+/**
+ * Callback that resolves the apiKeySecretId for a preset with legacy
+ * plaintext-key wiring (`def.apiKey.legacy` is set). The plugin injects an
+ * implementation backed by Obsidian's secret storage (side-effecting:
+ * secret writes + Notices); tests inject a fake. Called only for presets
+ * whose registry entry carries `apiKey.legacy`.
+ */
+export type ApiKeyMigrator = (args: {
+	def: PresetAgentDefinition;
+	/** apiKeySecretId currently stored for this preset ("" if unset). */
+	current: string;
+	/** Legacy plaintext apiKey lingering in data.json ("" if absent). */
+	legacyPlain: string;
+}) => string;
+
+/** Registry defaults as a fresh user-settings entry (no user overrides). */
+export const defaultPresetAgentSettings = (
+	def: PresetAgentDefinition,
+): PresetAgentUserSettings => ({
+	id: def.presetId,
+	displayName: def.defaultDisplayName,
+	apiKeySecretId: "",
+	command: def.defaultCommand,
+	args: [...def.defaultArgs],
+	env: [],
+});
+
+/**
+ * Normalize the presetAgents record from raw data.json contents.
+ *
+ * Reproduces the historic per-agent loadSettings behavior verbatim:
+ * 1. Source order per preset: `raw.presetAgents[presetId]` → legacy
+ *    per-agent sub-object (`raw[legacySettingsKey]`) → registry defaults.
+ * 2. `id` is force-synced to presetId — never read from raw.
+ * 3. `command` falls back to the legacy top-level command-path key
+ *    (claudeCodeAcpCommandPath / geminiCommandPath) before the default.
+ * 4. Args that sanitize to empty fall back to the registry defaults
+ *    (historic Gemini behavior, generalized — a no-op for presets whose
+ *    defaults are empty).
+ * 5. `apiKeySecretId` goes through `migrateApiKey` only for presets with
+ *    legacy plaintext-key wiring.
+ * 6. Unknown presetIds (entries written by a newer plugin version, e.g. via
+ *    Obsidian Sync or a BRAT rollback) are preserved with field-level
+ *    sanitizing only, so a save round-trip doesn't destroy them. They are
+ *    not enumerated anywhere (enumeration is registry-driven).
+ *
+ * Takes the whole raw data.json object because legacy command-path keys
+ * live at the top level.
+ */
+export const normalizePresetAgents = (
+	raw: Record<string, unknown>,
+	registry: readonly PresetAgentDefinition[],
+	migrateApiKey: ApiKeyMigrator,
+): Record<string, PresetAgentUserSettings> => {
+	const rawRecord = obj(raw.presetAgents) ?? {};
+	const result: Record<string, PresetAgentUserSettings> = {};
+
+	for (const def of registry) {
+		const entry =
+			obj(rawRecord[def.presetId]) ??
+			(def.legacySettingsKey ? obj(raw[def.legacySettingsKey]) : null) ??
+			{};
+
+		const storedSecretId = str(entry.apiKeySecretId, "");
+		const apiKeySecretId = def.apiKey?.legacy
+			? migrateApiKey({
+					def,
+					current: storedSecretId,
+					legacyPlain: str(entry.apiKey, ""),
+				})
+			: storedSecretId;
+
+		const legacyCommand = def.legacyCommandPathKey
+			? str(raw[def.legacyCommandPathKey], "")
+			: "";
+		const args = sanitizeArgs(entry.args);
+
+		result[def.presetId] = {
+			id: def.presetId, // Fixed — never from raw
+			displayName: str(entry.displayName, def.defaultDisplayName),
+			apiKeySecretId,
+			command:
+				str(entry.command, "") || legacyCommand || def.defaultCommand,
+			args: args.length > 0 ? args : [...def.defaultArgs],
+			env: normalizeEnvVars(entry.env),
+		};
+	}
+
+	// Preserve unknown presetIds (version skew): sanitize known fields,
+	// spread-through the rest so fields this version doesn't know survive.
+	const knownIds = new Set(registry.map((def) => def.presetId));
+	for (const [presetId, value] of Object.entries(rawRecord)) {
+		if (knownIds.has(presetId)) continue;
+		const entry = obj(value);
+		if (!entry) continue;
+		result[presetId] = {
+			...entry,
+			id: presetId,
+			displayName: str(entry.displayName, presetId),
+			apiKeySecretId: str(entry.apiKeySecretId, ""),
+			command: str(entry.command, ""),
+			args: sanitizeArgs(entry.args),
+			env: normalizeEnvVars(entry.env),
+		};
+	}
+
+	return result;
 };
 
 /**

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -54,50 +54,16 @@ export interface BaseAgentSettings {
 }
 
 /**
- * Configuration for Gemini CLI agent.
+ * Per-preset user overrides for a preset (built-in) agent.
  *
- * Extends base settings with Gemini-specific requirements.
- * The API key (GEMINI_API_KEY) is stored in Obsidian's secret storage
+ * Stored in `settings.presetAgents[presetId]`. The static side of a preset
+ * (default command, API-key env var name, install hints, settings copy) lives
+ * in the registry (`services/preset-agents.ts`); this type holds only what
+ * the user can change. The API key is stored in Obsidian's secret storage
  * and referenced by ID. Empty string means no API key is configured.
  */
-export interface GeminiAgentSettings extends BaseAgentSettings {
-	/** Secret storage ID containing the Gemini API key (GEMINI_API_KEY) */
-	apiKeySecretId: string;
-}
-
-/**
- * Configuration for Claude Code agent.
- *
- * Extends base settings with Claude-specific requirements.
- * The API key (ANTHROPIC_API_KEY) is stored in Obsidian's secret storage
- * and referenced by ID. Empty string means no API key is configured.
- */
-export interface ClaudeAgentSettings extends BaseAgentSettings {
-	/** Secret storage ID containing the Anthropic API key (ANTHROPIC_API_KEY) */
-	apiKeySecretId: string;
-}
-
-/**
- * Configuration for Codex CLI agent.
- *
- * Extends base settings with Codex-specific requirements.
- * The API key (OPENAI_API_KEY) is stored in Obsidian's secret storage
- * and referenced by ID. Empty string means no API key is configured.
- */
-export interface CodexAgentSettings extends BaseAgentSettings {
-	/** Secret storage ID containing the OpenAI API key (OPENAI_API_KEY) */
-	apiKeySecretId: string;
-}
-
-/**
- * Configuration for Mistral Vibe agent.
- *
- * Extends base settings with Mistral-specific requirements.
- * The API key (MISTRAL_API_KEY) is stored in Obsidian's secret storage
- * and referenced by ID. Empty string means no API key is configured.
- */
-export interface MistralVibeAgentSettings extends BaseAgentSettings {
-	/** Secret storage ID containing the Mistral API key (MISTRAL_API_KEY) */
+export interface PresetAgentUserSettings extends BaseAgentSettings {
+	/** Secret storage ID containing the agent's API key */
 	apiKeySecretId: string;
 }
 

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -358,16 +358,16 @@ export const ChatPanel = React.memo(function ChatPanel({
 	const activeAgentLabel = useMemo(() => {
 		const activeId = session.agentId;
 		if (PRESET_AGENTS.some((def) => def.presetId === activeId)) {
-			const preset = plugin.settings.presetAgents[activeId];
+			const preset = settings.presetAgents[activeId];
 			if (preset) {
 				return preset.displayName || preset.id;
 			}
 		}
-		const custom = plugin.settings.customAgents.find(
+		const custom = settings.customAgents.find(
 			(agent) => agent.id === activeId,
 		);
 		return custom?.displayName || custom?.id || activeId;
-	}, [session.agentId, plugin.settings]);
+	}, [session.agentId, settings.presetAgents, settings.customAgents]);
 
 	const availableAgents = useMemo(() => {
 		return plugin.getAvailableAgents();

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -45,6 +45,7 @@ import {
 import { checkAgentUpdate } from "../services/update-checker";
 import type { SessionStatus } from "../services/view-registry";
 import { buildGeminiDeprecationNotice } from "../services/session-helpers";
+import { PRESET_AGENTS, GEMINI_PRESET_ID } from "../services/preset-agents";
 
 /** Stable empty array for useSuggestions when no commands available */
 const EMPTY_COMMANDS: SlashCommand[] = [];
@@ -152,10 +153,7 @@ function selectChatPanelSettings(s: AgentClientPluginSettings) {
 		// These change rarely (only via SettingsTab), so adding them to the slice
 		// does not erode the #20 narrow-subscription intent (no high-frequency
 		// fields here).
-		claude: s.claude,
-		codex: s.codex,
-		gemini: s.gemini,
-		mistralVibe: s.mistralVibe,
+		presetAgents: s.presetAgents,
 		customAgents: s.customAgents,
 		displaySettings: { fontSize: s.displaySettings.fontSize },
 	};
@@ -174,13 +172,10 @@ function chatPanelSettingsEqual(
 		a.enableSystemNotifications === b.enableSystemNotifications &&
 		// SessionStorage always writes a fresh array; reference compare suffices.
 		a.savedSessions === b.savedSessions &&
-		// SettingsTab rebuilds each built-in agent ({ ...settings.claude, … })
-		// and flushSettings emits a fresh customAgents array on edit, so a
+		// SettingsTab.updatePresetAgent emits a fresh presetAgents record and
+		// flushSettings emits a fresh customAgents array on edit, so a
 		// reference compare detects agent changes (and only those).
-		a.claude === b.claude &&
-		a.codex === b.codex &&
-		a.gemini === b.gemini &&
-		a.mistralVibe === b.mistralVibe &&
+		a.presetAgents === b.presetAgents &&
 		a.customAgents === b.customAgents &&
 		a.displaySettings.fontSize === b.displaySettings.fontSize
 	);
@@ -362,26 +357,11 @@ export const ChatPanel = React.memo(function ChatPanel({
 	// ============================================================
 	const activeAgentLabel = useMemo(() => {
 		const activeId = session.agentId;
-		if (activeId === plugin.settings.claude.id) {
-			return (
-				plugin.settings.claude.displayName || plugin.settings.claude.id
-			);
-		}
-		if (activeId === plugin.settings.codex.id) {
-			return (
-				plugin.settings.codex.displayName || plugin.settings.codex.id
-			);
-		}
-		if (activeId === plugin.settings.gemini.id) {
-			return (
-				plugin.settings.gemini.displayName || plugin.settings.gemini.id
-			);
-		}
-		if (activeId === plugin.settings.mistralVibe.id) {
-			return (
-				plugin.settings.mistralVibe.displayName ||
-				plugin.settings.mistralVibe.id
-			);
+		if (PRESET_AGENTS.some((def) => def.presetId === activeId)) {
+			const preset = plugin.settings.presetAgents[activeId];
+			if (preset) {
+				return preset.displayName || preset.id;
+			}
 		}
 		const custom = plugin.settings.customAgents.find(
 			(agent) => agent.id === activeId,
@@ -391,10 +371,10 @@ export const ChatPanel = React.memo(function ChatPanel({
 
 	const availableAgents = useMemo(() => {
 		return plugin.getAvailableAgents();
-		// Depend on the whole settings slice: its identity flips through the
-		// useSettingsSelector equality cache whenever a selected field changes,
-		// so the agent list refreshes on agent-settings edits.
-	}, [plugin, settings]);
+		// Depend on just the agent identity fields (not the whole slice), so
+		// unrelated slice changes (e.g. savedSessions on every turn save)
+		// don't rebuild the header dropdown.
+	}, [plugin, settings.presetAgents, settings.customAgents]);
 
 	// ============================================================
 	// Chat Actions
@@ -436,10 +416,10 @@ export const ChatPanel = React.memo(function ChatPanel({
 	// derived synchronously from the active agent id (no network).
 	const geminiNotice = useMemo(
 		() =>
-			session.agentId === plugin.settings.gemini.id
+			session.agentId === GEMINI_PRESET_ID
 				? buildGeminiDeprecationNotice()
 				: null,
-		[session.agentId, plugin.settings.gemini.id],
+		[session.agentId],
 	);
 
 	// Dismiss state lives locally in ChatPanel so it never races with the

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -1140,6 +1140,19 @@ export class AgentClientSettingTab extends PluginSettingTab {
 						await this.flushSettings();
 						this.refreshAgentDropdown();
 					});
+				// Captured on focus: was the custom being edited the default
+				// agent? At blur time `defaultAgentId === presetId` is
+				// ambiguous — either onChange's keystroke-retargeting followed
+				// this edit, or the default pointed at the preset all along —
+				// and only the former should follow the repair rename.
+				let wasDefaultAtFocus = false;
+				text.inputEl.addEventListener("focus", () => {
+					const currentId =
+						this.plugin.settings.customAgents[index]?.id;
+					wasDefaultAtFocus =
+						currentId !== undefined &&
+						this.plugin.settings.defaultAgentId === currentId;
+				});
 				// Preset ids are reserved. Validate on blur, not per
 				// keystroke: onChange commits every intermediate value, so a
 				// mid-typing collision check would misfire.
@@ -1167,6 +1180,9 @@ export class AgentClientSettingTab extends PluginSettingTab {
 						candidate = `${committed}-${suffix}`;
 					}
 					this.plugin.settings.customAgents[index].id = candidate;
+					if (wasDefaultAtFocus) {
+						this.plugin.settings.defaultAgentId = candidate;
+					}
 					text.setValue(candidate);
 					new Notice(
 						`[Agent Client] "${committed}" is reserved for a built-in agent. This custom agent was renamed to "${candidate}".`,

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -1,5 +1,6 @@
 import {
 	App,
+	Notice,
 	PluginSettingTab,
 	Setting,
 	DropdownComponent,
@@ -9,9 +10,14 @@ import {
 import type AgentClientPlugin from "../plugin";
 import type {
 	CustomAgentSettings,
+	PresetAgentUserSettings,
 	AgentEnvVar,
 	ChatViewLocation,
 } from "../plugin";
+import {
+	PRESET_AGENTS,
+	type PresetAgentDefinition,
+} from "../services/preset-agents";
 import { resolveCommandPath, resolveCommandPathInWsl } from "../utils/paths";
 import {
 	normalizeEnvVars,
@@ -606,10 +612,9 @@ export class AgentClientSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl).setName("Built-in agents").setHeading();
 
-		this.renderClaudeSettings(containerEl);
-		this.renderCodexSettings(containerEl);
-		this.renderGeminiSettings(containerEl);
-		this.renderMistralVibeSettings(containerEl);
+		for (const def of PRESET_AGENTS) {
+			this.renderPresetSettings(containerEl, def);
+		}
 
 		new Setting(containerEl).setName("Custom agents").setHeading();
 
@@ -911,28 +916,15 @@ export class AgentClientSettingTab extends PluginSettingTab {
 			id,
 			label: `${displayName} (${id})`,
 		});
-		const options: { id: string; label: string }[] = [
-			toOption(
-				this.plugin.settings.claude.id,
-				this.plugin.settings.claude.displayName ||
-					this.plugin.settings.claude.id,
-			),
-			toOption(
-				this.plugin.settings.codex.id,
-				this.plugin.settings.codex.displayName ||
-					this.plugin.settings.codex.id,
-			),
-			toOption(
-				this.plugin.settings.gemini.id,
-				this.plugin.settings.gemini.displayName ||
-					this.plugin.settings.gemini.id,
-			),
-			toOption(
-				this.plugin.settings.mistralVibe.id,
-				this.plugin.settings.mistralVibe.displayName ||
-					this.plugin.settings.mistralVibe.id,
-			),
-		];
+		const options: { id: string; label: string }[] = PRESET_AGENTS.map(
+			(def) => {
+				const preset = this.plugin.settings.presetAgents[def.presetId];
+				return toOption(
+					def.presetId,
+					preset?.displayName || def.presetId,
+				);
+			},
+		);
 		for (const agent of this.plugin.settings.customAgents) {
 			if (agent.id && agent.id.length > 0) {
 				const labelSource =
@@ -952,383 +944,129 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		});
 	}
 
-	private renderGeminiSettings(sectionEl: HTMLElement) {
-		const gemini = this.plugin.settings.gemini;
-
-		new Setting(sectionEl)
-			.setName(gemini.displayName || "Gemini CLI")
-			.setHeading();
-
-		new Setting(sectionEl)
-			.setName("API key")
-			.setDesc(
-				"Gemini API key. Required if not logging in with a Google account. Select from Obsidian's Keychain or create a new secret.",
-			)
-			.addComponent((el) =>
-				new SecretComponent(this.app, el)
-					.setValue(gemini.apiKeySecretId)
-					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							gemini: {
-								...this.plugin.settings.gemini,
-								apiKeySecretId: value,
-							},
-						});
-					}),
-			);
-
-		const geminiPathSetting = new Setting(sectionEl)
-			.setName("Path")
-			.setDesc(
-				'Command name or path to the Gemini CLI. Use just "gemini" to let the login shell resolve it, or enter an absolute path for a specific version.',
-			)
-			.addText((text) => {
-				text.setPlaceholder("gemini")
-					.setValue(gemini.command)
-					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							gemini: {
-								...this.plugin.settings.gemini,
-								command: value.trim(),
-							},
-						});
-					});
-			});
-		this.addAutoDetectButton(geminiPathSetting, "gemini", async (path) => {
-			await this.plugin.settingsService.updateSettings({
-				gemini: {
-					...this.plugin.settings.gemini,
-					command: path,
-				},
-			});
+	/**
+	 * Write a partial update for one preset agent through the settings
+	 * service. Emits a fresh presetAgents record + fresh entry so slice
+	 * subscribers (ChatPanel via useSettingsSelector) detect the change by
+	 * reference compare.
+	 */
+	private async updatePresetAgent(
+		presetId: string,
+		updates: Partial<PresetAgentUserSettings>,
+	): Promise<void> {
+		const current = this.plugin.settings.presetAgents[presetId];
+		if (!current) {
+			return;
+		}
+		await this.plugin.settingsService.updateSettings({
+			presetAgents: {
+				...this.plugin.settings.presetAgents,
+				[presetId]: { ...current, ...updates },
+			},
 		});
-		this.addInstallHint(sectionEl, "@google/gemini-cli");
-
-		new Setting(sectionEl)
-			.setName("Arguments")
-			.setDesc(
-				'Enter one argument per line. Leave empty to run without arguments.(Currently, the Gemini CLI requires the "--experimental-acp" option.)',
-			)
-			.addTextArea((text) => {
-				text.setPlaceholder("")
-					.setValue(this.formatArgs(gemini.args))
-					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							gemini: {
-								...this.plugin.settings.gemini,
-								args: this.parseArgs(value),
-							},
-						});
-					});
-				text.inputEl.rows = 3;
-			});
-
-		new Setting(sectionEl)
-			.setName("Environment variables")
-			.setDesc(
-				"Enter KEY=VALUE pairs, one per line. Required to authenticate with Vertex AI. GEMINI_API_KEY is derived from the field above.",
-			)
-			.addTextArea((text) => {
-				text.setPlaceholder("GOOGLE_CLOUD_PROJECT=...")
-					.setValue(this.formatEnv(gemini.env))
-					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							gemini: {
-								...this.plugin.settings.gemini,
-								env: this.parseEnv(value),
-							},
-						});
-					});
-				text.inputEl.rows = 3;
-			});
 	}
 
-	private renderClaudeSettings(sectionEl: HTMLElement) {
-		const claude = this.plugin.settings.claude;
+	/**
+	 * Render the settings section for one preset agent, driven entirely by
+	 * its registry definition (heading, API key row, path + auto-detect,
+	 * install hint, arguments, environment variables).
+	 */
+	private renderPresetSettings(
+		sectionEl: HTMLElement,
+		def: PresetAgentDefinition,
+	) {
+		const preset = this.plugin.settings.presetAgents[def.presetId];
+		if (!preset) {
+			// Normalization guarantees an entry per registry preset.
+			return;
+		}
 
 		new Setting(sectionEl)
-			.setName(claude.displayName || "Claude Code (ACP)")
+			.setName(preset.displayName || def.defaultDisplayName)
 			.setHeading();
 
-		new Setting(sectionEl)
-			.setName("API key")
-			.setDesc(
-				"Anthropic API key. Required if not logging in with an Anthropic account. Select from Obsidian's Keychain or create a new secret.",
-			)
-			.addComponent((el) =>
-				new SecretComponent(this.app, el)
-					.setValue(claude.apiKeySecretId)
-					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							claude: {
-								...this.plugin.settings.claude,
+		if (def.apiKey) {
+			new Setting(sectionEl)
+				.setName("API key")
+				.setDesc(def.apiKey.settingDesc)
+				.addComponent((el) =>
+					new SecretComponent(this.app, el)
+						.setValue(preset.apiKeySecretId)
+						.onChange(async (value) => {
+							await this.updatePresetAgent(def.presetId, {
 								apiKeySecretId: value,
-							},
-						});
-					}),
-			);
+							});
+						}),
+				);
+		}
 
-		const claudePathSetting = new Setting(sectionEl)
+		const pathSetting = new Setting(sectionEl)
 			.setName("Path")
-			.setDesc(
-				'Command name or path to claude-agent-acp. Use just "claude-agent-acp" to let the login shell resolve it, or enter an absolute path.',
-			)
+			.setDesc(def.settingsCopy.pathDesc)
 			.addText((text) => {
-				text.setPlaceholder("claude-agent-acp")
-					.setValue(claude.command)
+				text.setPlaceholder(def.defaultCommand)
+					.setValue(preset.command)
 					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							claude: {
-								...this.plugin.settings.claude,
-								command: value.trim(),
-							},
+						await this.updatePresetAgent(def.presetId, {
+							command: value.trim(),
 						});
 					});
 			});
 		this.addAutoDetectButton(
-			claudePathSetting,
-			"claude-agent-acp",
+			pathSetting,
+			def.defaultCommand,
 			async (path) => {
-				await this.plugin.settingsService.updateSettings({
-					claude: {
-						...this.plugin.settings.claude,
-						command: path,
-					},
-				});
+				await this.updatePresetAgent(def.presetId, { command: path });
 			},
 		);
-		this.addInstallHint(sectionEl, "@agentclientprotocol/claude-agent-acp");
-
-		new Setting(sectionEl)
-			.setName("Arguments")
-			.setDesc(
-				"Enter one argument per line. Leave empty to run without arguments.",
-			)
-			.addTextArea((text) => {
-				text.setPlaceholder("")
-					.setValue(this.formatArgs(claude.args))
-					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							claude: {
-								...this.plugin.settings.claude,
-								args: this.parseArgs(value),
-							},
-						});
-					});
-				text.inputEl.rows = 3;
-			});
-
-		new Setting(sectionEl)
-			.setName("Environment variables")
-			.setDesc(
-				"Enter KEY=VALUE pairs, one per line. ANTHROPIC_API_KEY is derived from the field above.",
-			)
-			.addTextArea((text) => {
-				text.setPlaceholder("")
-					.setValue(this.formatEnv(claude.env))
-					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							claude: {
-								...this.plugin.settings.claude,
-								env: this.parseEnv(value),
-							},
-						});
-					});
-				text.inputEl.rows = 3;
-			});
-	}
-
-	private renderCodexSettings(sectionEl: HTMLElement) {
-		const codex = this.plugin.settings.codex;
-
-		new Setting(sectionEl)
-			.setName(codex.displayName || "Codex")
-			.setHeading();
-
-		new Setting(sectionEl)
-			.setName("API key")
-			.setDesc(
-				"OpenAI API key. Required if not logging in with an OpenAI account. Select from Obsidian's Keychain or create a new secret.",
-			)
-			.addComponent((el) =>
-				new SecretComponent(this.app, el)
-					.setValue(codex.apiKeySecretId)
-					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							codex: {
-								...this.plugin.settings.codex,
-								apiKeySecretId: value,
-							},
-						});
-					}),
-			);
-
-		const codexPathSetting = new Setting(sectionEl)
-			.setName("Path")
-			.setDesc(
-				'Command name or path to codex-acp. Use just "codex-acp" to let the login shell resolve it, or enter an absolute path.',
-			)
-			.addText((text) => {
-				text.setPlaceholder("codex-acp")
-					.setValue(codex.command)
-					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							codex: {
-								...this.plugin.settings.codex,
-								command: value.trim(),
-							},
-						});
-					});
-			});
-		this.addAutoDetectButton(
-			codexPathSetting,
-			"codex-acp",
-			async (path) => {
-				await this.plugin.settingsService.updateSettings({
-					codex: {
-						...this.plugin.settings.codex,
-						command: path,
-					},
-				});
-			},
-		);
-		this.addInstallHint(sectionEl, "@zed-industries/codex-acp");
-
-		new Setting(sectionEl)
-			.setName("Arguments")
-			.setDesc(
-				"Enter one argument per line. Leave empty to run without arguments.",
-			)
-			.addTextArea((text) => {
-				text.setPlaceholder("")
-					.setValue(this.formatArgs(codex.args))
-					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							codex: {
-								...this.plugin.settings.codex,
-								args: this.parseArgs(value),
-							},
-						});
-					});
-				text.inputEl.rows = 3;
-			});
-
-		new Setting(sectionEl)
-			.setName("Environment variables")
-			.setDesc(
-				"Enter KEY=VALUE pairs, one per line. OPENAI_API_KEY is derived from the field above.",
-			)
-			.addTextArea((text) => {
-				text.setPlaceholder("")
-					.setValue(this.formatEnv(codex.env))
-					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							codex: {
-								...this.plugin.settings.codex,
-								env: this.parseEnv(value),
-							},
-						});
-					});
-				text.inputEl.rows = 3;
-			});
-	}
-
-	private renderMistralVibeSettings(sectionEl: HTMLElement) {
-		const mistralVibe = this.plugin.settings.mistralVibe;
-
-		new Setting(sectionEl)
-			.setName(mistralVibe.displayName || "Mistral Vibe")
-			.setHeading();
-
-		new Setting(sectionEl)
-			.setName("API key")
-			.setDesc(
-				"Mistral API key. Required if not logging in with a Mistral account. Select from Obsidian's Keychain or create a new secret.",
-			)
-			.addComponent((el) =>
-				new SecretComponent(this.app, el)
-					.setValue(mistralVibe.apiKeySecretId)
-					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							mistralVibe: {
-								...this.plugin.settings.mistralVibe,
-								apiKeySecretId: value,
-							},
-						});
-					}),
-			);
-
-		const vibePathSetting = new Setting(sectionEl)
-			.setName("Path")
-			.setDesc(
-				'Command name or path to vibe-acp. Use just "vibe-acp" to let the login shell resolve it, or enter an absolute path.',
-			)
-			.addText((text) => {
-				text.setPlaceholder("vibe-acp")
-					.setValue(mistralVibe.command)
-					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							mistralVibe: {
-								...this.plugin.settings.mistralVibe,
-								command: value.trim(),
-							},
-						});
-					});
-			});
-		this.addAutoDetectButton(vibePathSetting, "vibe-acp", async (path) => {
-			await this.plugin.settingsService.updateSettings({
-				mistralVibe: {
-					...this.plugin.settings.mistralVibe,
-					command: path,
-				},
-			});
-		});
-		// Vibe's curl installer is macOS/Linux-only; native Windows uses the
-		// official uv bootstrap instead (WSL mode runs commands in bash, so
-		// curl is correct there). The WSL toggle re-renders the tab, keeping
-		// this hint in sync.
+		// Native Windows may need a different install command than the
+		// POSIX-shell one (WSL mode runs commands in bash, so it keeps the
+		// default). The WSL toggle re-renders the tab, keeping this in sync.
 		const isNativeWindows =
 			Platform.isWin && !this.plugin.settings.windowsWslMode;
-		this.addInstallHintCustom(
+		this.addInstallHint(
 			sectionEl,
-			isNativeWindows
-				? 'powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"; uv tool install mistral-vibe'
-				: "curl -LsSf https://mistral.ai/vibe/install.sh | bash",
+			isNativeWindows && def.installHint.nativeWindows
+				? def.installHint.nativeWindows
+				: def.installHint.default,
 		);
 
 		new Setting(sectionEl)
 			.setName("Arguments")
 			.setDesc(
-				"Enter one argument per line. Leave empty to run without arguments.",
+				"Enter one argument per line. Leave empty to run without arguments." +
+					(def.settingsCopy.argsDescSuffix ?? ""),
 			)
 			.addTextArea((text) => {
 				text.setPlaceholder("")
-					.setValue(this.formatArgs(mistralVibe.args))
+					.setValue(this.formatArgs(preset.args))
 					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							mistralVibe: {
-								...this.plugin.settings.mistralVibe,
-								args: this.parseArgs(value),
-							},
+						await this.updatePresetAgent(def.presetId, {
+							args: this.parseArgs(value),
 						});
 					});
 				text.inputEl.rows = 3;
 			});
 
+		const envDescParts = ["Enter KEY=VALUE pairs, one per line."];
+		if (def.settingsCopy.envDescExtra) {
+			envDescParts.push(def.settingsCopy.envDescExtra);
+		}
+		if (def.apiKey) {
+			envDescParts.push(
+				`${def.apiKey.envVarName} is derived from the field above.`,
+			);
+		}
+
 		new Setting(sectionEl)
 			.setName("Environment variables")
-			.setDesc(
-				"Enter KEY=VALUE pairs, one per line. MISTRAL_API_KEY is derived from the field above.",
-			)
+			.setDesc(envDescParts.join(" "))
 			.addTextArea((text) => {
-				text.setPlaceholder("")
-					.setValue(this.formatEnv(mistralVibe.env))
+				text.setPlaceholder(def.settingsCopy.envPlaceholder ?? "")
+					.setValue(this.formatEnv(preset.env))
 					.onChange(async (value) => {
-						await this.plugin.settingsService.updateSettings({
-							mistralVibe: {
-								...this.plugin.settings.mistralVibe,
-								env: this.parseEnv(value),
-							},
+						await this.updatePresetAgent(def.presetId, {
+							env: this.parseEnv(value),
 						});
 					});
 				text.inputEl.rows = 3;
@@ -1402,6 +1140,42 @@ export class AgentClientSettingTab extends PluginSettingTab {
 						await this.flushSettings();
 						this.refreshAgentDropdown();
 					});
+				// Preset ids are reserved. Validate on blur, not per
+				// keystroke: onChange commits every intermediate value, so a
+				// mid-typing collision check would misfire.
+				text.inputEl.addEventListener("blur", () => {
+					const committed =
+						this.plugin.settings.customAgents[index]?.id;
+					if (
+						!committed ||
+						!PRESET_AGENTS.some((def) => def.presetId === committed)
+					) {
+						return;
+					}
+					const taken = new Set<string>(
+						PRESET_AGENTS.map((def) => def.presetId),
+					);
+					this.plugin.settings.customAgents.forEach((item, i) => {
+						if (i !== index) {
+							taken.add(item.id);
+						}
+					});
+					let suffix = 2;
+					let candidate = `${committed}-${suffix}`;
+					while (taken.has(candidate)) {
+						suffix += 1;
+						candidate = `${committed}-${suffix}`;
+					}
+					this.plugin.settings.customAgents[index].id = candidate;
+					text.setValue(candidate);
+					new Notice(
+						`[Agent Client] "${committed}" is reserved for a built-in agent. This custom agent was renamed to "${candidate}".`,
+					);
+					this.plugin.ensureDefaultAgentId();
+					void this.flushSettings().then(() => {
+						this.refreshAgentDropdown();
+					});
+				});
 			});
 
 		idSetting.addExtraButton((button) => {
@@ -1506,22 +1280,10 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	private generateCustomAgentDisplayName(): string {
 		const base = "Custom agent";
 		const existing = new Set<string>();
-		existing.add(
-			this.plugin.settings.claude.displayName ||
-				this.plugin.settings.claude.id,
-		);
-		existing.add(
-			this.plugin.settings.codex.displayName ||
-				this.plugin.settings.codex.id,
-		);
-		existing.add(
-			this.plugin.settings.gemini.displayName ||
-				this.plugin.settings.gemini.id,
-		);
-		existing.add(
-			this.plugin.settings.mistralVibe.displayName ||
-				this.plugin.settings.mistralVibe.id,
-		);
+		for (const def of PRESET_AGENTS) {
+			const preset = this.plugin.settings.presetAgents[def.presetId];
+			existing.add(preset?.displayName || def.presetId);
+		}
 		for (const item of this.plugin.settings.customAgents) {
 			existing.add(item.displayName || item.id);
 		}
@@ -1556,22 +1318,9 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	}
 
 	/**
-	 * Renders a copyable npm install command hint below a Path setting.
-	 */
-	private addInstallHint(containerEl: HTMLElement, npmPackage: string): void {
-		this.addInstallHintCustom(
-			containerEl,
-			`npm install -g ${npmPackage}@latest`,
-		);
-	}
-
-	/**
 	 * Renders a copyable install command hint below a Path setting.
 	 */
-	private addInstallHintCustom(
-		containerEl: HTMLElement,
-		command: string,
-	): void {
+	private addInstallHint(containerEl: HTMLElement, command: string): void {
 		const frag = createFragment();
 		frag.appendText("Not installed? Run in terminal: ");
 		frag.createEl("code", { text: command });

--- a/test/session-helpers.test.ts
+++ b/test/session-helpers.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+	getDefaultAgentId,
+	getAvailableAgentsFromSettings,
+	findAgentSettings,
+	buildAgentConfigWithApiKey,
+} from "../src/services/session-helpers";
+import type { AgentClientPluginSettings } from "../src/plugin";
+import type {
+	PresetAgentUserSettings,
+	CustomAgentSettings,
+} from "../src/types/agent";
+
+// Characterization tests: every expected value below is a string literal,
+// deliberately NOT derived from PRESET_AGENTS. A transcription mistake in the
+// registry (wrong id, wrong env var, wrong order) must fail here.
+
+const preset = (
+	id: string,
+	displayName: string,
+	command: string,
+	overrides: Partial<PresetAgentUserSettings> = {},
+): PresetAgentUserSettings => ({
+	id,
+	displayName,
+	apiKeySecretId: "",
+	command,
+	args: [],
+	env: [],
+	...overrides,
+});
+
+const custom = (id: string, displayName: string): CustomAgentSettings => ({
+	id,
+	displayName,
+	command: "my-cmd",
+	args: [],
+	env: [],
+});
+
+function makeSettings(
+	overrides: Partial<AgentClientPluginSettings> = {},
+): AgentClientPluginSettings {
+	return {
+		presetAgents: {
+			"claude-code-acp": preset(
+				"claude-code-acp",
+				"Claude Code",
+				"claude-agent-acp",
+			),
+			"codex-acp": preset("codex-acp", "Codex", "codex-acp"),
+			"gemini-cli": preset("gemini-cli", "Gemini CLI", "gemini", {
+				args: ["--experimental-acp"],
+			}),
+			"mistral-vibe": preset("mistral-vibe", "Mistral Vibe", "vibe-acp"),
+		},
+		customAgents: [],
+		defaultAgentId: "",
+		...overrides,
+	} as AgentClientPluginSettings;
+}
+
+describe("getAvailableAgentsFromSettings", () => {
+	it("enumerates the four presets in order, then customs", () => {
+		const settings = makeSettings({
+			customAgents: [custom("my-custom", "My Custom")],
+		});
+		expect(getAvailableAgentsFromSettings(settings)).toEqual([
+			{ id: "claude-code-acp", displayName: "Claude Code" },
+			{ id: "codex-acp", displayName: "Codex" },
+			{ id: "gemini-cli", displayName: "Gemini CLI" },
+			{ id: "mistral-vibe", displayName: "Mistral Vibe" },
+			{ id: "my-custom", displayName: "My Custom" },
+		]);
+	});
+
+	it("falls back to the id when a displayName is empty", () => {
+		const settings = makeSettings();
+		settings.presetAgents["codex-acp"].displayName = "";
+		const agents = getAvailableAgentsFromSettings(settings);
+		expect(agents[1]).toEqual({
+			id: "codex-acp",
+			displayName: "codex-acp",
+		});
+	});
+});
+
+describe("findAgentSettings", () => {
+	it("resolves a preset before a custom agent with the same id", () => {
+		const settings = makeSettings({
+			customAgents: [custom("gemini-cli", "Shadowed Custom")],
+		});
+		const found = findAgentSettings(settings, "gemini-cli");
+		expect(found?.displayName).toBe("Gemini CLI");
+	});
+
+	it("resolves custom agents and returns null for unknown ids", () => {
+		const settings = makeSettings({
+			customAgents: [custom("my-custom", "My Custom")],
+		});
+		expect(findAgentSettings(settings, "my-custom")?.displayName).toBe(
+			"My Custom",
+		);
+		expect(findAgentSettings(settings, "ghost")).toBeNull();
+	});
+
+	it("does not let a preserved unknown presetAgents entry shadow a same-id custom", () => {
+		const settings = makeSettings({
+			customAgents: [custom("opencode", "My OpenCode")],
+		});
+		settings.presetAgents.opencode = preset(
+			"opencode",
+			"Stale Synced Entry",
+			"opencode",
+		);
+		expect(findAgentSettings(settings, "opencode")?.displayName).toBe(
+			"My OpenCode",
+		);
+	});
+});
+
+describe("buildAgentConfigWithApiKey", () => {
+	it.each([
+		["claude-code-acp", "ANTHROPIC_API_KEY"],
+		["codex-acp", "OPENAI_API_KEY"],
+		["gemini-cli", "GEMINI_API_KEY"],
+		["mistral-vibe", "MISTRAL_API_KEY"],
+	])("attaches the %s secret as %s", (agentId, envVarName) => {
+		const agentSettings = preset(agentId, "Name", "cmd", {
+			apiKeySecretId: "my-secret",
+		});
+		const config = buildAgentConfigWithApiKey(
+			agentSettings,
+			agentId,
+			"/wd",
+		);
+		expect(config).toMatchObject({
+			id: agentId,
+			workingDirectory: "/wd",
+			apiKey: { secretId: "my-secret", envVarName },
+		});
+	});
+
+	it("passes custom agents through without API key injection", () => {
+		const config = buildAgentConfigWithApiKey(
+			custom("my-custom", "My Custom"),
+			"my-custom",
+			"/wd",
+		);
+		expect(config).not.toHaveProperty("apiKey");
+	});
+});
+
+describe("getDefaultAgentId", () => {
+	it("returns the stored default when set", () => {
+		expect(
+			getDefaultAgentId(makeSettings({ defaultAgentId: "codex-acp" })),
+		).toBe("codex-acp");
+	});
+
+	it("falls back to the first preset when unset", () => {
+		expect(getDefaultAgentId(makeSettings())).toBe("claude-code-acp");
+	});
+});

--- a/test/session-helpers.test.ts
+++ b/test/session-helpers.test.ts
@@ -141,6 +141,16 @@ describe("buildAgentConfigWithApiKey", () => {
 		});
 	});
 
+	it("skips API key wiring when no secret is configured", () => {
+		const agentSettings = preset("claude-code-acp", "Claude Code", "cmd");
+		const config = buildAgentConfigWithApiKey(
+			agentSettings,
+			"claude-code-acp",
+			"/wd",
+		);
+		expect(config).not.toHaveProperty("apiKey");
+	});
+
 	it("passes custom agents through without API key injection", () => {
 		const config = buildAgentConfigWithApiKey(
 			custom("my-custom", "My Custom"),

--- a/test/settings-normalizer.test.ts
+++ b/test/settings-normalizer.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+	normalizePresetAgents,
+	defaultPresetAgentSettings,
+	ensureUniqueCustomAgentIds,
+	resolveDefaultAgentId,
+	type ApiKeyMigrator,
+} from "../src/services/settings-normalizer";
+import { PRESET_AGENTS } from "../src/services/preset-agents";
+import type { CustomAgentSettings } from "../src/types/agent";
+
+// Pass-through migrator: returns the stored secret id unchanged. Tests that
+// exercise the migration chain use a vi.fn wrapper instead.
+const noMigration: ApiKeyMigrator = ({ current }) => current;
+
+const PRESET_IDS = PRESET_AGENTS.map((def) => def.presetId);
+
+describe("normalizePresetAgents", () => {
+	it("migrates the legacy per-agent sub-objects with values preserved", () => {
+		const raw = {
+			claude: {
+				id: "claude-code-acp",
+				displayName: "My Claude",
+				apiKeySecretId: "claude-secret",
+				command: "/opt/claude-agent-acp",
+				args: ["--verbose"],
+				env: [{ key: "FOO", value: "bar" }],
+			},
+			codex: { command: "/opt/codex-acp" },
+			gemini: { displayName: "Gemini" },
+			mistralVibe: { args: ["--x"] },
+		};
+		const result = normalizePresetAgents(raw, PRESET_AGENTS, noMigration);
+
+		expect(result["claude-code-acp"]).toEqual({
+			id: "claude-code-acp",
+			displayName: "My Claude",
+			apiKeySecretId: "claude-secret",
+			command: "/opt/claude-agent-acp",
+			args: ["--verbose"],
+			env: [{ key: "FOO", value: "bar" }],
+		});
+		expect(result["codex-acp"].command).toBe("/opt/codex-acp");
+		expect(result["gemini-cli"].displayName).toBe("Gemini");
+		expect(result["mistral-vibe"].args).toEqual(["--x"]);
+	});
+
+	it("respects the legacy top-level command-path keys", () => {
+		const raw = {
+			claudeCodeAcpCommandPath: "/legacy/claude-agent-acp",
+			geminiCommandPath: "/legacy/gemini",
+		};
+		const result = normalizePresetAgents(raw, PRESET_AGENTS, noMigration);
+
+		expect(result["claude-code-acp"].command).toBe(
+			"/legacy/claude-agent-acp",
+		);
+		expect(result["gemini-cli"].command).toBe("/legacy/gemini");
+		// A stored command wins over the legacy top-level key.
+		const withStored = normalizePresetAgents(
+			{ ...raw, claude: { command: "/stored/claude" } },
+			PRESET_AGENTS,
+			noMigration,
+		);
+		expect(withStored["claude-code-acp"].command).toBe("/stored/claude");
+	});
+
+	it("backfills empty gemini args to the registry default", () => {
+		const empty = normalizePresetAgents(
+			{ gemini: { args: [] } },
+			PRESET_AGENTS,
+			noMigration,
+		);
+		expect(empty["gemini-cli"].args).toEqual(["--experimental-acp"]);
+
+		const whitespace = normalizePresetAgents(
+			{ gemini: { args: ["  ", ""] } },
+			PRESET_AGENTS,
+			noMigration,
+		);
+		expect(whitespace["gemini-cli"].args).toEqual(["--experimental-acp"]);
+
+		const explicit = normalizePresetAgents(
+			{ gemini: { args: ["--experimental-acp", "--foo"] } },
+			PRESET_AGENTS,
+			noMigration,
+		);
+		expect(explicit["gemini-cli"].args).toEqual([
+			"--experimental-acp",
+			"--foo",
+		]);
+	});
+
+	it("force-syncs the entry id to the record key, never from raw", () => {
+		const fromNew = normalizePresetAgents(
+			{ presetAgents: { "claude-code-acp": { id: "polluted" } } },
+			PRESET_AGENTS,
+			noMigration,
+		);
+		expect(fromNew["claude-code-acp"].id).toBe("claude-code-acp");
+
+		const fromLegacy = normalizePresetAgents(
+			{ claude: { id: "claude" } },
+			PRESET_AGENTS,
+			noMigration,
+		);
+		expect(fromLegacy["claude-code-acp"].id).toBe("claude-code-acp");
+	});
+
+	it("prefers the new presetAgents record over legacy sub-objects, and falls back to registry defaults when both are absent", () => {
+		const both = normalizePresetAgents(
+			{
+				presetAgents: { "claude-code-acp": { command: "/new/path" } },
+				claude: { command: "/old/path" },
+			},
+			PRESET_AGENTS,
+			noMigration,
+		);
+		expect(both["claude-code-acp"].command).toBe("/new/path");
+
+		const neither = normalizePresetAgents({}, PRESET_AGENTS, noMigration);
+		for (const def of PRESET_AGENTS) {
+			expect(neither[def.presetId]).toEqual(
+				defaultPresetAgentSettings(def),
+			);
+		}
+	});
+
+	it("preserves unknown presetIds (version skew) across a save round-trip, including fields this version doesn't know", () => {
+		const raw = {
+			presetAgents: {
+				opencode: {
+					id: "opencode",
+					displayName: "OpenCode",
+					apiKeySecretId: "",
+					command: "opencode",
+					args: ["acp"],
+					env: [],
+					enabled: false,
+				},
+			},
+		};
+		const first = normalizePresetAgents(raw, PRESET_AGENTS, noMigration);
+		expect(first.opencode).toMatchObject({
+			id: "opencode",
+			displayName: "OpenCode",
+			command: "opencode",
+			args: ["acp"],
+			enabled: false,
+		});
+
+		// Round-trip: what got saved is normalized again on next load.
+		const second = normalizePresetAgents(
+			{ presetAgents: first },
+			PRESET_AGENTS,
+			noMigration,
+		);
+		expect(second.opencode).toEqual(first.opencode);
+	});
+
+	it("routes legacy plaintext apiKeys through the injected migrator with registry wiring", () => {
+		const migrate = vi.fn<ApiKeyMigrator>(({ def, legacyPlain }) =>
+			legacyPlain ? `migrated-${def.presetId}` : "",
+		);
+		const result = normalizePresetAgents(
+			{
+				claude: { apiKey: "sk-plain-key" },
+			},
+			PRESET_AGENTS,
+			migrate,
+		);
+
+		// Called once per preset with legacy wiring (all four originals).
+		expect(migrate).toHaveBeenCalledTimes(4);
+		const claudeCall = migrate.mock.calls.find(
+			([args]) => args.def.presetId === "claude-code-acp",
+		);
+		expect(claudeCall).toBeDefined();
+		expect(claudeCall?.[0]).toMatchObject({
+			current: "",
+			legacyPlain: "sk-plain-key",
+		});
+		// The registry carries the historic Notice label ("Claude", not
+		// "Claude Code") so the migrator reproduces the exact user-facing text.
+		expect(claudeCall?.[0].def.apiKey?.legacy?.noticeLabel).toBe("Claude");
+		expect(result["claude-code-acp"].apiKeySecretId).toBe(
+			"migrated-claude-code-acp",
+		);
+		expect(result["codex-acp"].apiKeySecretId).toBe("");
+	});
+});
+
+describe("ensureUniqueCustomAgentIds with reserved ids", () => {
+	const custom = (id: string): CustomAgentSettings => ({
+		id,
+		displayName: id,
+		command: "cmd",
+		args: [],
+		env: [],
+	});
+
+	it("suffix-renames a custom agent colliding with a preset id", () => {
+		const result = ensureUniqueCustomAgentIds(
+			[custom("claude-code-acp"), custom("my-agent")],
+			PRESET_IDS,
+		);
+		expect(result.map((a) => a.id)).toEqual([
+			"claude-code-acp-2",
+			"my-agent",
+		]);
+	});
+
+	it("keeps repairing duplicates among customs themselves", () => {
+		const result = ensureUniqueCustomAgentIds(
+			[custom("dup"), custom("dup")],
+			PRESET_IDS,
+		);
+		expect(result.map((a) => a.id)).toEqual(["dup", "dup-2"]);
+	});
+});
+
+describe("resolveDefaultAgentId", () => {
+	const available = ["claude-code-acp", "codex-acp", "my-custom"];
+
+	it("keeps a stored defaultAgentId that is available", () => {
+		expect(
+			resolveDefaultAgentId({ defaultAgentId: "my-custom" }, available),
+		).toBe("my-custom");
+	});
+
+	it("migrates the old activeAgentId name", () => {
+		expect(
+			resolveDefaultAgentId({ activeAgentId: "codex-acp" }, available),
+		).toBe("codex-acp");
+	});
+
+	it("prefers defaultAgentId over activeAgentId", () => {
+		expect(
+			resolveDefaultAgentId(
+				{ defaultAgentId: "codex-acp", activeAgentId: "my-custom" },
+				available,
+			),
+		).toBe("codex-acp");
+	});
+
+	it("falls back to the first available id when unset or unknown", () => {
+		expect(resolveDefaultAgentId({}, available)).toBe("claude-code-acp");
+		expect(
+			resolveDefaultAgentId({ defaultAgentId: "ghost" }, available),
+		).toBe("claude-code-acp");
+	});
+});


### PR DESCRIPTION
## Description

Adding Mistral Vibe (#347) required hand-written symmetry across 18 files. This PR replaces the four per-agent settings fields (`claude` / `codex` / `gemini` / `mistralVibe`) with a `presetAgents` record driven by a static registry (`services/preset-agents.ts`), so adding a preset becomes one registry entry plus docs. It is the storage/plumbing foundation for the upcoming enable/disable toggle (#340), collapsible agent sections, and the OpenCode / Kiro presets.

**Behavior-invariant refactor** — no user-visible change. Every settings-screen string, migration rule, and resolution order is reproduced verbatim (one dead-branch exception and one deliberate review-follow-up fix, both below).

- **Registry** (`services/preset-agents.ts`, new): per-preset identity, spawn defaults, legacy data.json migration keys, API-key wiring (incl. historic migration-notice labels), install hints (incl. the native-Windows variant), and settings-screen copy
- **Types**: the four identical `*AgentSettings` interfaces collapse into `PresetAgentUserSettings`
- **Normalization**: `normalizePresetAgents` is a pure function; secret-storage side effects are injected via `ApiKeyMigrator`. Unknown `presetAgents` keys written by a newer plugin version survive save round-trips (Sync / BRAT rollback protection)
- **Single enumeration point**: `plugin.getAvailableAgents` delegates to `getAvailableAgentsFromSettings`; `findAgentSettings` gates preset lookups on registry membership so preserved unknown entries can't shadow a same-id custom agent
- **Settings UI**: one registry-driven renderer replaces the four hand-written sections; custom agent ids are validated against reserved preset ids on blur
- **ChatPanel**: subscribes to the single `presetAgents` field; the header dropdown no longer rebuilds on every session save
- **AGENTS.md**: "Add Agent Type" is now "add one registry entry + docs (named-file list)"

**Migration**: on load, new record → legacy per-agent sub-object → registry defaults; entry ids force-synced to the record key; `claudeCodeAcpCommandPath` / `geminiCommandPath` honored; empty Gemini args backfill to `--experimental-acp`; customs colliding with a preset id (dead weight under preset-first resolution) get a `-2` suffix. The rewrite is lazy (first save), same as previous migrations.

⚠️ **Downgrade note**: versions before this one don't read `presetAgents`, so preset agent settings reset to defaults after a downgrade. Custom agents, sessions, and API keys (secret storage) are unaffected.

Known micro-difference: the settings heading fallback for an explicitly-empty Claude display name changes from "Claude Code (ACP)" to "Claude Code" (dead branch; other presets already matched).

Deliberate behavior fix (review follow-up): when no API key secret is configured, the `apiKey` wiring is now skipped and empty secret values are no longer exported into the agent process env — previously `ANTHROPIC_API_KEY=""` etc. was set even for account-based logins.

## Related issue

Groundwork for #340 (enable/disable lands in the follow-up PR).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" warnings are brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian — old-format data.json migrated in place on a real vault (presets preserved, legacy keys dropped, colliding custom renamed, `defaultAgentId` kept); settings screen copy identical for all four agents
- [x] Existing functionality still works (146 unit tests; 25 new migration + characterization tests with literal expected values, mutation-verified)
- [x] Documentation updated if needed (AGENTS.md contributor guide)

## Testing environment

- Agent: all four presets (settings UI + migration); spawn paths unchanged by this PR
- OS: macOS

## Screenshots

N/A (no visual changes; settings screen copy is identical by design)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preset-based agent setup, making built-in agent options easier to manage and customize.
  * Improved agent selection by showing clearer preset names and keeping custom agents available alongside them.

* **Bug Fixes**
  * Fixed default agent handling when saved selections are missing or no longer available.
  * Prevented blank API key values from being applied when a secret is absent.
  * Resolved name and ID conflicts between built-in and custom agents more reliably.

* **Documentation**
  * Updated the developer guide to reflect the new preset-agent workflow and setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->