### PR TITLE
feat: add per-agent enable/disable toggles

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -69,6 +69,12 @@ Use the **Broadcast** commands:
 
 By default, new views open in the right pane. You can change this in **Settings → Agent Client → Display → Chat view location** to open in editor tabs or splits instead.
 
+### How do I hide agents I don't use?
+
+Every agent section in **Settings → Agent Client** has an **Enabled** toggle. Turning it off removes the agent from the switch menus, the default-agent dropdown, and the command palette — its settings are kept, so you can re-enable it anytime. At least one agent must stay enabled.
+
+Disabling only hides the agent from lists: already-open chats, restored sessions, and code blocks that pin the agent with `agent:` keep working.
+
 ### What is a custom agent?
 
 Any ACP-compatible agent beyond the built-in ones (Claude Code, Codex, Gemini CLI, Mistral Vibe). You can add custom agents in **Settings → Agent Client → Custom agents**. See [Custom Agents](/agent-setup/custom-agents).

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -88,6 +88,10 @@ The agent connected but couldn't create a session.
 2. Check if your vault path contains special characters that might cause issues
 3. Reload the plugin
 
+### An agent is missing from the agent lists
+
+If an agent doesn't appear in the switch menu, the default-agent dropdown, or the command palette, its **Enabled** toggle is probably off. Go to **Settings → Agent Client**, find the agent's section, and turn **Enabled** back on.
+
 ### "Agent Not Found" error
 
 The selected agent ID doesn't exist in settings.

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -51,6 +51,7 @@ import {
 import { PRESET_AGENTS } from "./services/preset-agents";
 import {
 	getAvailableAgentsFromSettings,
+	getAllAgentsFromSettings,
 	findAgentSettings,
 	isAgentEnabled,
 	firstEnabledAgentId,
@@ -1139,19 +1140,7 @@ export default class AgentClientPlugin extends Plugin {
 	 * limitation), but their enabled state is also checked live.
 	 */
 	private registerAgentCommands(): void {
-		const presetAgents = PRESET_AGENTS.map((def) => {
-			const preset = this.settings.presetAgents[def.presetId];
-			return {
-				id: def.presetId,
-				displayName: preset?.displayName || def.presetId,
-			};
-		});
-		const customAgents = this.settings.customAgents.map((agent) => ({
-			id: agent.id,
-			displayName: agent.displayName || agent.id,
-		}));
-
-		for (const agent of [...presetAgents, ...customAgents]) {
+		for (const agent of getAllAgentsFromSettings(this.settings)) {
 			this.addCommand({
 				id: `switch-agent-to-${agent.id}`,
 				name: `Switch agent to ${agent.displayName}`,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -864,17 +864,32 @@ export default class AgentClientPlugin extends Plugin {
 		}
 
 		// Collect non-fatal warnings: parser warnings plus a mount-side check
-		// for an unknown agent id (#28). Copy the parser array rather than
+		// on the pinned agent id (#28). Copy the parser array rather than
 		// mutating it, since parse results may be shared once cached.
+		// Warnings match actual behavior, which differs by block type: a chat
+		// block spawns the pinned agent as-is (unknown → startup error), a
+		// button block falls back to the default agent when the id is unknown.
+		// Both use a pinned agent even while it is disabled. Computed at
+		// render time — a later toggle doesn't update an already-rendered
+		// block (known limitation).
 		const warnings = parsed.warnings ? [...parsed.warnings] : [];
 		const requestedAgent = parsed.config.agent;
-		if (
-			requestedAgent &&
-			!this.getAvailableAgents().some((a) => a.id === requestedAgent)
-		) {
-			warnings.push(
-				`Unknown agent "${requestedAgent}", using the default agent instead.`,
+		if (requestedAgent) {
+			const agentSettings = findAgentSettings(
+				this.settings,
+				requestedAgent,
 			);
+			if (!agentSettings) {
+				warnings.push(
+					parsed.config.type === "chat"
+						? `Unknown agent "${requestedAgent}" — this block will fail to start. Check the agent id in Settings → Agent Client.`
+						: `Unknown agent "${requestedAgent}", using the default agent instead.`,
+				);
+			} else if (!isAgentEnabled(agentSettings)) {
+				warnings.push(
+					`Agent "${requestedAgent}" is disabled in settings; this block pins it and will still use it.`,
+				);
+			}
 		}
 
 		if (warnings.length > 0) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1115,16 +1115,35 @@ export default class AgentClientPlugin extends Plugin {
 	}
 
 	/**
-	 * Register commands for each configured agent
+	 * Register commands for each configured agent.
+	 *
+	 * All presets register unconditionally; a checkCallback hides the command
+	 * while its agent is disabled, so the palette follows the Enabled toggles
+	 * without re-registration. Custom agents remain a load-time snapshot
+	 * (a newly added custom gets its command after a reload — existing
+	 * limitation), but their enabled state is also checked live.
 	 */
 	private registerAgentCommands(): void {
-		const agents = this.getAvailableAgents();
+		const presetAgents = PRESET_AGENTS.map((def) => {
+			const preset = this.settings.presetAgents[def.presetId];
+			return {
+				id: def.presetId,
+				displayName: preset?.displayName || def.presetId,
+			};
+		});
+		const customAgents = this.settings.customAgents.map((agent) => ({
+			id: agent.id,
+			displayName: agent.displayName || agent.id,
+		}));
 
-		for (const agent of agents) {
+		for (const agent of [...presetAgents, ...customAgents]) {
 			this.addCommand({
 				id: `switch-agent-to-${agent.id}`,
 				name: `Switch agent to ${agent.displayName}`,
-				callback: () => {
+				checkCallback: (checking) => {
+					const found = findAgentSettings(this.settings, agent.id);
+					if (!found || !isAgentEnabled(found)) return false;
+					if (checking) return true;
 					this.app.workspace.trigger(
 						"agent-client:new-chat-requested",
 						this.lastActiveChatViewId,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -49,7 +49,13 @@ import {
 	xyPoint,
 } from "./services/settings-normalizer";
 import { PRESET_AGENTS } from "./services/preset-agents";
-import { getAvailableAgentsFromSettings } from "./services/session-helpers";
+import {
+	getAvailableAgentsFromSettings,
+	findAgentSettings,
+	isAgentEnabled,
+	firstEnabledAgentId,
+	repairNoEnabledAgents,
+} from "./services/session-helpers";
 import {
 	AgentEnvVar,
 	PresetAgentUserSettings,
@@ -1483,6 +1489,7 @@ export default class AgentClientPlugin extends Plugin {
 			floatingButtonPosition: xyPoint(raw.floatingButtonPosition),
 		};
 
+		this.ensureAtLeastOneEnabled();
 		this.ensureDefaultAgentId();
 
 		if (migratedSecrets) {
@@ -1648,12 +1655,20 @@ export default class AgentClientPlugin extends Plugin {
 
 	ensureDefaultAgentId(): void {
 		const availableIds = this.collectAvailableAgentIds();
-		if (availableIds.length === 0) {
-			this.settings.defaultAgentId = PRESET_AGENTS[0].presetId;
-			return;
-		}
 		if (!availableIds.includes(this.settings.defaultAgentId)) {
-			this.settings.defaultAgentId = availableIds[0];
+			this.settings.defaultAgentId = firstEnabledAgentId(this.settings);
+		}
+	}
+
+	/**
+	 * Repair the "everything disabled" state by re-enabling the first preset.
+	 * The settings UI refuses to disable the last enabled agent, so this is a
+	 * backstop for load-time data and indirect paths (custom deletion).
+	 */
+	ensureAtLeastOneEnabled(): void {
+		const repaired = repairNoEnabledAgents(this.settings);
+		if (repaired) {
+			this.settings.presetAgents = repaired;
 		}
 	}
 

--- a/src/services/session-helpers.ts
+++ b/src/services/session-helpers.ts
@@ -35,31 +35,97 @@ export interface AgentDisplayInfo {
 // ============================================================================
 
 /**
- * Get the default agent ID from settings (for new views).
+ * Whether an agent participates in enumeration (lists, menus, commands).
+ * `undefined` means enabled — data stored before the toggle existed.
  */
-export function getDefaultAgentId(settings: AgentClientPluginSettings): string {
-	return settings.defaultAgentId || PRESET_AGENTS[0].presetId;
+export function isAgentEnabled(
+	agent: Pick<BaseAgentSettings, "enabled">,
+): boolean {
+	return agent.enabled !== false;
 }
 
 /**
- * Get list of all available agents from settings.
+ * First enabled agent, registry-ordered presets before customs. Backstops to
+ * the first preset when nothing is enabled (repairNoEnabledAgents prevents
+ * that state from persisting).
+ */
+export function firstEnabledAgentId(
+	settings: AgentClientPluginSettings,
+): string {
+	for (const def of PRESET_AGENTS) {
+		const preset = settings.presetAgents[def.presetId];
+		if (!preset || isAgentEnabled(preset)) {
+			return def.presetId;
+		}
+	}
+	const custom = settings.customAgents.find(isAgentEnabled);
+	return custom ? custom.id : PRESET_AGENTS[0].presetId;
+}
+
+/**
+ * Repair for the "everything disabled" state: returns a presetAgents record
+ * with the first preset re-enabled, or null when no repair is needed.
+ * Callers write the repaired record back (plugin.ensureAtLeastOneEnabled).
+ */
+export function repairNoEnabledAgents(
+	settings: AgentClientPluginSettings,
+): Record<string, PresetAgentUserSettings> | null {
+	if (getAvailableAgentsFromSettings(settings).length > 0) {
+		return null;
+	}
+	const firstId = PRESET_AGENTS[0].presetId;
+	const first = settings.presetAgents[firstId];
+	if (!first) {
+		return null;
+	}
+	return {
+		...settings.presetAgents,
+		[firstId]: { ...first, enabled: true },
+	};
+}
+
+/**
+ * Get the default agent ID from settings (for new views). Falls back to the
+ * first enabled agent when the stored default is unknown or disabled —
+ * second line of defense behind plugin.ensureDefaultAgentId, so a stale
+ * default can't keep spawning a disabled agent.
+ */
+export function getDefaultAgentId(settings: AgentClientPluginSettings): string {
+	const stored = settings.defaultAgentId;
+	if (stored) {
+		const agent = findAgentSettings(settings, stored);
+		if (agent && isAgentEnabled(agent)) {
+			return stored;
+		}
+	}
+	return firstEnabledAgentId(settings);
+}
+
+/**
+ * Get list of all available (= enabled) agents from settings.
  *
  * The single enumeration implementation (plugin.getAvailableAgents delegates
- * here): registry-ordered presets first, then custom agents. Unknown
- * presetAgents entries (version skew) are deliberately not enumerated.
+ * here): registry-ordered presets first, then custom agents. Disabled agents
+ * and unknown presetAgents entries (version skew) are not enumerated;
+ * resolution (findAgentSettings) stays unfiltered.
  */
 export function getAvailableAgentsFromSettings(
 	settings: AgentClientPluginSettings,
 ): AgentDisplayInfo[] {
 	return [
-		...PRESET_AGENTS.map((def) => {
+		...PRESET_AGENTS.flatMap((def) => {
 			const preset = settings.presetAgents[def.presetId];
-			return {
-				id: def.presetId,
-				displayName: preset?.displayName || def.presetId,
-			};
+			if (preset && !isAgentEnabled(preset)) {
+				return [];
+			}
+			return [
+				{
+					id: def.presetId,
+					displayName: preset?.displayName || def.presetId,
+				},
+			];
 		}),
-		...settings.customAgents.map((agent) => ({
+		...settings.customAgents.filter(isAgentEnabled).map((agent) => ({
 			id: agent.id,
 			displayName: agent.displayName || agent.id,
 		})),
@@ -68,19 +134,20 @@ export function getAvailableAgentsFromSettings(
 
 /**
  * Get the currently active agent information from settings.
+ *
+ * Resolves by unfiltered lookup, not enumeration: a session on a disabled
+ * agent must keep its display name (view titles, export frontmatter) instead
+ * of degrading to the raw id.
  */
 export function getCurrentAgent(
 	settings: AgentClientPluginSettings,
 	agentId?: string,
 ): AgentDisplayInfo {
 	const activeId = agentId || getDefaultAgentId(settings);
-	const agents = getAvailableAgentsFromSettings(settings);
-	return (
-		agents.find((agent) => agent.id === activeId) || {
-			id: activeId,
-			displayName: activeId,
-		}
-	);
+	const found = findAgentSettings(settings, activeId);
+	return found
+		? { id: activeId, displayName: found.displayName || found.id }
+		: { id: activeId, displayName: activeId };
 }
 
 // ============================================================================

--- a/src/services/session-helpers.ts
+++ b/src/services/session-helpers.ts
@@ -102,34 +102,57 @@ export function getDefaultAgentId(settings: AgentClientPluginSettings): string {
 }
 
 /**
- * Get list of all available (= enabled) agents from settings.
- *
- * The single enumeration implementation (plugin.getAvailableAgents delegates
- * here): registry-ordered presets first, then custom agents. Disabled agents
- * and unknown presetAgents entries (version skew) are not enumerated;
- * resolution (findAgentSettings) stays unfiltered.
+ * The single enumeration implementation: ordering (registry-ordered presets,
+ * then customs) and display-name resolution are defined here and nowhere
+ * else. `enabled` is decided alongside each entry — including the "missing
+ * presetAgents record entry counts as enabled" rule — so the public views
+ * below never re-resolve ids. Unknown presetAgents entries (version skew)
+ * are not enumerated.
+ */
+function enumerateAgents(
+	settings: AgentClientPluginSettings,
+): Array<AgentDisplayInfo & { enabled: boolean }> {
+	return [
+		...PRESET_AGENTS.map((def) => {
+			const preset = settings.presetAgents[def.presetId];
+			return {
+				id: def.presetId,
+				displayName: preset?.displayName || def.presetId,
+				enabled: !preset || isAgentEnabled(preset),
+			};
+		}),
+		...settings.customAgents.map((agent) => ({
+			id: agent.id,
+			displayName: agent.displayName || agent.id,
+			enabled: isAgentEnabled(agent),
+		})),
+	];
+}
+
+/**
+ * All agents regardless of enabled state — for surfaces that register
+ * everything and gate visibility live (command palette checkCallback).
+ */
+export function getAllAgentsFromSettings(
+	settings: AgentClientPluginSettings,
+): AgentDisplayInfo[] {
+	return enumerateAgents(settings).map(({ id, displayName }) => ({
+		id,
+		displayName,
+	}));
+}
+
+/**
+ * Enabled agents only (plugin.getAvailableAgents delegates here) — the
+ * enumeration every list, menu, and dropdown consumes. Resolution
+ * (findAgentSettings) stays unfiltered.
  */
 export function getAvailableAgentsFromSettings(
 	settings: AgentClientPluginSettings,
 ): AgentDisplayInfo[] {
-	return [
-		...PRESET_AGENTS.flatMap((def) => {
-			const preset = settings.presetAgents[def.presetId];
-			if (preset && !isAgentEnabled(preset)) {
-				return [];
-			}
-			return [
-				{
-					id: def.presetId,
-					displayName: preset?.displayName || def.presetId,
-				},
-			];
-		}),
-		...settings.customAgents.filter(isAgentEnabled).map((agent) => ({
-			id: agent.id,
-			displayName: agent.displayName || agent.id,
-		})),
-	];
+	return enumerateAgents(settings)
+		.filter((agent) => agent.enabled)
+		.map(({ id, displayName }) => ({ id, displayName }));
 }
 
 /**

--- a/src/services/settings-normalizer.ts
+++ b/src/services/settings-normalizer.ts
@@ -143,6 +143,7 @@ export const normalizeCustomAgent = (
 				: "",
 		args: sanitizeArgs(agent?.args),
 		env: normalizeEnvVars(agent?.env),
+		enabled: bool(agent?.enabled, true),
 	};
 };
 
@@ -215,6 +216,7 @@ export const defaultPresetAgentSettings = (
 	command: def.defaultCommand,
 	args: [...def.defaultArgs],
 	env: [],
+	enabled: true,
 });
 
 /**
@@ -275,6 +277,7 @@ export const normalizePresetAgents = (
 				str(entry.command, "") || legacyCommand || def.defaultCommand,
 			args: args.length > 0 ? args : [...def.defaultArgs],
 			env: normalizeEnvVars(entry.env),
+			enabled: bool(entry.enabled, true),
 		};
 	}
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -51,6 +51,14 @@ export interface BaseAgentSettings {
 
 	/** Environment variables for the agent process */
 	env: AgentEnvVar[];
+
+	/**
+	 * Whether the agent appears in agent lists and menus (enumeration).
+	 * `undefined` means enabled (backward compatibility with stored data).
+	 * Disabling never blocks resolution: pinned blocks, restored sessions,
+	 * and already-open chats keep working. Check via `isAgentEnabled()`.
+	 */
+	enabled?: boolean;
 }
 
 /**

--- a/src/ui/AgentButtonBlock.tsx
+++ b/src/ui/AgentButtonBlock.tsx
@@ -5,6 +5,7 @@ import { Notice } from "obsidian";
 
 import type AgentClientPlugin from "../plugin";
 import type { AgentButtonBlockConfig } from "../utils/agent-block-parser";
+import { findAgentSettings } from "../services/session-helpers";
 
 interface AgentButtonBlockProps {
 	plugin: AgentClientPlugin;
@@ -21,8 +22,12 @@ function resolveAgentId(
 	plugin: AgentClientPlugin,
 	preferred: string | undefined,
 ): string {
-	const available = plugin.getAvailableAgents().map((a) => a.id);
-	if (preferred && available.includes(preferred)) return preferred;
+	// Resolution, not enumeration: an explicit `agent:` pin is honored even
+	// while the agent is disabled (same semantics as pinned chat blocks).
+	// Only an unknown id falls back to the default agent.
+	if (preferred && findAgentSettings(plugin.settings, preferred)) {
+		return preferred;
+	}
 	return plugin.settings.defaultAgentId;
 }
 

--- a/src/ui/ChatHeader.tsx
+++ b/src/ui/ChatHeader.tsx
@@ -1,8 +1,39 @@
 import * as React from "react";
-const { useRef, useEffect } = React;
+const { useRef, useEffect, useMemo } = React;
 import { setIcon, DropdownComponent } from "obsidian";
 import { HeaderButton } from "./shared/IconButton";
 import type { AgentDisplayInfo } from "../services/session-helpers";
+
+/** Stable empty list for the pinned-agent case (no switchable agents). */
+const EMPTY_AGENTS: AgentDisplayInfo[] = [];
+
+/**
+ * Selector options = enabled agents, plus the active agent appended as an
+ * explicit "(disabled)" option when it is not in the enabled enumeration
+ * (kept session or pinned block on a disabled agent). Without it the
+ * dropdown's setValue silently no-ops and the selector renders blank.
+ * Returns `availableAgents` by reference when no append is needed, so the
+ * dropdown-rebuild effect doesn't re-run on ordinary agent switches.
+ */
+function useSelectorAgents(
+	availableAgents: AgentDisplayInfo[] | undefined,
+	currentAgentId: string | undefined,
+	agentLabel: string,
+): AgentDisplayInfo[] {
+	return useMemo(() => {
+		if (!availableAgents) return EMPTY_AGENTS;
+		if (
+			!currentAgentId ||
+			availableAgents.some((agent) => agent.id === currentAgentId)
+		) {
+			return availableAgents;
+		}
+		return [
+			...availableAgents,
+			{ id: currentAgentId, displayName: `${agentLabel} (disabled)` },
+		];
+	}, [availableAgents, currentAgentId, agentLabel]);
+}
 
 // ============================================================================
 // Props Types
@@ -204,13 +235,19 @@ function FloatingHeader({
 	const onAgentChangeRef = useRef(onAgentChange);
 	onAgentChangeRef.current = onAgentChange;
 
+	const selectorAgents = useSelectorAgents(
+		availableAgents,
+		currentAgentId,
+		agentLabel,
+	);
+
 	// Initialize agent dropdown
 	useEffect(() => {
 		const containerEl = agentDropdownRef.current;
 		if (!containerEl) return;
 
 		// Only show dropdown if there are multiple agents
-		if (availableAgents.length <= 1) {
+		if (selectorAgents.length <= 1) {
 			if (agentDropdownInstance.current) {
 				containerEl.empty();
 				agentDropdownInstance.current = null;
@@ -224,7 +261,7 @@ function FloatingHeader({
 			agentDropdownInstance.current = dropdown;
 
 			// Add options
-			for (const agent of availableAgents) {
+			for (const agent of selectorAgents) {
 				dropdown.addOption(agent.id, agent.displayName);
 			}
 
@@ -239,14 +276,14 @@ function FloatingHeader({
 			});
 		}
 
-		// Cleanup on unmount or when availableAgents change
+		// Cleanup on unmount or when the selector options change
 		return () => {
 			if (agentDropdownInstance.current) {
 				containerEl.empty();
 				agentDropdownInstance.current = null;
 			}
 		};
-	}, [availableAgents]);
+	}, [selectorAgents]);
 
 	// Update dropdown value when currentAgentId changes
 	useEffect(() => {
@@ -260,7 +297,7 @@ function FloatingHeader({
 			className={`agent-client-inline-header agent-client-inline-header-floating`}
 		>
 			<div className="agent-client-inline-header-main">
-				{availableAgents.length > 1 ? (
+				{selectorAgents.length > 1 ? (
 					<div className="agent-client-agent-selector">
 						<div ref={agentDropdownRef} />
 						<span
@@ -334,12 +371,18 @@ function EmbeddedHeader({
 	const onAgentChangeRef = useRef(onAgentChange);
 	onAgentChangeRef.current = onAgentChange;
 
+	const selectorAgents = useSelectorAgents(
+		availableAgents,
+		currentAgentId,
+		agentLabel,
+	);
+
 	// Initialize agent dropdown (only when multiple switchable agents exist)
 	useEffect(() => {
 		const containerEl = agentDropdownRef.current;
 		if (!containerEl) return;
 
-		if (!availableAgents || availableAgents.length <= 1) {
+		if (selectorAgents.length <= 1) {
 			if (agentDropdownInstance.current) {
 				containerEl.empty();
 				agentDropdownInstance.current = null;
@@ -351,7 +394,7 @@ function EmbeddedHeader({
 			const dropdown = new DropdownComponent(containerEl);
 			agentDropdownInstance.current = dropdown;
 
-			for (const agent of availableAgents) {
+			for (const agent of selectorAgents) {
 				dropdown.addOption(agent.id, agent.displayName);
 			}
 
@@ -370,7 +413,7 @@ function EmbeddedHeader({
 				agentDropdownInstance.current = null;
 			}
 		};
-	}, [availableAgents]);
+	}, [selectorAgents]);
 
 	// Keep dropdown value in sync with currentAgentId
 	useEffect(() => {
@@ -379,7 +422,7 @@ function EmbeddedHeader({
 		}
 	}, [currentAgentId]);
 
-	const hasSelector = !!availableAgents && availableAgents.length > 1;
+	const hasSelector = selectorAgents.length > 1;
 
 	return (
 		<div className="agent-client-inline-header agent-client-inline-header-embedded">

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -18,6 +18,10 @@ import {
 	PRESET_AGENTS,
 	type PresetAgentDefinition,
 } from "../services/preset-agents";
+import {
+	getAvailableAgentsFromSettings,
+	isAgentEnabled,
+} from "../services/session-helpers";
 import { resolveCommandPath, resolveCommandPathInWsl } from "../utils/paths";
 import {
 	normalizeEnvVars,
@@ -912,28 +916,14 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	}
 
 	private getAgentOptions(): { id: string; label: string }[] {
-		const toOption = (id: string, displayName: string) => ({
+		// Default-agent candidates come from the enabled enumeration —
+		// disabled agents can't be picked as the default.
+		const options = getAvailableAgentsFromSettings(
+			this.plugin.settings,
+		).map(({ id, displayName }) => ({
 			id,
 			label: `${displayName} (${id})`,
-		});
-		const options: { id: string; label: string }[] = PRESET_AGENTS.map(
-			(def) => {
-				const preset = this.plugin.settings.presetAgents[def.presetId];
-				return toOption(
-					def.presetId,
-					preset?.displayName || def.presetId,
-				);
-			},
-		);
-		for (const agent of this.plugin.settings.customAgents) {
-			if (agent.id && agent.id.length > 0) {
-				const labelSource =
-					agent.displayName && agent.displayName.length > 0
-						? agent.displayName
-						: agent.id;
-				options.push(toOption(agent.id, labelSource));
-			}
-		}
+		}));
 		const seen = new Set<string>();
 		return options.filter(({ id }) => {
 			if (seen.has(id)) {
@@ -942,6 +932,54 @@ export class AgentClientSettingTab extends PluginSettingTab {
 			seen.add(id);
 			return true;
 		});
+	}
+
+	/** True when `agentId` is the only agent still enabled. */
+	private isLastEnabledAgent(agentId: string): boolean {
+		const enabled = getAvailableAgentsFromSettings(this.plugin.settings);
+		return enabled.length === 1 && enabled[0].id === agentId;
+	}
+
+	/**
+	 * Shared "Enabled" toggle row for preset and custom agent sections.
+	 * Refuses to disable the last enabled agent (Notice + revert). After the
+	 * write, re-validates the default agent and refreshes the default-agent
+	 * dropdown in place — no refreshDisplay(), so the tab keeps its scroll
+	 * and focus state.
+	 */
+	private addEnabledToggle(
+		sectionEl: HTMLElement,
+		// Resolved at interaction time: a custom agent's id can be renamed
+		// after this row rendered (the id editor commits per keystroke).
+		getAgentId: () => string | undefined,
+		currentValue: boolean,
+		writer: { write: (value: boolean) => Promise<void> | void },
+	): void {
+		new Setting(sectionEl)
+			.setName("Enabled")
+			.setDesc(
+				"Show this agent in agent lists, menus, and commands. Pinned blocks and restored sessions keep working while disabled.",
+			)
+			.addToggle((toggle) => {
+				toggle.setValue(currentValue).onChange(async (value) => {
+					const agentId = getAgentId();
+					if (agentId === undefined) {
+						return;
+					}
+					if (!value && this.isLastEnabledAgent(agentId)) {
+						toggle.setValue(true);
+						new Notice(
+							"[Agent Client] At least one agent must stay enabled.",
+						);
+						return;
+					}
+					await writer.write(value);
+					this.plugin.ensureAtLeastOneEnabled();
+					this.plugin.ensureDefaultAgentId();
+					await this.flushSettings();
+					this.refreshAgentDropdown();
+				});
+			});
 	}
 
 	/**
@@ -984,6 +1022,16 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		new Setting(sectionEl)
 			.setName(preset.displayName || def.defaultDisplayName)
 			.setHeading();
+
+		this.addEnabledToggle(
+			sectionEl,
+			() => def.presetId,
+			isAgentEnabled(preset),
+			{
+				write: (value) =>
+					this.updatePresetAgent(def.presetId, { enabled: value }),
+			},
+		);
 
 		if (def.apiKey) {
 			new Setting(sectionEl)
@@ -1115,6 +1163,17 @@ export class AgentClientSettingTab extends PluginSettingTab {
 			cls: "agent-client-custom-agent",
 		});
 
+		this.addEnabledToggle(
+			blockEl,
+			() => this.plugin.settings.customAgents[index]?.id,
+			isAgentEnabled(agent),
+			{
+				write: (value) => {
+					this.plugin.settings.customAgents[index].enabled = value;
+				},
+			},
+		);
+
 		const idSetting = new Setting(blockEl)
 			.setName("Agent ID")
 			.setDesc("Unique identifier used to reference this agent.")
@@ -1200,6 +1259,9 @@ export class AgentClientSettingTab extends PluginSettingTab {
 				.setTooltip("Delete this agent")
 				.onClick(async () => {
 					this.plugin.settings.customAgents.splice(index, 1);
+					// Deleting the last enabled agent must not leave
+					// everything disabled.
+					this.plugin.ensureAtLeastOneEnabled();
 					this.plugin.ensureDefaultAgentId();
 					await this.flushSettings();
 					this.refreshDisplay();

--- a/test/session-helpers.test.ts
+++ b/test/session-helpers.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
 	getDefaultAgentId,
 	getAvailableAgentsFromSettings,
+	getCurrentAgent,
 	findAgentSettings,
 	buildAgentConfigWithApiKey,
+	isAgentEnabled,
+	firstEnabledAgentId,
+	repairNoEnabledAgents,
 } from "../src/services/session-helpers";
 import type { AgentClientPluginSettings } from "../src/plugin";
 import type {
@@ -83,6 +87,65 @@ describe("getAvailableAgentsFromSettings", () => {
 			displayName: "codex-acp",
 		});
 	});
+
+	it("excludes disabled presets and customs; undefined means enabled", () => {
+		const settings = makeSettings({
+			customAgents: [
+				custom("my-custom", "My Custom"),
+				{ ...custom("off-custom", "Off Custom"), enabled: false },
+			],
+		});
+		settings.presetAgents["codex-acp"].enabled = false;
+		settings.presetAgents["claude-code-acp"].enabled = true;
+		expect(
+			getAvailableAgentsFromSettings(settings).map((a) => a.id),
+		).toEqual([
+			"claude-code-acp",
+			"gemini-cli",
+			"mistral-vibe",
+			"my-custom",
+		]);
+	});
+});
+
+describe("enabled helpers", () => {
+	it("isAgentEnabled treats only explicit false as disabled", () => {
+		expect(isAgentEnabled({})).toBe(true);
+		expect(isAgentEnabled({ enabled: true })).toBe(true);
+		expect(isAgentEnabled({ enabled: false })).toBe(false);
+	});
+
+	it("firstEnabledAgentId walks presets in registry order, then customs", () => {
+		const settings = makeSettings({
+			customAgents: [custom("my-custom", "My Custom")],
+		});
+		expect(firstEnabledAgentId(settings)).toBe("claude-code-acp");
+
+		settings.presetAgents["claude-code-acp"].enabled = false;
+		expect(firstEnabledAgentId(settings)).toBe("codex-acp");
+
+		for (const entry of Object.values(settings.presetAgents)) {
+			entry.enabled = false;
+		}
+		expect(firstEnabledAgentId(settings)).toBe("my-custom");
+
+		settings.customAgents[0].enabled = false;
+		// Backstop when everything is disabled (repair prevents persisting).
+		expect(firstEnabledAgentId(settings)).toBe("claude-code-acp");
+	});
+
+	it("repairNoEnabledAgents re-enables the first preset only when everything is disabled", () => {
+		const healthy = makeSettings();
+		expect(repairNoEnabledAgents(healthy)).toBeNull();
+
+		const broken = makeSettings();
+		for (const entry of Object.values(broken.presetAgents)) {
+			entry.enabled = false;
+		}
+		const repaired = repairNoEnabledAgents(broken);
+		expect(repaired?.["claude-code-acp"].enabled).toBe(true);
+		expect(repaired?.["codex-acp"].enabled).toBe(false);
+	});
 });
 
 describe("findAgentSettings", () => {
@@ -116,6 +179,32 @@ describe("findAgentSettings", () => {
 		expect(findAgentSettings(settings, "opencode")?.displayName).toBe(
 			"My OpenCode",
 		);
+	});
+
+	it("resolves disabled agents (disabling filters enumeration, not resolution)", () => {
+		const settings = makeSettings();
+		settings.presetAgents["gemini-cli"].enabled = false;
+		expect(findAgentSettings(settings, "gemini-cli")?.displayName).toBe(
+			"Gemini CLI",
+		);
+	});
+});
+
+describe("getCurrentAgent", () => {
+	it("keeps the display name of a disabled agent", () => {
+		const settings = makeSettings();
+		settings.presetAgents["gemini-cli"].enabled = false;
+		expect(getCurrentAgent(settings, "gemini-cli")).toEqual({
+			id: "gemini-cli",
+			displayName: "Gemini CLI",
+		});
+	});
+
+	it("degrades to the raw id for unknown agents", () => {
+		expect(getCurrentAgent(makeSettings(), "ghost")).toEqual({
+			id: "ghost",
+			displayName: "ghost",
+		});
 	});
 });
 
@@ -170,5 +259,11 @@ describe("getDefaultAgentId", () => {
 
 	it("falls back to the first preset when unset", () => {
 		expect(getDefaultAgentId(makeSettings())).toBe("claude-code-acp");
+	});
+
+	it("falls back to the first enabled agent when the stored default is disabled", () => {
+		const settings = makeSettings({ defaultAgentId: "claude-code-acp" });
+		settings.presetAgents["claude-code-acp"].enabled = false;
+		expect(getDefaultAgentId(settings)).toBe("codex-acp");
 	});
 });

--- a/test/session-helpers.test.ts
+++ b/test/session-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
 	getDefaultAgentId,
 	getAvailableAgentsFromSettings,
+	getAllAgentsFromSettings,
 	getCurrentAgent,
 	findAgentSettings,
 	buildAgentConfigWithApiKey,
@@ -104,6 +105,24 @@ describe("getAvailableAgentsFromSettings", () => {
 			"gemini-cli",
 			"mistral-vibe",
 			"my-custom",
+		]);
+	});
+});
+
+describe("getAllAgentsFromSettings", () => {
+	it("includes disabled agents (unfiltered contract for command registration)", () => {
+		const settings = makeSettings({
+			customAgents: [
+				{ ...custom("off-custom", "Off Custom"), enabled: false },
+			],
+		});
+		settings.presetAgents["codex-acp"].enabled = false;
+		expect(getAllAgentsFromSettings(settings)).toEqual([
+			{ id: "claude-code-acp", displayName: "Claude Code" },
+			{ id: "codex-acp", displayName: "Codex" },
+			{ id: "gemini-cli", displayName: "Gemini CLI" },
+			{ id: "mistral-vibe", displayName: "Mistral Vibe" },
+			{ id: "off-custom", displayName: "Off Custom" },
 		]);
 	});
 });

--- a/test/settings-normalizer.test.ts
+++ b/test/settings-normalizer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
 	normalizePresetAgents,
 	defaultPresetAgentSettings,
+	normalizeCustomAgent,
 	ensureUniqueCustomAgentIds,
 	resolveDefaultAgentId,
 	type ApiKeyMigrator,
@@ -39,6 +40,7 @@ describe("normalizePresetAgents", () => {
 			command: "/opt/claude-agent-acp",
 			args: ["--verbose"],
 			env: [{ key: "FOO", value: "bar" }],
+			enabled: true,
 		});
 		expect(result["codex-acp"].command).toBe("/opt/codex-acp");
 		expect(result["gemini-cli"].displayName).toBe("Gemini");
@@ -158,6 +160,20 @@ describe("normalizePresetAgents", () => {
 		expect(second.opencode).toEqual(first.opencode);
 	});
 
+	it("defaults enabled to true and preserves an explicit false", () => {
+		const result = normalizePresetAgents(
+			{
+				presetAgents: {
+					"codex-acp": { enabled: false },
+				},
+			},
+			PRESET_AGENTS,
+			noMigration,
+		);
+		expect(result["claude-code-acp"].enabled).toBe(true);
+		expect(result["codex-acp"].enabled).toBe(false);
+	});
+
 	it("routes legacy plaintext apiKeys through the injected migrator with registry wiring", () => {
 		const migrate = vi.fn<ApiKeyMigrator>(({ def, legacyPlain }) =>
 			legacyPlain ? `migrated-${def.presetId}` : "",
@@ -216,6 +232,15 @@ describe("ensureUniqueCustomAgentIds with reserved ids", () => {
 			PRESET_IDS,
 		);
 		expect(result.map((a) => a.id)).toEqual(["dup", "dup-2"]);
+	});
+});
+
+describe("normalizeCustomAgent", () => {
+	it("defaults enabled to true and preserves an explicit false", () => {
+		expect(normalizeCustomAgent({ id: "a" }).enabled).toBe(true);
+		expect(normalizeCustomAgent({ id: "a", enabled: false }).enabled).toBe(
+			false,
+		);
 	});
 });
 


### PR DESCRIPTION
## Description

Adds an **Enabled** toggle to every agent section (presets and customs). Disabling removes the agent from the switch menus, the header dropdown, the default-agent candidates, and the command palette — while its settings are kept and resolution stays intact.

Design: **disabling filters enumeration, not resolution.** The filter lives in the single enumeration implementation (`getAvailableAgentsFromSettings`, consolidated in #348), so every list follows automatically. `findAgentSettings` never checks `enabled`, which keeps working: already-open sessions, restored sessions (sidebar and persist blocks), and explicit `agent:` pins in code blocks.

- **Invariants enforced at runtime**, not just at load: the default agent falls back to the first enabled agent the moment it is disabled (no reload needed), and at least one agent must stay enabled (the UI refuses the last toggle with a notice; a load-time repair backstops corrupted data)
- **Command palette** registers all presets once and gates visibility with a `checkCallback` — no re-registration machinery
- **Chat header** shows an active-but-disabled agent as an explicit "`<name> (disabled)`" option (previously the selector rendered blank in that state — pre-existing bug this fixes in passing)
- **Block warnings now match actual behavior**: a chat block with an unknown agent warns "will fail to start" (the old "using the default agent instead" was never true for chat blocks); button blocks keep the fallback and its warning. Both block types now honor a disabled pin, with an honest warning
- `getCurrentAgent` resolves by unfiltered lookup so view titles and export frontmatter keep the display name of a disabled agent

Known limitations: block warnings are computed at render time and don't update on a later toggle; a newly added custom agent's palette command still appears after reload (existing limitation).

## Related issue

Closes #340 — implemented as an explicit per-agent toggle rather than the proposed "hide when no API key" heuristic: Claude Code, Mistral Vibe, and others work key-less with CLI account login, so key presence is not a reliable availability signal.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" warnings are brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian — toggle → dropdown/palette/block-warning surfaces; disabling the default falls back to the first enabled agent without a reload; the last enabled toggle is refused; a persist block pinning a disabled agent still restores
- [x] Existing functionality still works (157 unit tests; +10 covering enumeration filtering, unfiltered resolution, first-enabled fallback, and the all-disabled repair)
- [x] Documentation updated if needed (FAQ + troubleshooting)

## Testing environment

- Agent: all four presets + custom agents (toggle/enumeration paths)
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Enabled** toggle for agents in settings to hide unused agents from menus (switch lists, default-agent dropdown, and command palette) while retaining their settings.
  * Disabled agents can still appear in open chats/restored sessions, and selector dropdowns may include the current agent marked **(disabled)**.

* **Bug Fixes**
  * Prevented disabling the last remaining enabled agent and automatically repaired the “all agents disabled” state.
  * Improved agent selection and default-agent fallback when the saved default is disabled (including pinned blocks behavior).

* **Documentation**
  * Updated FAQ and added troubleshooting guidance for missing agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->