### PR TITLE
feat: collapse agent settings sections behind summary rows

### DIFF
--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -7,6 +7,7 @@ import {
 	Platform,
 	SecretComponent,
 	ToggleComponent,
+	ExtraButtonComponent,
 	setIcon,
 } from "obsidian";
 import type AgentClientPlugin from "../plugin";
@@ -1015,6 +1016,10 @@ export class AgentClientSettingTab extends PluginSettingTab {
 			write: (value: boolean) => Promise<void> | void;
 		},
 		renderBody: (bodyEl: HTMLElement, nameEl: HTMLElement) => void,
+		// Optional controls rendered after the Enabled toggle (e.g. the
+		// custom agent delete button). Siblings of the collapse button, so
+		// their clicks can't toggle the section.
+		renderSummaryTrailing?: (summaryEl: HTMLElement) => void,
 	): void {
 		const isOpen = this.openSections.has(sectionId);
 
@@ -1040,6 +1045,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 			enabledToggle.currentValue,
 			{ write: enabledToggle.write },
 		);
+		renderSummaryTrailing?.(summaryEl);
 
 		const bodyEl = containerEl.createDiv({
 			cls: "agent-client-agent-section-body",
@@ -1264,6 +1270,23 @@ export class AgentClientSettingTab extends PluginSettingTab {
 			},
 			(bodyEl, nameEl) =>
 				this.renderCustomAgentBody(bodyEl, nameEl, agent, index),
+			(summaryEl) => {
+				// Delete lives in the summary row (next to the Enabled
+				// toggle) so it clearly removes the whole agent — inside the
+				// body it read as deleting just the Agent ID.
+				new ExtraButtonComponent(summaryEl)
+					.setIcon("trash")
+					.setTooltip("Delete this agent")
+					.onClick(async () => {
+						this.plugin.settings.customAgents.splice(index, 1);
+						// Deleting the last enabled agent must not leave
+						// everything disabled.
+						this.plugin.ensureAtLeastOneEnabled();
+						this.plugin.ensureDefaultAgentId();
+						await this.flushSettings();
+						this.refreshDisplay();
+					});
+			},
 		);
 	}
 
@@ -1273,7 +1296,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		agent: CustomAgentSettings,
 		index: number,
 	) {
-		const idSetting = new Setting(bodyEl)
+		new Setting(bodyEl)
 			.setName("Agent ID")
 			.setDesc("Unique identifier used to reference this agent.")
 			.addText((text) => {
@@ -1351,21 +1374,6 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					});
 				});
 			});
-
-		idSetting.addExtraButton((button) => {
-			button
-				.setIcon("trash")
-				.setTooltip("Delete this agent")
-				.onClick(async () => {
-					this.plugin.settings.customAgents.splice(index, 1);
-					// Deleting the last enabled agent must not leave
-					// everything disabled.
-					this.plugin.ensureAtLeastOneEnabled();
-					this.plugin.ensureDefaultAgentId();
-					await this.flushSettings();
-					this.refreshDisplay();
-				});
-		});
 
 		new Setting(bodyEl)
 			.setName("Display name")

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -6,6 +6,8 @@ import {
 	DropdownComponent,
 	Platform,
 	SecretComponent,
+	ToggleComponent,
+	setIcon,
 } from "obsidian";
 import type AgentClientPlugin from "../plugin";
 import type {
@@ -34,6 +36,14 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	plugin: AgentClientPlugin;
 	private agentSelector: DropdownComponent | null = null;
 	private unsubscribe: (() => void) | null = null;
+	/**
+	 * Open agent sections ("preset:<id>" / "custom:<id>"). Deliberately
+	 * non-persisted (cleared on hide), but held on the instance so
+	 * refreshDisplay() calls from in-section actions (Auto-detect, the WSL
+	 * toggle) re-render sections in their current open state instead of
+	 * collapsing everything.
+	 */
+	private openSections = new Set<string>();
 
 	constructor(app: App, plugin: AgentClientPlugin) {
 		super(app, plugin);
@@ -877,6 +887,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 			this.unsubscribe();
 			this.unsubscribe = null;
 		}
+		this.openSections.clear();
 	}
 
 	private renderAgentSelector(containerEl: HTMLElement) {
@@ -941,45 +952,113 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	}
 
 	/**
-	 * Shared "Enabled" toggle row for preset and custom agent sections.
+	 * "Enabled" toggle rendered into an agent section's summary row.
 	 * Refuses to disable the last enabled agent (Notice + revert). After the
 	 * write, re-validates the default agent and refreshes the default-agent
-	 * dropdown in place — no refreshDisplay(), so the tab keeps its scroll
-	 * and focus state.
+	 * dropdown in place — no refreshDisplay(), so open sections, scroll,
+	 * and focus are kept.
 	 */
-	private addEnabledToggle(
-		sectionEl: HTMLElement,
+	private addEnabledToggleControl(
+		parentEl: HTMLElement,
 		// Resolved at interaction time: a custom agent's id can be renamed
 		// after this row rendered (the id editor commits per keystroke).
 		getAgentId: () => string | undefined,
 		currentValue: boolean,
 		writer: { write: (value: boolean) => Promise<void> | void },
 	): void {
-		new Setting(sectionEl)
-			.setName("Enabled")
-			.setDesc(
-				"Show this agent in agent lists, menus, and commands. Pinned blocks and restored sessions keep working while disabled.",
-			)
-			.addToggle((toggle) => {
-				toggle.setValue(currentValue).onChange(async (value) => {
-					const agentId = getAgentId();
-					if (agentId === undefined) {
-						return;
-					}
-					if (!value && this.isLastEnabledAgent(agentId)) {
-						toggle.setValue(true);
-						new Notice(
-							"[Agent Client] At least one agent must stay enabled.",
-						);
-						return;
-					}
-					await writer.write(value);
-					this.plugin.ensureAtLeastOneEnabled();
-					this.plugin.ensureDefaultAgentId();
-					await this.flushSettings();
-					this.refreshAgentDropdown();
-				});
+		const toggle = new ToggleComponent(parentEl);
+		toggle
+			.setValue(currentValue)
+			.setTooltip("Show this agent in agent lists, menus, and commands")
+			.onChange(async (value) => {
+				const agentId = getAgentId();
+				if (agentId === undefined) {
+					return;
+				}
+				if (!value && this.isLastEnabledAgent(agentId)) {
+					toggle.setValue(true);
+					new Notice(
+						"[Agent Client] At least one agent must stay enabled.",
+					);
+					return;
+				}
+				await writer.write(value);
+				this.plugin.ensureAtLeastOneEnabled();
+				this.plugin.ensureDefaultAgentId();
+				await this.flushSettings();
+				this.refreshAgentDropdown();
 			});
+		toggle.toggleEl.setAttribute("aria-label", "Enabled");
+	}
+
+	/**
+	 * Collapsible section shell shared by preset and custom agent sections.
+	 * The summary row is a real <button> (keyboard/focus for free, with
+	 * aria-expanded) holding the chevron + agent name; the Enabled toggle
+	 * sits in the row as a flex sibling — not nested, since interactive
+	 * content inside a button is invalid and as a sibling its clicks can't
+	 * reach the collapse handler. Open/close flips classes in place, no
+	 * re-render. Interim UI until the SettingsTab migrates to the
+	 * declarative settings API (Obsidian 1.13, see plan/TODO.md).
+	 *
+	 * `renderBody` receives the (initially hidden when closed) body element
+	 * plus the summary name element, so body controls that edit the display
+	 * name can sync the summary label in place.
+	 */
+	private renderCollapsibleAgentSection(
+		containerEl: HTMLElement,
+		sectionId: string,
+		name: string,
+		enabledToggle: {
+			getAgentId: () => string | undefined;
+			currentValue: boolean;
+			write: (value: boolean) => Promise<void> | void;
+		},
+		renderBody: (bodyEl: HTMLElement, nameEl: HTMLElement) => void,
+	): void {
+		const isOpen = this.openSections.has(sectionId);
+
+		const summaryEl = containerEl.createDiv({
+			cls: "agent-client-agent-summary",
+		});
+		summaryEl.toggleClass("agent-client-open", isOpen);
+		const buttonEl = summaryEl.createEl("button", {
+			cls: "agent-client-agent-summary-button",
+			attr: { type: "button", "aria-expanded": String(isOpen) },
+		});
+		const nameEl = buttonEl.createSpan({
+			cls: "agent-client-agent-summary-name",
+			text: name,
+		});
+		const chevronEl = buttonEl.createSpan({
+			cls: "agent-client-agent-summary-chevron",
+		});
+		setIcon(chevronEl, "chevron-right");
+		this.addEnabledToggleControl(
+			summaryEl,
+			enabledToggle.getAgentId,
+			enabledToggle.currentValue,
+			{ write: enabledToggle.write },
+		);
+
+		const bodyEl = containerEl.createDiv({
+			cls: "agent-client-agent-section-body",
+		});
+		bodyEl.toggleClass("agent-client-collapsed", !isOpen);
+
+		buttonEl.addEventListener("click", () => {
+			const open = !this.openSections.has(sectionId);
+			if (open) {
+				this.openSections.add(sectionId);
+			} else {
+				this.openSections.delete(sectionId);
+			}
+			buttonEl.setAttribute("aria-expanded", String(open));
+			summaryEl.toggleClass("agent-client-open", open);
+			bodyEl.toggleClass("agent-client-collapsed", !open);
+		});
+
+		renderBody(bodyEl, nameEl);
 	}
 
 	/**
@@ -1005,12 +1084,13 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	}
 
 	/**
-	 * Render the settings section for one preset agent, driven entirely by
-	 * its registry definition (heading, API key row, path + auto-detect,
-	 * install hint, arguments, environment variables).
+	 * Render the collapsible settings section for one preset agent, driven
+	 * entirely by its registry definition (summary row with Enabled toggle,
+	 * API key row, path + auto-detect, install hint, arguments, environment
+	 * variables).
 	 */
 	private renderPresetSettings(
-		sectionEl: HTMLElement,
+		containerEl: HTMLElement,
 		def: PresetAgentDefinition,
 	) {
 		const preset = this.plugin.settings.presetAgents[def.presetId];
@@ -1019,22 +1099,27 @@ export class AgentClientSettingTab extends PluginSettingTab {
 			return;
 		}
 
-		new Setting(sectionEl)
-			.setName(preset.displayName || def.defaultDisplayName)
-			.setHeading();
-
-		this.addEnabledToggle(
-			sectionEl,
-			() => def.presetId,
-			isAgentEnabled(preset),
+		this.renderCollapsibleAgentSection(
+			containerEl,
+			`preset:${def.presetId}`,
+			preset.displayName || def.defaultDisplayName,
 			{
+				getAgentId: () => def.presetId,
+				currentValue: isAgentEnabled(preset),
 				write: (value) =>
 					this.updatePresetAgent(def.presetId, { enabled: value }),
 			},
+			(bodyEl) => this.renderPresetSettingsBody(bodyEl, def, preset),
 		);
+	}
 
+	private renderPresetSettingsBody(
+		bodyEl: HTMLElement,
+		def: PresetAgentDefinition,
+		preset: PresetAgentUserSettings,
+	) {
 		if (def.apiKey) {
-			new Setting(sectionEl)
+			new Setting(bodyEl)
 				.setName("API key")
 				.setDesc(def.apiKey.settingDesc)
 				.addComponent((el) =>
@@ -1048,7 +1133,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 				);
 		}
 
-		const pathSetting = new Setting(sectionEl)
+		const pathSetting = new Setting(bodyEl)
 			.setName("Path")
 			.setDesc(def.settingsCopy.pathDesc)
 			.addText((text) => {
@@ -1073,13 +1158,13 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		const isNativeWindows =
 			Platform.isWin && !this.plugin.settings.windowsWslMode;
 		this.addInstallHint(
-			sectionEl,
+			bodyEl,
 			isNativeWindows && def.installHint.nativeWindows
 				? def.installHint.nativeWindows
 				: def.installHint.default,
 		);
 
-		new Setting(sectionEl)
+		new Setting(bodyEl)
 			.setName("Arguments")
 			.setDesc(
 				"Enter one argument per line. Leave empty to run without arguments." +
@@ -1106,7 +1191,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 			);
 		}
 
-		new Setting(sectionEl)
+		new Setting(bodyEl)
 			.setName("Environment variables")
 			.setDesc(envDescParts.join(" "))
 			.addTextArea((text) => {
@@ -1147,6 +1232,9 @@ export class AgentClientSettingTab extends PluginSettingTab {
 						args: [],
 						env: [],
 					});
+					// Open the new agent's section so it can be configured
+					// right away.
+					this.openSections.add(`custom:${newId}`);
 					this.plugin.ensureDefaultAgentId();
 					await this.flushSettings();
 					this.refreshDisplay();
@@ -1163,18 +1251,29 @@ export class AgentClientSettingTab extends PluginSettingTab {
 			cls: "agent-client-custom-agent",
 		});
 
-		this.addEnabledToggle(
+		this.renderCollapsibleAgentSection(
 			blockEl,
-			() => this.plugin.settings.customAgents[index]?.id,
-			isAgentEnabled(agent),
+			`custom:${agent.id}`,
+			agent.displayName || agent.id,
 			{
+				getAgentId: () => this.plugin.settings.customAgents[index]?.id,
+				currentValue: isAgentEnabled(agent),
 				write: (value) => {
 					this.plugin.settings.customAgents[index].enabled = value;
 				},
 			},
+			(bodyEl, nameEl) =>
+				this.renderCustomAgentBody(bodyEl, nameEl, agent, index),
 		);
+	}
 
-		const idSetting = new Setting(blockEl)
+	private renderCustomAgentBody(
+		bodyEl: HTMLElement,
+		summaryNameEl: HTMLElement,
+		agent: CustomAgentSettings,
+		index: number,
+	) {
+		const idSetting = new Setting(bodyEl)
 			.setName("Agent ID")
 			.setDesc("Unique identifier used to reference this agent.")
 			.addText((text) => {
@@ -1268,7 +1367,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 				});
 		});
 
-		new Setting(blockEl)
+		new Setting(bodyEl)
 			.setName("Display name")
 			.setDesc("Shown in menus and headers.")
 			.addText((text) => {
@@ -1276,16 +1375,21 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					.setValue(agent.displayName || agent.id)
 					.onChange(async (value) => {
 						const trimmed = value.trim();
-						this.plugin.settings.customAgents[index].displayName =
+						const next =
 							trimmed.length > 0
 								? trimmed
 								: this.plugin.settings.customAgents[index].id;
+						this.plugin.settings.customAgents[index].displayName =
+							next;
+						// Keep the collapsed-summary label in sync without a
+						// re-render (which would drop focus mid-typing).
+						summaryNameEl.setText(next);
 						await this.flushSettings();
 						this.refreshAgentDropdown();
 					});
 			});
 
-		new Setting(blockEl)
+		new Setting(bodyEl)
 			.setName("Path")
 			.setDesc(
 				"Command name or path to the custom agent. Use just the command name to let the login shell resolve it, or enter an absolute path.",
@@ -1300,7 +1404,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					});
 			});
 
-		new Setting(blockEl)
+		new Setting(bodyEl)
 			.setName("Arguments")
 			.setDesc(
 				"Enter one argument per line. Leave empty to run without arguments.",
@@ -1316,7 +1420,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 				text.inputEl.rows = 3;
 			});
 
-		new Setting(blockEl)
+		new Setting(bodyEl)
 			.setName("Environment variables")
 			.setDesc(
 				"Enter KEY=VALUE pairs, one per line. (Stored as plain text)",

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -953,6 +953,20 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	}
 
 	/**
+	 * Move a custom section's open state when its agent id changes. Without
+	 * this, a section renamed while open stays keyed under the old id and
+	 * the next refreshDisplay() collapses it mid-edit.
+	 */
+	private rekeyOpenSection(oldId: string, newId: string): void {
+		if (oldId === newId) {
+			return;
+		}
+		if (this.openSections.delete(`custom:${oldId}`)) {
+			this.openSections.add(`custom:${newId}`);
+		}
+	}
+
+	/**
 	 * "Enabled" toggle rendered into an agent section's summary row.
 	 * Refuses to disable the last enabled agent (Notice + revert). After the
 	 * write, re-validates the default agent and refreshes the default-agent
@@ -1312,6 +1326,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 							text.setValue(nextId);
 						}
 						this.plugin.settings.customAgents[index].id = nextId;
+						this.rekeyOpenSection(previousId, nextId);
 						if (
 							this.plugin.settings.defaultAgentId === previousId
 						) {
@@ -1361,6 +1376,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 						candidate = `${committed}-${suffix}`;
 					}
 					this.plugin.settings.customAgents[index].id = candidate;
+					this.rekeyOpenSection(committed, candidate);
 					if (wasDefaultAtFocus) {
 						this.plugin.settings.defaultAgentId = candidate;
 					}

--- a/styles.css
+++ b/styles.css
@@ -158,6 +158,61 @@ If your plugin does not need CSS, delete this file.
 	border-radius: 8px;
 }
 
+/* ===== Settings Tab Collapsible Agent Sections ===== */
+.agent-client-agent-summary {
+	display: flex;
+	align-items: center;
+	gap: var(--size-4-2);
+	padding: var(--size-4-2) 0;
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+/* Inside the bordered custom-agent card the border-top double-lines with
+   the card border — drop it there. */
+.agent-client-custom-agent .agent-client-agent-summary {
+	border-top: none;
+	padding-top: 0;
+}
+
+/* Text-like button: the summary is a real <button> for keyboard/focus,
+   restyled to read as a heading row. Name left, chevron pushed right. */
+.agent-client-agent-summary-button {
+	display: flex;
+	flex: 1 1 auto;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--size-4-2);
+	padding: 0 var(--size-4-2);
+	background: none;
+	border: none;
+	box-shadow: none;
+	color: var(--text-normal);
+	font-size: var(--font-ui-medium);
+	font-weight: var(--font-semibold);
+	text-align: left;
+	cursor: pointer;
+}
+
+.agent-client-agent-summary-button:hover {
+	color: var(--text-accent);
+}
+
+.agent-client-agent-summary-chevron {
+	display: flex;
+	align-items: center;
+	color: var(--text-muted);
+	transition: transform 100ms ease-in-out;
+}
+
+.agent-client-agent-summary.agent-client-open
+	.agent-client-agent-summary-chevron {
+	transform: rotate(90deg);
+}
+
+.agent-client-agent-section-body.agent-client-collapsed {
+	display: none;
+}
+
 /* ===== Loading Indicator ===== */
 .agent-client-loading-indicator {
 	display: flex;


### PR DESCRIPTION
## Description

With six-plus agent sections on the settings screen (and more presets coming), the agents area gets long. Each preset/custom agent section now folds behind a summary row: agent name on the left, a chevron on the right, the Enabled toggle (from #349) inline in the row, and — for custom agents — the delete button next to the toggle. All sections start collapsed.

- The summary is a real `<button>` with `aria-expanded` — keyboard operation and focus come for free. The Enabled toggle and delete button sit in the row as flex siblings, not nested inside the button (interactive nesting is invalid HTML, and as siblings their clicks can't interfere with collapsing)
- The custom agent delete button moved from the body's "Agent ID" row (where it read as deleting just the id) into the summary row, so it clearly removes the whole agent and works without expanding
- Open/close flips CSS classes in place — no re-render, no scroll/focus loss
- Open state is deliberately **non-persisted** (per settings-tab visit, cleared on hide), but held on the tab instance so `refreshDisplay()` from in-section actions (Auto-detect success, the WSL-mode toggle) re-renders sections in their current open state instead of collapsing everything
- A newly added custom agent opens its section immediately; custom display-name edits sync the summary label in place
- Styling is CSS-only (styles.css), per plugin guidelines

This is interim UI: once Obsidian 1.13's declarative settings API leaves Catalyst beta, the whole tab migrates to `getSettingDefinitions()` (which has native page/group concepts) and this shell goes away.

No docs changes: section headings and all documented navigation strings ("Settings → Agent Client → Built-in agents") are unchanged.

## Related issue

Follow-up to #348/#349 (preset registry + enable/disable) — the third piece of the preset agents overhaul.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" warnings are brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian — expand/collapse via click and keyboard; Enabled toggle and delete button don't interfere with collapsing; delete works from a collapsed section; sections stay open across Auto-detect / WSL-toggle re-renders; new custom agent opens expanded with its summary label tracking display-name edits; reopening settings starts all-collapsed
- [x] Existing functionality still works (158 unit tests)
- [x] Documentation updated if needed (not needed — headings and navigation strings unchanged)

## Testing environment

- Agent: all four presets + custom agents (settings UI)
- OS: macOS

## Screenshots

(To be added — before/after of the collapsed agents list.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Settings tab to use collapsible sections for preset and custom agents, with a cleaner summary header.
  * Newly added custom agents open automatically, and header actions now provide quick enable/disable and delete without disrupting the layout.

* **Bug Fixes**
  * Disabling agents now enforces at least one enabled agent to prevent invalid configurations.
  * Enabled toggles and refreshes preserve scroll/focus for a smoother experience.
  * Agent display name edits update instantly in the header while remaining consistent with saved settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->