### PR TITLE
refactor: rename "Built-in agents" to "Preset agents"

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -86,7 +86,7 @@ https://github.com/user-attachments/assets/1c538349-b3fb-44dd-a163-7331cbca7824
 
 4. **設定 → Agent Client** で設定:
    - **Node.js path**: 例: `/usr/local/bin/node`
-   - **Built-in agents → Claude Code → Path**: 例: `/usr/local/bin/claude-agent-acp`（`claude`ではない）
+   - **Preset agents → Claude Code → Path**: 例: `/usr/local/bin/claude-agent-acp`（`claude`ではない）
    - **API key**: キーを追加、またはCLIでログイン済みの場合は空欄
 
 5. **チャット開始**: リボンのロボットアイコンをクリック

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Open a terminal (Terminal on macOS/Linux, PowerShell on Windows) and run the fol
 
 4. **Configure** in **Settings → Agent Client**:
    - **Node.js path**: e.g., `/usr/local/bin/node`
-   - **Built-in agents → Claude Code → Path**: e.g., `/usr/local/bin/claude-agent-acp` (not `claude`)
+   - **Preset agents → Claude Code → Path**: e.g., `/usr/local/bin/claude-agent-acp` (not `claude`)
    - **API key**: Add your key, or leave empty if logged in via CLI
 
 5. **Start chatting**: Click the robot icon in the ribbon

--- a/docs/agent-setup/claude-code.md
+++ b/docs/agent-setup/claude-code.md
@@ -37,7 +37,7 @@ Choose one of the following methods:
 ### Option A: API Key
 
 1. Get your API key from [Anthropic Console](https://console.anthropic.com/)
-2. Open **Settings → Agent Client → Built-in agents → Claude Code → API key**
+2. Open **Settings → Agent Client → Preset agents → Claude Code → API key**
 3. Click the **Link...** button next to the API key field
 4. In the **Select secret** dialog:
    - To use an existing secret: select it from the list and click **Save**

--- a/docs/agent-setup/codex.md
+++ b/docs/agent-setup/codex.md
@@ -37,7 +37,7 @@ Choose one of the following methods:
 ### Option A: API Key
 
 1. Get your API key from [OpenAI Platform](https://platform.openai.com/api-keys)
-2. Open **Settings → Agent Client → Built-in agents → Codex → API key**
+2. Open **Settings → Agent Client → Preset agents → Codex → API key**
 3. Click the **Link...** button next to the API key field
 4. In the **Select secret** dialog:
    - To use an existing secret: select it from the list and click **Save**

--- a/docs/agent-setup/gemini-cli.md
+++ b/docs/agent-setup/gemini-cli.md
@@ -67,7 +67,7 @@ If you have a Gemini Code Assist License from your organization, add `GOOGLE_CLO
 If you prefer to use an API key for authentication:
 
 1. Get your API key from [Google AI Studio](https://aistudio.google.com/apikey)
-2. Open **Settings → Agent Client → Built-in agents → Gemini CLI → API key**
+2. Open **Settings → Agent Client → Preset agents → Gemini CLI → API key**
 3. Click the **Link...** button next to the API key field
 4. In the **Select secret** dialog:
    - To use an existing secret: select it from the list and click **Save**
@@ -93,7 +93,7 @@ If authentication still fails, set the key on the Gemini CLI side instead: run `
 
 If you are using Vertex AI for enterprise workloads:
 
-1. In **Settings → Agent Client → Built-in agents → Gemini CLI → Environment variables**, add:
+1. In **Settings → Agent Client → Preset agents → Gemini CLI → Environment variables**, add:
 
 ```
 GOOGLE_API_KEY=YOUR_API_KEY

--- a/docs/announcements/gemini-cli-deprecation.md
+++ b/docs/announcements/gemini-cli-deprecation.md
@@ -54,9 +54,9 @@ This plugin works with any agent that speaks the Agent Client Protocol (ACP). If
 
 ## What about Antigravity CLI?
 
-Google's replacement, **Antigravity CLI**, does **not currently support ACP** (there is no `--experimental-acp` mode), so this plugin **cannot connect to it as a built-in agent yet**. Antigravity CLI is also not open source.
+Google's replacement, **Antigravity CLI**, does **not currently support ACP** (there is no `--experimental-acp` mode), so this plugin **cannot connect to it as a preset agent yet**. Antigravity CLI is also not open source.
 
-If Google adds ACP support — or if an adapter built on the **Antigravity SDK** emerges (similar to how `claude-agent-acp` is built on the Claude Agent SDK rather than wrapping the CLI) — built-in support will be reconsidered. For Google's own migration steps, see the [Antigravity CLI migration guide](https://antigravity.google/docs/gcli-migration).
+If Google adds ACP support — or if an adapter built on the **Antigravity SDK** emerges (similar to how `claude-agent-acp` is built on the Claude Agent SDK rather than wrapping the CLI) — adding it as a preset will be reconsidered. For Google's own migration steps, see the [Antigravity CLI migration guide](https://antigravity.google/docs/gcli-migration).
 
 A community ACP bridge, [`agy-acp`](https://github.com/openabdev/openab/tree/main/agy-acp), does exist and can be added as a [custom agent](/agent-setup/custom-agents). It works as a minimal text chat only — streaming, tool calls, and diffs don't come through — so it's an escape hatch rather than a full replacement.
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -77,7 +77,7 @@ Disabling only hides the agent from lists: already-open chats, restored sessions
 
 ### What is a custom agent?
 
-Any ACP-compatible agent beyond the built-in ones (Claude Code, Codex, Gemini CLI, Mistral Vibe). You can add custom agents in **Settings → Agent Client → Custom agents**. See [Custom Agents](/agent-setup/custom-agents).
+Any ACP-compatible agent beyond the preset ones (Claude Code, Codex, Gemini CLI, Mistral Vibe). You can add custom agents in **Settings → Agent Client → Custom agents**. See [Custom Agents](/agent-setup/custom-agents).
 
 ### Do all agents support the same features?
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -42,18 +42,18 @@ The agent executable cannot be found at the specified path.
 The agent requires authentication before processing requests.
 
 **For Claude Code:**
-- **API key**: Open **Settings → Agent Client → Built-in agents → Claude Code → API key**, click **Link...**, and link or create a secret. See [Claude Code Setup](/agent-setup/claude-code#authentication).
+- **API key**: Open **Settings → Agent Client → Preset agents → Claude Code → API key**, click **Link...**, and link or create a secret. See [Claude Code Setup](/agent-setup/claude-code#authentication).
 - **Account login**: Run `claude` in Terminal first and complete the login flow
 
 **For Codex:**
-- Open **Settings → Agent Client → Built-in agents → Codex → API key**, click **Link...**, and link or create a secret. See [Codex Setup](/agent-setup/codex#authentication).
+- Open **Settings → Agent Client → Preset agents → Codex → API key**, click **Link...**, and link or create a secret. See [Codex Setup](/agent-setup/codex#authentication).
 
 **For Gemini CLI:**
-- Open **Settings → Agent Client → Built-in agents → Gemini CLI → API key**, click **Link...**, and link or create a secret. See [Gemini CLI Setup](/agent-setup/gemini-cli#authentication).
+- Open **Settings → Agent Client → Preset agents → Gemini CLI → API key**, click **Link...**, and link or create a secret. See [Gemini CLI Setup](/agent-setup/gemini-cli#authentication).
 - Or run `gemini` in Terminal first to authenticate with your Google account
 
 **For Mistral Vibe:**
-- Open **Settings → Agent Client → Built-in agents → Mistral Vibe → API key**, click **Link...**, and link or create a secret. See [Mistral Vibe Setup](/agent-setup/mistral-vibe#authentication).
+- Open **Settings → Agent Client → Preset agents → Mistral Vibe → API key**, click **Link...**, and link or create a secret. See [Mistral Vibe Setup](/agent-setup/mistral-vibe#authentication).
 - Or run `vibe` in Terminal first to authenticate with your Mistral account
 
 ### "No Authentication Methods" error

--- a/src/acp/acp-client.ts
+++ b/src/acp/acp-client.ts
@@ -209,7 +209,7 @@ export class AcpClient {
 
 		// In WSL mode, forward the configured env var NAMES into WSL via WSLENV
 		// (Windows env vars are otherwise invisible to the Linux agent process,
-		// so the plugin's API key field would have no effect in WSL). Built-in
+		// so the plugin's API key field would have no effect in WSL). Preset
 		// agents resolve the API key into baseEnv above — not into config.env —
 		// so its var name must be added explicitly, or the key would never cross
 		// into WSL. Must run AFTER the secret is injected into baseEnv. (#312)

--- a/src/services/update-checker.ts
+++ b/src/services/update-checker.ts
@@ -1,7 +1,7 @@
 /**
  * Agent Update Checker
  *
- * Checks built-in agent ACP adapters for:
+ * Checks preset agent ACP adapters for:
  * 1. Package migration — deprecated packages that have been renamed
  * 2. Version updates — newer versions available on npm
  *

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -62,7 +62,7 @@ export interface BaseAgentSettings {
 }
 
 /**
- * Per-preset user overrides for a preset (built-in) agent.
+ * Per-preset user overrides for a preset agent.
  *
  * Stored in `settings.presetAgents[presetId]`. The static side of a preset
  * (default command, API-key env var name, install hints, settings copy) lives

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -159,7 +159,7 @@ export interface ChatSession {
 	/** Current state of the session */
 	state: SessionState;
 
-	/** ID of the active agent (a built-in agent ID such as "claude-code-acp", or a custom agent ID) */
+	/** ID of the active agent (a preset agent ID such as "claude-code-acp", or a custom agent ID) */
 	agentId: string;
 
 	/** Display name of the agent at session creation time */

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -625,7 +625,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		// Agents
 		// ─────────────────────────────────────────────────────────────────────
 
-		new Setting(containerEl).setName("Built-in agents").setHeading();
+		new Setting(containerEl).setName("Preset agents").setHeading();
 
 		for (const def of PRESET_AGENTS) {
 			this.renderPresetSettings(containerEl, def);
@@ -1382,7 +1382,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					}
 					text.setValue(candidate);
 					new Notice(
-						`[Agent Client] "${committed}" is reserved for a built-in agent. This custom agent was renamed to "${candidate}".`,
+						`[Agent Client] "${committed}" is reserved for a preset agent. This custom agent was renamed to "${candidate}".`,
 					);
 					this.plugin.ensureDefaultAgentId();
 					void this.flushSettings().then(() => {


### PR DESCRIPTION
## Description

Renames the user-facing term for bundled agents from "built-in" to "preset", aligning the UI and docs with the internal vocabulary introduced by the registry overhaul (#348: `PRESET_AGENTS`, `presetAgents` storage). One coherent sweep, done before the OpenCode/Kiro preset PRs so their docs are written against the final name.

- **Settings**: the agents heading is now **Preset agents**; the reserved-id notice says "reserved for a preset agent"
- **Docs/READMEs**: every navigation string ("Settings → Agent Client → Preset agents → …") across the agent-setup pages, troubleshooting, and both READMEs; prose terminology in the FAQ and the Gemini deprecation announcement
- **Code comments**: terminology unified in `types/`, `update-checker`, `acp-client`

Deliberately kept: "built-in ACP support" on the Mistral Vibe rows (means the CLI ships ACP natively — not the agent category), "built-in fuzzy search" (library feature), and a "preset (built-in) agents" gloss at the registry definition and in AGENTS.md as a bridge for readers who know the old term.

## Related issue

Terminology follow-up to #348–#350 (preset agents overhaul).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [x] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" warnings are brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian — settings heading shows "Preset agents"
- [x] Existing functionality still works (158 unit tests; `npm run docs:build` passes)
- [x] Documentation updated if needed (all navigation strings updated in the same sweep)

## Testing environment

- Agent: n/a (wording only; no behavior change)
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup, troubleshooting, FAQ, and announcement text to use **“Preset agents”** instead of **“Built-in agents”** across agent configuration guides.
  * Refreshed Claude Code, Codex, Gemini CLI, and related setup steps to match the current settings navigation.

* **UI Improvements**
  * Renamed the Agents settings section to **Preset agents**.
  * Improved the rename warning for conflicting agent IDs to clearly explain they’re reserved for preset agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->