### PR TITLE
Restore header model display from ACP metadata

### DIFF
--- a/src/acp/acp-handler.ts
+++ b/src/acp/acp-handler.ts
@@ -6,6 +6,15 @@ import type { PermissionManager } from "./permission-handler";
 import type { TerminalManager } from "./terminal-handler";
 import type { Logger } from "../utils/logger";
 
+export function getModelIdFromMeta(
+	meta: { [key: string]: unknown } | null | undefined,
+): string | undefined {
+	const modelId = meta?.modelId;
+	if (typeof modelId !== "string") return undefined;
+	const trimmed = modelId.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
 /**
  * Handles incoming ACP protocol events from the agent.
  *
@@ -75,6 +84,15 @@ export class AcpHandler {
 
 		switch (update.sessionUpdate) {
 			case "agent_message_chunk":
+				if (update.content.type === "text") {
+					this.emitSessionUpdate({
+						type: "agent_message_chunk",
+						sessionId,
+						text: update.content.text,
+						modelId: getModelIdFromMeta(update._meta),
+					});
+				}
+				break;
 			case "agent_thought_chunk":
 			case "user_message_chunk":
 				if (update.content.type === "text") {
@@ -98,8 +116,7 @@ export class AcpHandler {
 					content: AcpTypeConverter.toToolCallContent(update.content),
 					locations: update.locations ?? undefined,
 					rawInput: update.rawInput as
-						| { [k: string]: unknown }
-						| undefined,
+						{ [k: string]: unknown } | undefined,
 				});
 				break;
 

--- a/src/hooks/useAgentSession.ts
+++ b/src/hooks/useAgentSession.ts
@@ -136,7 +136,23 @@ export function useAgentSession(
 					setSession((prev) => ({
 						...prev,
 						configOptions: update.configOptions,
+						confirmedModelId: update.configOptions.some(
+							(option) => option.category === "model",
+						)
+							? undefined
+							: prev.confirmedModelId,
 					}));
+					break;
+				case "agent_message_chunk":
+					if (!update.modelId) break;
+					setSession((prev) =>
+						prev.confirmedModelId === update.modelId
+							? prev
+							: {
+									...prev,
+									confirmedModelId: update.modelId,
+								},
+					);
 					break;
 				case "usage_update":
 					setSession((prev) => ({
@@ -182,6 +198,7 @@ export function useAgentSession(
 				availableCommands: undefined,
 				modes: undefined,
 				configOptions: undefined,
+				confirmedModelId: undefined,
 				usage: undefined,
 				promptCapabilities: prev.promptCapabilities,
 				agentCapabilities: prev.agentCapabilities,
@@ -318,6 +335,7 @@ export function useAgentSession(
 			...prev,
 			sessionId: null,
 			state: "disconnected",
+			confirmedModelId: undefined,
 		}));
 	}, [agentClient]);
 
@@ -399,6 +417,7 @@ export function useAgentSession(
 				state: "ready",
 				modes: finalModes ?? prev.modes,
 				configOptions: finalConfigOptions ?? prev.configOptions,
+				confirmedModelId: undefined,
 				lastActivityAt: new Date(),
 			}));
 		},
@@ -459,6 +478,9 @@ export function useAgentSession(
 			}
 
 			const previousConfigOptions = s.configOptions;
+			const isModelConfig = previousConfigOptions?.some(
+				(opt) => opt.id === configId && opt.category === "model",
+			);
 
 			setSession((prev) => {
 				if (!prev.configOptions) return prev;
@@ -469,6 +491,9 @@ export function useAgentSession(
 							? { ...opt, currentValue: value }
 							: opt,
 					),
+					confirmedModelId: isModelConfig
+						? undefined
+						: prev.confirmedModelId,
 				};
 			});
 

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -188,6 +188,12 @@ export interface ChatSession {
 	configOptions?: SessionConfigOption[];
 
 	/**
+	 * Last model identifier confirmed by an assistant response.
+	 * Some agents expose the effective model only on response chunk metadata.
+	 */
+	confirmedModelId?: string;
+
+	/**
 	 * Context window usage and cost information.
 	 * Updated dynamically via ACP's `usage_update` notification.
 	 * Agent sends this after each prompt response and on session load/resume.
@@ -270,6 +276,7 @@ interface SessionUpdateBase {
 export interface AgentMessageChunk extends SessionUpdateBase {
 	type: "agent_message_chunk";
 	text: string;
+	modelId?: string;
 }
 
 /**

--- a/src/ui/ChatHeader.tsx
+++ b/src/ui/ChatHeader.tsx
@@ -15,6 +15,8 @@ export interface SidebarHeaderProps {
 	variant: "sidebar";
 	/** Display name of the active agent */
 	agentLabel: string;
+	/** Effective model confirmed by the latest assistant response */
+	modelLabel?: string;
 	/** Whether a plugin update is available */
 	isUpdateAvailable: boolean;
 	/** Callback to create a new chat session */
@@ -34,6 +36,8 @@ export interface FloatingHeaderProps {
 	variant: "floating";
 	/** Display name of the active agent */
 	agentLabel: string;
+	/** Effective model confirmed by the latest assistant response */
+	modelLabel?: string;
 	/** Available agents for switching */
 	availableAgents: AgentDisplayInfo[];
 	/** Current agent ID */
@@ -102,6 +106,7 @@ function NavActionButton({
  */
 function SidebarHeader({
 	agentLabel,
+	modelLabel,
 	isUpdateAvailable,
 	onNewChat,
 	onExportChat,
@@ -114,6 +119,11 @@ function SidebarHeader({
 				<span className="agent-client-chat-view-header-title">
 					{agentLabel}
 				</span>
+				{modelLabel && (
+					<span className="agent-client-header-model-label">
+						{modelLabel}
+					</span>
+				)}
 				{isUpdateAvailable && (
 					<span className="agent-client-chat-view-header-update">
 						Plugin update available!
@@ -161,6 +171,7 @@ function SidebarHeader({
  */
 function FloatingHeader({
 	agentLabel,
+	modelLabel,
 	availableAgents,
 	currentAgentId,
 	isUpdateAvailable,
@@ -246,6 +257,11 @@ function FloatingHeader({
 				) : (
 					<span className="agent-client-agent-label">
 						{agentLabel}
+					</span>
+				)}
+				{modelLabel && (
+					<span className="agent-client-header-model-label">
+						{modelLabel}
 					</span>
 				)}
 			</div>

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -278,6 +278,8 @@ export function ChatPanel({
 		return custom?.displayName || custom?.id || activeId;
 	}, [session.agentId, plugin.settings]);
 
+	const headerModelLabel = session.confirmedModelId;
+
 	const availableAgents = useMemo(() => {
 		return plugin.getAvailableAgents();
 	}, [plugin]);
@@ -1179,6 +1181,7 @@ export function ChatPanel({
 			<ChatHeader
 				variant="sidebar"
 				agentLabel={activeAgentLabel}
+				modelLabel={headerModelLabel}
 				isUpdateAvailable={isUpdateAvailable}
 				onNewChat={() => void handleNewChatWithPersist()}
 				onExportChat={() => void handleExportChat()}
@@ -1189,6 +1192,7 @@ export function ChatPanel({
 			<ChatHeader
 				variant="floating"
 				agentLabel={activeAgentLabel}
+				modelLabel={headerModelLabel}
 				availableAgents={availableAgents}
 				currentAgentId={session.agentId}
 				isUpdateAvailable={isUpdateAvailable}

--- a/styles.css
+++ b/styles.css
@@ -536,6 +536,16 @@ If your plugin does not need CSS, delete this file.
 	white-space: nowrap;
 }
 
+.agent-client-header-model-label {
+	flex: 0 1 auto;
+	max-width: 45%;
+	color: var(--text-muted);
+	font-size: 11px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .agent-client-chat-view-header-update {
 	flex: 0 1 auto;
 	padding: 2px 8px;
@@ -567,6 +577,8 @@ If your plugin does not need CSS, delete this file.
 	display: flex;
 	align-items: center;
 	gap: 8px;
+	min-width: 0;
+	flex: 1 1 auto;
 }
 
 .agent-client-inline-header-actions {

--- a/test/acp-handler.test.ts
+++ b/test/acp-handler.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getModelIdFromMeta } from "../src/acp/acp-handler";
+
+describe("getModelIdFromMeta", () => {
+	it("returns a trimmed modelId string from ACP metadata", () => {
+		expect(getModelIdFromMeta({ modelId: "  claude-sonnet-4  " })).toBe(
+			"claude-sonnet-4",
+		);
+	});
+
+	it("ignores absent, blank, and non-string modelId values", () => {
+		expect(getModelIdFromMeta(undefined)).toBeUndefined();
+		expect(getModelIdFromMeta({ modelId: "   " })).toBeUndefined();
+		expect(getModelIdFromMeta({ modelId: 42 })).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
- carry `_meta.modelId` from ACP assistant message chunks into session updates
- remember the latest confirmed model on the active chat session
- render the confirmed model next to the agent label in sidebar and floating headers, clearing stale values on model/session changes

Fixes #342

## Verification
- `tsc -noEmit -skipLibCheck`
- `git diff --check`

`vitest run` currently fails to start in this local checkout because dependencies were installed with pnpm (npm is unavailable here), resolving Vitest/Vite to an incompatible graph: `Package subpath './module-runner' is not defined by exports`.