### PR TITLE
refactor: drop the display() deprecation suppression

### DIFF
--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -40,7 +40,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	/**
 	 * Open agent sections ("preset:<id>" / "custom:<id>"). Deliberately
 	 * non-persisted (cleared on hide), but held on the instance so
-	 * refreshDisplay() calls from in-section actions (Auto-detect, the WSL
+	 * renderContent() calls from in-section actions (Auto-detect, the WSL
 	 * toggle) re-render sections in their current open state instead of
 	 * collapsing everything.
 	 */
@@ -52,16 +52,25 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	}
 
 	/**
-	 * Re-renders the settings tab. Wraps the deprecated display() call so the
-	 * suppression lives in one place until Obsidian 1.13 leaves Catalyst beta
-	 * and the tab can migrate to getSettingDefinitions().
+	 * Obsidian's entry point for rendering the tab. Kept as a thin delegate:
+	 * SettingTab.display() is deprecated since Obsidian 1.13, so internal
+	 * re-renders must call renderContent() directly — a this.display() call
+	 * would trip @typescript-eslint/no-deprecated (an error in the obsidianmd
+	 * config), and Obsidian's plugin review rejects disabling that rule.
+	 * Overriding the method itself is lint-clean. Migrate to
+	 * getSettingDefinitions() once Obsidian 1.13 leaves Catalyst beta.
 	 */
-	private refreshDisplay(): void {
-		// eslint-disable-next-line @typescript-eslint/no-deprecated -- migrate to getSettingDefinitions once Obsidian 1.13 leaves Catalyst beta
-		this.display();
+	display(): void {
+		this.renderContent();
 	}
 
-	display(): void {
+	/**
+	 * Full render of the settings tab into containerEl. Called by display()
+	 * (Obsidian's entry point) and directly by in-tab actions that need a
+	 * re-render (visibility toggles, custom agent add/delete, auto-detect).
+	 * Same delegation shape as SessionHistoryModal.renderContent().
+	 */
+	private renderContent(): void {
 		const { containerEl } = this;
 
 		containerEl.empty();
@@ -386,7 +395,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 								autoCollapseDiffs: value,
 							},
 						});
-						this.refreshDisplay();
+						this.renderContent();
 					}),
 			);
 
@@ -535,7 +544,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.promptInjection.enabled = value;
 						await this.plugin.saveSettings();
-						this.refreshDisplay();
+						this.renderContent();
 					}),
 			);
 
@@ -607,7 +616,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 							await this.plugin.settingsService.updateSettings({
 								windowsWslMode: value,
 							});
-							this.refreshDisplay(); // Refresh to show/hide distribution setting
+							this.renderContent(); // Refresh to show/hide distribution setting
 						}),
 				);
 
@@ -728,7 +737,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 								includeImages: value,
 							},
 						});
-						this.refreshDisplay();
+						this.renderContent();
 					}),
 			);
 
@@ -760,7 +769,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 										| "base64",
 								},
 							});
-							this.refreshDisplay();
+							this.renderContent();
 						}),
 				);
 
@@ -970,7 +979,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	/**
 	 * Move a custom section's open state when its agent id changes. Without
 	 * this, a section renamed while open stays keyed under the old id and
-	 * the next refreshDisplay() collapses it mid-edit.
+	 * the next renderContent() collapses it mid-edit.
 	 */
 	private rekeyOpenSection(oldId: string, newId: string): void {
 		if (oldId === newId) {
@@ -985,7 +994,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	 * "Enabled" toggle rendered into an agent section's summary row.
 	 * Refuses to disable the last enabled agent (Notice + revert). After the
 	 * write, re-validates the default agent and refreshes the default-agent
-	 * dropdown in place — no refreshDisplay(), so open sections, scroll,
+	 * dropdown in place — no renderContent(), so open sections, scroll,
 	 * and focus are kept.
 	 */
 	private addEnabledToggleControl(
@@ -1272,7 +1281,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					this.openSections.add(`custom:${newId}`);
 					this.plugin.ensureDefaultAgentId();
 					await this.flushSettings();
-					this.refreshDisplay();
+					this.renderContent();
 				});
 		});
 	}
@@ -1313,7 +1322,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 						this.plugin.ensureAtLeastOneEnabled();
 						this.plugin.ensureDefaultAgentId();
 						await this.flushSettings();
-						this.refreshDisplay();
+						this.renderContent();
 					});
 			},
 		);
@@ -1590,7 +1599,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 							: await resolveCommandPath(commandName);
 						if (found) {
 							await onResolved(found);
-							this.refreshDisplay();
+							this.renderContent();
 						} else {
 							btn.setButtonText("Not found");
 							window.setTimeout(() => {


### PR DESCRIPTION
## Description

Obsidian's automated plugin review flags the `eslint-disable-next-line @typescript-eslint/no-deprecated` comment in `SettingsTab.ts` as an error — disabling that rule is not allowed. Removing the suppression, however, breaks our own CI: `eslint-plugin-obsidianmd`'s recommended config sets the same rule to `error`, and the settings tab re-renders itself by calling `SettingTab.display()`, deprecated since Obsidian 1.13 in favor of `getSettingDefinitions()` (which we can't adopt yet — it would force `minAppVersion` past what regular users run).

The deadlock exists only because we *reference* the deprecated symbol: the rule flags calls, not override declarations (verified empirically with a probe class). So this PR restructures the tab so nothing references it:

- **The render body moves to a private `renderContent()`.** `display()` stays as a thin entry point for Obsidian to call — overriding it is lint-clean.
- **The eight in-tab re-render sites call `renderContent()` directly** (visibility toggles, custom agent add/delete, auto-detect), so the `refreshDisplay()` wrapper from #345 — which existed solely to centralize the suppression — is removed along with the suppression itself.
- **Comment references to the removed wrapper are updated in place** so no stale method names drift in JSDoc.

Zero behavior change: same render body, same eight re-render triggers, and open agent sections still survive re-renders. The invariant is machine-enforced going forward — any future `this.display()` self-call fails `npm run lint` immediately. The delegation shape mirrors `SessionHistoryModal.renderContent()`.

The `getSettingDefinitions()` migration remains future work for when Obsidian 1.13 leaves Catalyst beta.

## Related issue

None (raised by Obsidian's automated plugin review of the dev branch).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes — zero errors, with no `no-deprecated` disables left in `src/`
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed (internal restructure — no docs impact)

## Testing environment

- Agent: N/A (settings tab restructure only — no agent runtime change). Manually verified all eight re-render triggers, including open sections surviving Auto-detect and the add/delete custom agent flows.
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings panel updates so changes appear more smoothly and consistently.
  * Fixed refresh behavior for toggles, dropdowns, custom agents, and auto-detected paths.
  * Reduced unnecessary full-panel redraws while editing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->