### PR TITLE
chore: declare the ES2020 standard lib the code already uses

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
 		"importHelpers": true,
 		"isolatedModules": true,
 		"strictNullChecks": true,
-		"lib": ["DOM", "ES5", "ES6", "ES7"],
+		"lib": ["DOM", "ES2020"],
 		"jsx": "react-jsx"
 	},
 	"include": ["src/**/*.ts", "src/**/*.tsx"]


### PR DESCRIPTION
## Description

Follow-up to the Obsidian automated plugin review sweep that produced #357. The largest remaining warning class is `@typescript-eslint/no-unsafe-*` noise, and about a third of it has a single root cause on our side: **the declared `lib` in `tsconfig.json` stops at ES2016** (`["DOM", "ES5", "ES6", "ES7"]`), while the code freely uses ES2017–ES2020 built-ins (`padStart`, `Object.entries`, `Object.fromEntries`, `flatMap`, `matchAll`, `Promise.allSettled`).

This only type-checks locally by accident: with no `types` field, TypeScript auto-includes `@types/node`, whose `index.d.ts` carries `/// <reference lib="es2020" />` — smuggling the full ES2020 standard lib into the compilation. The review environment type-checks without devDependencies, so the smuggled lib disappears, those built-ins become unresolved, their expressions degrade to `error` types (any-like), and every touching line lights up as unsafe.

The fix is one line: declare `"lib": ["DOM", "ES2020"]`.

- **Provably zero local change.** Lib files chain-reference downward (`es2020` → `es2019` → … → `es5`), so the old *effective* lib (`DOM ∪ es2016 chain ∪ smuggled es2020 chain`) and the new declared one (`DOM ∪ es2020 chain`) are the same set. Lint (0 errors / 46 warnings), build, and tests (182) all pass with identical counts.
- **Verified against a review-environment simulation.** With a probe tsconfig (`"types": []` to drop `@types/node`), `tsc --noEmit` errors drop from 73 to 50, and lib-caused `TS2550` errors in `src/` go to zero. The remaining 50 are Node/Electron API resolution errors — inherent to an `isDesktopOnly` plugin when no node types are installed, and out of scope here.
- **Deliberately ES2020, not higher.** ES2020 is the only value provably equivalent to today's effective lib; raising further would silently permit APIs the code doesn't use yet. If ES2021+ APIs are ever needed, the lib bump belongs in the same PR that introduces them.

No runtime impact: `lib` is type-check-only, tsc runs with `-noEmit`, and esbuild (which doesn't polyfill built-ins) emits an unchanged bundle.

## Related issue

None (raised by Obsidian's automated plugin review of the dev branch).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [ ] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed (config-only change — no docs impact)

## Testing environment

- Agent: N/A (type-check configuration only — the emitted bundle is unchanged)
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s TypeScript configuration to use modern JavaScript standards.
  * Improves compatibility with current language features and platform APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->