### PR TITLE
fix: reveal the host note tab when focusing an embedded chat

### DIFF
--- a/src/ui/CodeBlockChatView.tsx
+++ b/src/ui/CodeBlockChatView.tsx
@@ -219,16 +219,16 @@ export class EmbeddedChatViewContainer implements IChatViewContainer {
 	/**
 	 * Bounded per-frame wait for the block to be (re-)attached to the DOM,
 	 * then scroll and focus. Sections far from the scroll position may stay
-	 * pruned; give up silently after ~1s so a miss costs nothing.
+	 * pruned; give up silently after one second so a miss costs nothing.
 	 */
-	private scrollAndFocusInputWhenConnected(attemptsLeft = 60): void {
+	private scrollAndFocusInputWhenConnected(deadline = Date.now() + 1000): void {
 		if (this.containerEl.isConnected) {
 			this.scrollAndFocusInput();
 			return;
 		}
-		if (attemptsLeft <= 0) return;
+		if (Date.now() > deadline) return;
 		window.requestAnimationFrame(() =>
-			this.scrollAndFocusInputWhenConnected(attemptsLeft - 1),
+			this.scrollAndFocusInputWhenConnected(deadline),
 		);
 	}
 

--- a/src/ui/CodeBlockChatView.tsx
+++ b/src/ui/CodeBlockChatView.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 const { useEffect, useMemo } = React;
 import { createRoot, type Root } from "react-dom/client";
+import { MarkdownView, type WorkspaceLeaf } from "obsidian";
 
 import type AgentClientPlugin from "../plugin";
 import { ChatContextProvider } from "./ChatContext";
@@ -196,6 +197,67 @@ export class EmbeddedChatViewContainer implements IChatViewContainer {
 	}
 
 	focus(): void {
+		// The block can be registered yet invisible: its host note may sit in
+		// a background tab (switching notes does NOT unmount embedded blocks).
+		// Reveal the hosting leaf first — scrollIntoView and textarea.focus()
+		// are no-ops on a hidden container — mirroring ChatView.focus()'s
+		// revealLeaf and FloatingViewContainer.focus()'s expand.
+		const hostLeaf = this.findHostLeaf();
+		if (hostLeaf) {
+			void this.plugin.app.workspace.revealLeaf(hostLeaf).then(() => {
+				// The re-shown view re-attaches pruned sections with a delay
+				// that is not observable up front (one frame is measurably too
+				// short: focus() on a detached textarea is a silent no-op).
+				// Wait per frame, bounded, until the block is back in the DOM.
+				this.scrollAndFocusInputWhenConnected();
+			});
+			return;
+		}
+		this.scrollAndFocusInput();
+	}
+
+	/**
+	 * Bounded per-frame wait for the block to be (re-)attached to the DOM,
+	 * then scroll and focus. Sections far from the scroll position may stay
+	 * pruned; give up silently after ~1s so a miss costs nothing.
+	 */
+	private scrollAndFocusInputWhenConnected(attemptsLeft = 60): void {
+		if (this.containerEl.isConnected) {
+			this.scrollAndFocusInput();
+			return;
+		}
+		if (attemptsLeft <= 0) return;
+		window.requestAnimationFrame(() =>
+			this.scrollAndFocusInputWhenConnected(attemptsLeft - 1),
+		);
+	}
+
+	/**
+	 * The markdown leaf hosting this block, or null (e.g. a rendering context
+	 * that is not a leaf). DOM containment is tried first: while the block is
+	 * visible it picks the exact tab even when the same note is open in
+	 * multiple tabs, so revealLeaf stays a no-op for the tab the user is
+	 * already looking at. Containment fails while the block is detached —
+	 * background tabs are pruned from the preview DOM (verified 2026-07-15:
+	 * containerEl.isConnected === false) — so fall back to matching the
+	 * leaf's file against sourcePath.
+	 */
+	private findHostLeaf(): WorkspaceLeaf | null {
+		const leaves = this.plugin.app.workspace.getLeavesOfType("markdown");
+		return (
+			leaves.find((leaf) =>
+				leaf.view.containerEl.contains(this.containerEl),
+			) ??
+			leaves.find(
+				(leaf) =>
+					leaf.view instanceof MarkdownView &&
+					leaf.view.file?.path === this.sourcePath,
+			) ??
+			null
+		);
+	}
+
+	private scrollAndFocusInput(): void {
 		this.containerEl.scrollIntoView({ block: "nearest" });
 		window.requestAnimationFrame(() => {
 			const textarea = this.containerEl.querySelector(


### PR DESCRIPTION
## Description

Found while verifying Session Manager behavior for the embeddable-blocks docs work: clicking an embedded chat's entry in the Session Manager (or cycling with **Focus next/previous chat view**) did nothing when the block's host note sat in a background tab. The sidebar and floating views both recover from their hidden states (`revealLeaf` / expand), but the embedded container had no equivalent step.

Two facts, verified on a live vault, shape the fix:

- **A background tab's blocks are registered yet detached.** Obsidian prunes hidden tabs' sections from the preview DOM without unloading their render children (`containerEl.isConnected === false` while the entry still lists in the Session Manager). `scrollIntoView` and `focus()` are silent no-ops on a detached container — hence "nothing happens".
- **Re-attachment after revealing the tab takes more than one frame**, so focusing immediately after `revealLeaf` still missed.

`EmbeddedChatViewContainer.focus()` now:

1. **Finds the hosting markdown leaf** — by DOM containment while the block is visible (picks the exact tab even with duplicate tabs, and keeps `revealLeaf` a no-op for the tab the user is already looking at), falling back to a `sourcePath` match while detached.
2. **Reveals that leaf**, mirroring `ChatView.focus()`.
3. **Waits (bounded, ~1s) for the pruned section to re-attach**, then runs the existing scroll-and-focus. The wait is condition-driven (`isConnected`) rather than a timing guess, and gives up silently — every failure path degrades to the previous behavior or better.

Foreground behavior is unchanged (the connected check passes immediately). Consciously deferred: in very long notes where the block stays pruned far from the scroll position, the click fronts the note but may not reach the block — if that shows up in practice, a targeted line-based scroll can be added.

## Related issue

None (found during manual verification; pre-existing gap from the embeddable-blocks work in #341).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed (Session Manager docs follow-up lands separately with the embeddable-blocks docs branch)

## Testing environment

- Agent: Claude Code (view-management fix — no agent runtime change). Verified: background-tab reveal + scroll + input focus, Session Manager highlight following, focus-cycling commands, foreground behavior unchanged, sidebar/floating regression check
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focusing for embedded code-block chats.
  * Automatically reveals and locates the correct markdown section before scrolling to and focusing the chat input.
  * Added bounded retry handling to ensure focus works reliably while the chat view is still being attached to the page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->