### PR TITLE
style: render custom agent sections like presets

### DIFF
--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -1261,29 +1261,32 @@ export class AgentClientSettingTab extends PluginSettingTab {
 			});
 		}
 
-		new Setting(containerEl).addButton((button) => {
-			button
-				.setButtonText("Add custom agent")
-				.setCta()
-				.onClick(async () => {
-					const newId = this.generateCustomAgentId();
-					const newDisplayName =
-						this.generateCustomAgentDisplayName();
-					this.plugin.settings.customAgents.push({
-						id: newId,
-						displayName: newDisplayName,
-						command: "",
-						args: [],
-						env: [],
+		new Setting(containerEl)
+			.setName("New custom agent")
+			.setDesc("Register any ACP-compatible agent.")
+			.addButton((button) => {
+				button
+					.setButtonText("Add custom agent")
+					.setCta()
+					.onClick(async () => {
+						const newId = this.generateCustomAgentId();
+						const newDisplayName =
+							this.generateCustomAgentDisplayName();
+						this.plugin.settings.customAgents.push({
+							id: newId,
+							displayName: newDisplayName,
+							command: "",
+							args: [],
+							env: [],
+						});
+						// Open the new agent's section so it can be configured
+						// right away.
+						this.openSections.add(`custom:${newId}`);
+						this.plugin.ensureDefaultAgentId();
+						await this.flushSettings();
+						this.renderContent();
 					});
-					// Open the new agent's section so it can be configured
-					// right away.
-					this.openSections.add(`custom:${newId}`);
-					this.plugin.ensureDefaultAgentId();
-					await this.flushSettings();
-					this.renderContent();
-				});
-		});
+			});
 	}
 
 	private renderCustomAgent(

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -1291,12 +1291,8 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		agent: CustomAgentSettings,
 		index: number,
 	) {
-		const blockEl = containerEl.createDiv({
-			cls: "agent-client-custom-agent",
-		});
-
 		this.renderCollapsibleAgentSection(
-			blockEl,
+			containerEl,
 			`custom:${agent.id}`,
 			agent.displayName || agent.id,
 			{

--- a/styles.css
+++ b/styles.css
@@ -149,15 +149,6 @@ If your plugin does not need CSS, delete this file.
 	text-decoration: underline;
 }
 
-/* ===== Settings Tab Custom Agent Block ===== */
-.agent-client-custom-agent {
-	padding: 16px;
-	margin-bottom: 24px;
-	background-color: var(--background-secondary);
-	border: 1px solid var(--background-modifier-border);
-	border-radius: 8px;
-}
-
 /* ===== Settings Tab Collapsible Agent Sections ===== */
 .agent-client-agent-summary {
 	display: flex;
@@ -165,13 +156,6 @@ If your plugin does not need CSS, delete this file.
 	gap: var(--size-4-2);
 	padding: var(--size-4-2) 0;
 	border-top: 1px solid var(--background-modifier-border);
-}
-
-/* Inside the bordered custom-agent card the border-top double-lines with
-   the card border — drop it there. */
-.agent-client-custom-agent .agent-client-agent-summary {
-	border-top: none;
-	padding-top: 0;
 }
 
 /* Text-like button: the summary is a real <button> for keyboard/focus,


### PR DESCRIPTION
## Description

Custom agents in the settings tab were still wrapped in a card (background, border, rounded corners) — a leftover from before the collapsible agent sections (#350), when custom agent settings were a flat list and the card was the only thing marking where one agent ended and the next began. Since #350 the summary rows mark those boundaries themselves, so the card had become a double border; the CSS even carried a correction rule (`border-top: none` inside the card) to hide the doubling.

- **Drop the card**: `renderCustomAgent` no longer creates the `agent-client-custom-agent` wrapper and renders the collapsible section directly, exactly like `renderPresetSettings`. Both card CSS rules (the card itself and the border-top correction) are deleted with it — the class is now referenced nowhere (grep-verified). Custom agents render identically to presets: summary rows separated by thin rules.
- **Label the "Add custom agent" row**: with the card gone, the bare-button setting row stood out in themes that box every setting item (it rendered as an empty card with a lone button). Instead of fighting the theme with CSS, the row now has a name ("New custom agent") and description, so it reads like every other setting row in any theme. The button label is unchanged (docs reference it).

No behavior change: section open/collapse state, the Enabled toggle, and the delete button all live in the summary row and are untouched.

## Related issue

None.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed (button label unchanged, so the custom-agents setup steps stay accurate)

## Testing environment

- Agent: N/A (settings tab layout only — no agent runtime change). Verified: sections render like presets, open/collapse + Enabled toggle + delete work, adding an agent opens its new section, empty state intact, light/dark themes checked
- OS: macOS

## Screenshots

<img width="781" height="236" alt="image" src="https://github.com/user-attachments/assets/01f04b9c-91a7-4f7a-ac98-4934781e874d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Improved the labeling and description of the “New custom agent” setting for clearer setup.
  * Updated custom agent sections for a more consistent layout with other agent settings.
  * Simplified custom agent styling and removed the documentation link hover underline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->