### PR TITLE
fix: stop resetting an emptied custom agent id mid-typing

### DIFF
--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -1341,20 +1341,23 @@ export class AgentClientSettingTab extends PluginSettingTab {
 				text.setPlaceholder("custom-agent")
 					.setValue(agent.id)
 					.onChange(async (value) => {
+						const trimmed = value.trim();
+						// An empty field is a transient state while retyping,
+						// not a committable id — keep the last valid id in
+						// settings and let the user keep typing. The blur
+						// handler below restores the field if it is abandoned
+						// empty.
+						if (trimmed.length === 0) {
+							return;
+						}
 						const previousId =
 							this.plugin.settings.customAgents[index].id;
-						const trimmed = value.trim();
-						let nextId = trimmed;
-						if (nextId.length === 0) {
-							nextId = this.generateCustomAgentId();
-							text.setValue(nextId);
-						}
-						this.plugin.settings.customAgents[index].id = nextId;
-						this.rekeyOpenSection(previousId, nextId);
+						this.plugin.settings.customAgents[index].id = trimmed;
+						this.rekeyOpenSection(previousId, trimmed);
 						if (
 							this.plugin.settings.defaultAgentId === previousId
 						) {
-							this.plugin.settings.defaultAgentId = nextId;
+							this.plugin.settings.defaultAgentId = trimmed;
 						}
 						this.plugin.ensureDefaultAgentId();
 						await this.flushSettings();
@@ -1377,6 +1380,20 @@ export class AgentClientSettingTab extends PluginSettingTab {
 				// keystroke: onChange commits every intermediate value, so a
 				// mid-typing collision check would misfire.
 				text.inputEl.addEventListener("blur", () => {
+					// Restore an abandoned-empty field: onChange skips empty
+					// values (transient while retyping), so settings still
+					// hold the last valid id — put it back into the visible
+					// field. Settings are unchanged, so no commit is needed.
+					// Fall through to the preset-collision check: the
+					// committed id may still be a reserved preset id (typed,
+					// committed, then emptied before this blur).
+					if (text.getValue().trim().length === 0) {
+						const currentId =
+							this.plugin.settings.customAgents[index]?.id;
+						if (currentId) {
+							text.setValue(currentId);
+						}
+					}
 					const committed =
 						this.plugin.settings.customAgents[index]?.id;
 					if (


### PR DESCRIPTION
## Description

Retyping a custom agent's ID was nearly impossible: the moment the field went empty (deleting the last character), the per-keystroke `onChange` regenerated the default id (`custom-agent`) and wrote it straight back into the input. Deleting `custom-agent` character by character snapped back to `custom-agent` on the last backspace — the only workaround was select-all-and-overwrite.

The repair logic itself is legitimate (ids are keys — section open-state, `defaultAgentId` retargeting, and every keystroke persists via `flushSettings()` — so settings must never hold an empty id), but it ran at the wrong time. The same field already established the right timing for exactly this reason: the preset-collision check validates **on blur**, with a comment noting that per-keystroke validation misfires because onChange commits every intermediate value.

This PR moves the empty handling to the same model:

- **onChange skips empty values entirely.** An empty field is a transient state while retyping; settings keep the last valid id, so the "no empty id in settings" invariant is now guaranteed by never committing one rather than by regenerating.
- **Blur restores an abandoned-empty field.** Since settings always hold the last valid id, the field just gets it back — no regeneration, no rekey, no save. The restore falls through to the existing preset-collision check, so the edge case "type a reserved preset id (committed), select-all delete, blur" still gets the suffix-rename repair.

The Display name field is deliberately left unchanged: its blank-means-fallback model suits a derived cosmetic value, while an identity key that is referenced elsewhere (fence `agent:` pins, saved sessions, per-agent last-used maps) should conservatively restore rather than silently swap to a generated default.

## Related issue

None (reported during manual testing).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed (no docs describe the old reset behavior)

## Testing environment

- Agent: N/A (settings tab input handling only). Verified: deleting an id character by character no longer snaps back, abandoning an empty field restores the last valid id on blur, the preset-collision repair still fires after an empty-field blur, open sections survive renames, and the default agent follows a rename
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom agent ID editing by allowing the field to remain temporarily empty while typing.
  * Prevented unintended ID changes when an empty value is abandoned.
  * Restored the last valid custom agent ID when leaving the field without entering a replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->