### PR TITLE
fix: stop sidebar chats from double-initializing when opened with an agent id

### DIFF
--- a/src/hooks/useAgentSession.ts
+++ b/src/hooks/useAgentSession.ts
@@ -107,6 +107,14 @@ export function useAgentSession(
 	const sessionRef = useRef(session);
 	sessionRef.current = session;
 
+	// Generation counter for createSession: a run superseded by a newer call
+	// must not paint its late result — success or failure — over the newer
+	// attempt (mirrors useAgentMessages' generationRef, #200). Without this,
+	// the superseded run's rejection ("ACP connection closed" after its
+	// process is killed by the newer initialize) lands AFTER the newer run
+	// cleared errorInfo, leaving a stale error banner over a working session.
+	const createGenerationRef = useRef(0);
+
 	// ============================================================
 	// Session Update Handler (session-level only)
 	// ============================================================
@@ -167,6 +175,7 @@ export function useAgentSession(
 
 	const createSession = useCallback(
 		async (overrideAgentId?: string, overrideCwd?: string) => {
+			const generation = ++createGenerationRef.current;
 			const effectiveCwd = overrideCwd || workingDirectory;
 			const settings = settingsAccess.getSnapshot();
 			const agentId = overrideAgentId || getDefaultAgentId(settings);
@@ -261,6 +270,11 @@ export function useAgentSession(
 					finalModes = restored.modes;
 				}
 
+				// Superseded by a newer createSession — its state is already
+				// authoritative; discard this run's result.
+				if (generation !== createGenerationRef.current) {
+					return;
+				}
 				setSession((prev) => ({
 					...prev,
 					sessionId: sessionResult.sessionId,
@@ -280,6 +294,9 @@ export function useAgentSession(
 					lastActivityAt: new Date(),
 				}));
 			} catch (error) {
+				if (generation !== createGenerationRef.current) {
+					return;
+				}
 				setSession((prev) => ({ ...prev, state: "error" }));
 				setErrorInfo({
 					title: "Session Creation Failed",

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -342,11 +342,13 @@ export const ChatPanel = React.memo(function ChatPanel({
 	// conversation before restoring it (prevents a restart loop).
 	const persistRestartedRef = useRef(false);
 	// Gate the mount-init session-creation effect: run on first mount, then
-	// re-run ONLY when the resolved agent identity actually changes (e.g. the
-	// sidebar's onAgentIdRestored late-applies a persisted agent). A bare
-	// run-once boolean would break that restoration path; keying on the agent
-	// still ignores agentCwd-driven agent.createSession reference churn, which
-	// is what caused the persist-restore re-spawn race.
+	// re-run ONLY when the resolved agent identity actually changes. The
+	// sidebar mounts after Obsidian delivers its view state (ChatView.
+	// renderPanel), so initialAgentId is normally static — but a late
+	// setState after the fallback mount can still change it, and keying on
+	// the agent ignores agentCwd-driven agent.createSession reference churn,
+	// which is what caused the persist-restore re-spawn race. A bare
+	// run-once boolean would break both paths.
 	const hasInitializedRef = useRef(false);
 	const lastInitAgentRef = useRef<string | undefined>(undefined);
 
@@ -758,14 +760,14 @@ export const ChatPanel = React.memo(function ChatPanel({
 	// ============================================================
 	// Initialize session on mount
 	useEffect(() => {
-		// Resolve the effective agent BEFORE comparing: the sidebar's React
-		// root can mount before Obsidian's setState delivers initialAgentId,
-		// so the first run sees undefined and spawns the default agent. When
-		// the persisted id arrives a moment later and resolves to that same
-		// default, an unresolved comparison (undefined !== id) would re-run
-		// createSession and kill the first process mid-initialize — the
-		// "ACP connection closed" banner. Resolving both runs to a concrete
-		// id makes them comparable.
+		// Resolve the effective agent BEFORE comparing, so the guard always
+		// keys on a concrete id. The sidebar now mounts after its view state
+		// arrives, but this stays as a defense layer: if the fallback mount
+		// ran first (setState never arrived or arrived late), the first run
+		// sees undefined here, and a later setState delivering an id that
+		// resolves to the same default must compare equal — otherwise it
+		// would re-run createSession and kill the first process
+		// mid-initialize ("ACP connection closed").
 		const resolvedAgent =
 			config?.agent ||
 			initialAgentId ||

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -342,13 +342,14 @@ export const ChatPanel = React.memo(function ChatPanel({
 	// conversation before restoring it (prevents a restart loop).
 	const persistRestartedRef = useRef(false);
 	// Gate the mount-init session-creation effect: run on first mount, then
-	// re-run ONLY when the resolved agent identity actually changes. The
-	// sidebar mounts after Obsidian delivers its view state (ChatView.
-	// renderPanel), so initialAgentId is normally static — but a late
-	// setState after the fallback mount can still change it, and keying on
-	// the agent ignores agentCwd-driven agent.createSession reference churn,
-	// which is what caused the persist-restore re-spawn race. A bare
-	// run-once boolean would break both paths.
+	// re-run ONLY when an explicit directive (embedded config pin or the
+	// view state's initialAgentId) names a different agent than the last
+	// launch. The sidebar mounts after Obsidian delivers its view state
+	// (ChatView.renderPanel), so initialAgentId is normally static — but a
+	// late setState after the fallback mount can still change it, and the
+	// guard must keep ignoring agentCwd-driven agent.createSession reference
+	// churn (the persist-restore re-spawn race). A bare run-once boolean
+	// would break the late-setState path.
 	const hasInitializedRef = useRef(false);
 	const lastInitAgentRef = useRef<string | undefined>(undefined);
 
@@ -760,24 +761,27 @@ export const ChatPanel = React.memo(function ChatPanel({
 	// ============================================================
 	// Initialize session on mount
 	useEffect(() => {
-		// Resolve the effective agent BEFORE comparing, so the guard always
-		// keys on a concrete id. The sidebar now mounts after its view state
-		// arrives, but this stays as a defense layer: if the fallback mount
-		// ran first (setState never arrived or arrived late), the first run
-		// sees undefined here, and a later setState delivering an id that
-		// resolves to the same default must compare equal — otherwise it
-		// would re-run createSession and kill the first process
-		// mid-initialize ("ACP connection closed").
-		const resolvedAgent =
-			config?.agent ||
-			initialAgentId ||
-			getDefaultAgentId(plugin.settingsService.getSnapshot());
+		// Only an explicit directive — the embedded config pin or the view
+		// state's initialAgentId — may re-run init after mount, and only
+		// when it names a different agent than the one this effect last
+		// launched. The ambient default is resolved once, at launch; it must
+		// NOT be re-resolved for the comparison, or a settings change (new
+		// or disabled default agent) would turn an unrelated effect re-run —
+		// agentCwd churn from restoring a session in another directory —
+		// into a rogue createSession that kills the live session. The
+		// directive comparison still covers the fallback-mount path: a late
+		// setState delivering the id the default already resolved to
+		// compares equal to lastInitAgentRef and is skipped.
+		const directive = config?.agent || initialAgentId;
 		if (
 			hasInitializedRef.current &&
-			lastInitAgentRef.current === resolvedAgent
+			(!directive || directive === lastInitAgentRef.current)
 		) {
 			return;
 		}
+		const resolvedAgent =
+			directive ||
+			getDefaultAgentId(plugin.settingsService.getSnapshot());
 		hasInitializedRef.current = true;
 		lastInitAgentRef.current = resolvedAgent;
 		logger.log("[Debug] Starting connection setup via useSession...");

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -13,7 +13,10 @@ import {
 import type { AttachedFile, ChatInputState, ChatMessage } from "../types/chat";
 import type { NoteMetadata } from "../services/vault-service";
 import { isSameDirectory } from "../utils/platform";
-import { computeSessionTitle } from "../services/session-helpers";
+import {
+	computeSessionTitle,
+	getDefaultAgentId,
+} from "../services/session-helpers";
 import { useHistoryModal } from "../hooks/useHistoryModal";
 import { useChatActions } from "../hooks/useChatActions";
 import { ChangeDirectoryModal } from "./ChangeDirectoryModal";
@@ -755,7 +758,18 @@ export const ChatPanel = React.memo(function ChatPanel({
 	// ============================================================
 	// Initialize session on mount
 	useEffect(() => {
-		const resolvedAgent = config?.agent || initialAgentId;
+		// Resolve the effective agent BEFORE comparing: the sidebar's React
+		// root can mount before Obsidian's setState delivers initialAgentId,
+		// so the first run sees undefined and spawns the default agent. When
+		// the persisted id arrives a moment later and resolves to that same
+		// default, an unresolved comparison (undefined !== id) would re-run
+		// createSession and kill the first process mid-initialize — the
+		// "ACP connection closed" banner. Resolving both runs to a concrete
+		// id makes them comparable.
+		const resolvedAgent =
+			config?.agent ||
+			initialAgentId ||
+			getDefaultAgentId(plugin.settingsService.getSnapshot());
 		if (
 			hasInitializedRef.current &&
 			lastInitAgentRef.current === resolvedAgent

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -5,7 +5,7 @@ import type {
 	SessionStatus,
 } from "../services/view-registry";
 import * as React from "react";
-const { useState, useEffect, useMemo, useCallback } = React;
+const { useMemo, useCallback } = React;
 import { createRoot, Root } from "react-dom/client";
 
 import type AgentClientPlugin from "../plugin";
@@ -35,13 +35,6 @@ function ChatComponent({
 	viewId: string;
 }) {
 	// ============================================================
-	// Agent ID State (synced with Obsidian view state)
-	// ============================================================
-	const [restoredAgentId, setRestoredAgentId] = useState<string | undefined>(
-		view.getInitialAgentId() ?? undefined,
-	);
-
-	// ============================================================
 	// Context Value
 	// ============================================================
 	const contextValue = useMemo(
@@ -53,17 +46,6 @@ function ChatComponent({
 		}),
 		[plugin, view.acpClient, view.vaultService],
 	);
-
-	// ============================================================
-	// Agent ID Restoration (ChatView-specific)
-	// Subscribe to agentId restoration from Obsidian's setState
-	// ============================================================
-	useEffect(() => {
-		const unsubscribe = view.onAgentIdRestored((agentId) => {
-			setRestoredAgentId(agentId);
-		});
-		return unsubscribe;
-	}, [view]);
 
 	// Stable so ChatPanel's title-update effect deps are value-stable.
 	const handleSessionTitleChanged = useCallback(
@@ -79,7 +61,11 @@ function ChatComponent({
 			<ChatPanel
 				variant="sidebar"
 				viewId={viewId}
-				initialAgentId={restoredAgentId}
+				// Read directly: the panel mounts only after setState has
+				// delivered the view state (ChatView.renderPanel), and any
+				// later setState re-renders this component, so the prop stays
+				// current without a subscription.
+				initialAgentId={view.getInitialAgentId() ?? undefined}
 				viewHost={view}
 				onRegisterCallbacks={(callbacks) =>
 					view.setCallbacks(callbacks)
@@ -106,9 +92,8 @@ export class ChatView extends ItemView implements IChatViewContainer {
 	readonly viewType: ChatViewType = "sidebar";
 	/** Initial agent ID passed via state (for openNewChatViewWithAgent) */
 	private initialAgentId: string | null = null;
-	/** Callbacks to notify React when agentId is restored from workspace state */
-	private agentIdRestoredCallbacks: Set<(agentId: string) => void> =
-		new Set();
+	/** Fallback timer: mounts with defaults if setState never arrives. */
+	private mountFallbackTimer: number | null = null;
 
 	// Services owned by this class (lifecycle managed here)
 	/** @internal Exposed to ChatComponent for context creation */
@@ -153,22 +138,18 @@ export class ChatView extends ItemView implements IChatViewContainer {
 
 	/**
 	 * Restore the view state from persistence.
-	 * Notifies React when agentId is restored so it can re-create the session.
+	 * Mounts the React tree on the first call — the panel must not render
+	 * before the view's state (which agent to launch) is known, or it would
+	 * spawn the default agent and immediately kill it when the persisted id
+	 * arrives. Later calls re-render so the panel picks up a changed id.
 	 */
 	async setState(
 		state: ChatViewState,
 		result: { history: boolean },
 	): Promise<void> {
-		const previousAgentId = this.initialAgentId;
 		this.initialAgentId = state.initialAgentId ?? null;
 		await super.setState(state, result);
-
-		// Notify React when agentId is restored and differs from previous value
-		if (this.initialAgentId && this.initialAgentId !== previousAgentId) {
-			this.agentIdRestoredCallbacks.forEach((cb) =>
-				cb(this.initialAgentId!),
-			);
-		}
+		this.renderPanel();
 	}
 
 	/**
@@ -187,18 +168,6 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		this.initialAgentId = agentId;
 		// Request workspace to save the updated state
 		this.app.workspace.requestSaveLayout();
-	}
-
-	/**
-	 * Register a callback to be notified when agentId is restored from workspace state.
-	 * Used by React components to sync with Obsidian's setState lifecycle.
-	 * @returns Unsubscribe function
-	 */
-	onAgentIdRestored(callback: (agentId: string) => void): () => void {
-		this.agentIdRestoredCallbacks.add(callback);
-		return () => {
-			this.agentIdRestoredCallbacks.delete(callback);
-		};
 	}
 
 	// ============================================================
@@ -335,14 +304,38 @@ export class ChatView extends ItemView implements IChatViewContainer {
 	}
 
 	onOpen() {
-		const container = this.containerEl.children[1];
-		container.empty();
-
 		// Create services owned by this class
 		this.acpClient = this.plugin.getOrCreateAcpClient(this.viewId);
 		this.vaultService = new VaultService(this.plugin);
 
-		this.root = createRoot(container);
+		// Register with plugin's view registry
+		this.plugin.viewRegistry.register(this);
+
+		// Do NOT mount yet: Obsidian delivers the view state via setState()
+		// during setViewState, and the panel must know which agent to launch
+		// before it renders (mounting early spawns the default agent and
+		// kills it when the persisted id arrives a moment later). The timer
+		// is a safety net for any open path that skips setState — it mounts
+		// with defaults, degrading to the pre-state-driven behavior.
+		this.mountFallbackTimer = window.setTimeout(() => {
+			this.renderPanel();
+		}, 0);
+
+		return Promise.resolve();
+	}
+
+	/**
+	 * Mount (first call) or re-render (later calls) the React tree.
+	 * Re-rendering the same element makes ChatComponent re-read
+	 * getInitialAgentId(), so a setState that changes the agent flows into
+	 * ChatPanel as a prop change and its mount-init guard re-initializes.
+	 */
+	private renderPanel(): void {
+		if (!this.root) {
+			const container = this.containerEl.children[1];
+			container.empty();
+			this.root = createRoot(container);
+		}
 		this.root.render(
 			<ChatComponent
 				plugin={this.plugin}
@@ -350,15 +343,16 @@ export class ChatView extends ItemView implements IChatViewContainer {
 				viewId={this.viewId}
 			/>,
 		);
-
-		// Register with plugin's view registry
-		this.plugin.viewRegistry.register(this);
-
-		return Promise.resolve();
 	}
 
 	async onClose(): Promise<void> {
 		this.logger.log("[ChatView] onClose() called");
+
+		// Cancel a pending fallback mount (view closed within the tick).
+		if (this.mountFallbackTimer !== null) {
+			window.clearTimeout(this.mountFallbackTimer);
+			this.mountFallbackTimer = null;
+		}
 
 		// Unregister from plugin's view registry
 		this.plugin.viewRegistry.unregister(this.viewId);

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -331,6 +331,14 @@ export class ChatView extends ItemView implements IChatViewContainer {
 	 * ChatPanel as a prop change and its mount-init guard re-initializes.
 	 */
 	private renderPanel(): void {
+		// Any render supersedes the pending fallback mount: cancel it so it
+		// cannot fire a redundant re-render after setState already mounted
+		// the panel (on the normal path the timer always loses this race —
+		// the setState chain is microtasks, the timer a macrotask).
+		if (this.mountFallbackTimer !== null) {
+			window.clearTimeout(this.mountFallbackTimer);
+			this.mountFallbackTimer = null;
+		}
 		if (!this.root) {
 			const container = this.containerEl.children[1];
 			container.empty();


### PR DESCRIPTION
## Description

Opening a sidebar chat with an agent id (the **Open new chat view** command, agent buttons, workspace restore) initialized the session twice: React mounted before Obsidian's `setState` delivered `initialAgentId`, so the first run spawned the default agent, and the late-arriving id re-ran init and killed that first process mid-initialize. Depending on timing this left a stale "Session Creation Failed: ACP connection closed" banner over a perfectly working chat — and it always wasted a full agent spawn, the plugin's heaviest operation.

Four commits, each an independent mechanism:

1. **`fix(chat-panel): resolve the default agent before guarding mount init`** — the mount-init guard compares concrete agent ids, so "undefined (= use the default)" and the late-delivered default id no longer count as different agents.
2. **`fix(session): drop superseded createSession results`** — a generation counter (mirroring `useAgentMessages`' pattern from #200) makes a superseded `createSession` run discard its late result — success or failure — instead of painting a stale error banner over the newer attempt.
3. **`fix(chat-view): mount the panel after Obsidian delivers the view state`** — the structural fix. `ChatView` no longer mounts React in `onOpen` with a guessed agent and patches afterwards; it mounts on the first `setState` (with a `setTimeout(0)` fallback for open paths that never deliver state), making `initialAgentId` an ordinary settled prop. The `onAgentIdRestored` callback machinery is deleted outright. Agent-pinned opens and workspace restores now spawn exactly one process — the right one.
4. **`fix(chat-panel): re-init only on an explicit agent directive`** — fixes a regression a multi-lens review caught in commit 1: re-resolving the ambient default inside the guard comparison let a default-agent settings change plus `agentCwd` churn (e.g. restoring a session from another directory) fire a rogue `createSession` that killed the live session. Only an explicit directive (embedded pin / view-state id) may re-run init; the default is resolved once, at launch.

All `setState` orderings stay correct: the normal path mounts once with the settled id; if `setState` never arrives, the fallback mounts with defaults (the old behavior); if it arrives late, the re-render flows the id through the guard and commit 2 silences the superseded run.

## Related issue

None (tracked in the local backlog since 2026-07-04; found during the embeddable-blocks right-pane verification).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" warnings are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed (no user-facing docs affected)

## Testing environment

- Agent: Claude Code + OpenCode. Verified: agent-pinned button spawns only the pinned agent (no default spawn/kill, no console error); **Open new chat view** single spawn with no banner; workspace restore of non-default-agent views; different-cwd history restore after changing the default agent keeps the live session; autoSend queued delivery; sidebar/floating/embedded and agent switching regression pass
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale session-creation results from overwriting newer session status or error information.
  * Improved restoring of previously selected agents so the chat initializes with the correct saved selection.
  * Updated chat panel rendering to avoid showing a default agent while persisted state is still loading, with safe cleanup when closing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->