### PR TITLE
fix: honor the agent pin and the disabled setting when buttons open floating chats

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -772,7 +772,17 @@ export default class AgentClientPlugin extends Plugin {
 		initialExpanded = false,
 		initialPosition?: { x: number; y: number },
 		initialAgentId?: string,
-	): FloatingViewContainer {
+	): FloatingViewContainer | null {
+		// Single choke point for the setting: commands, the floating button,
+		// and the onload bootstrap are already gated upstream, but agent
+		// buttons and the in-window "new window" action are not. A window
+		// created while the feature is off becomes unreachable after a
+		// minimize (the button and every floating command are hidden or
+		// disabled with the setting), so refuse creation outright.
+		if (!this.settings.enableFloatingChat) {
+			new Notice("[Agent Client] Floating chat is disabled in settings.");
+			return null;
+		}
 		// instanceId is just the counter (e.g., "0", "1", "2")
 		// FloatingViewContainer will create viewId as "floating-chat-{instanceId}"
 		const instanceId = String(this.floatingChatCounter++);
@@ -1064,7 +1074,7 @@ export default class AgentClientPlugin extends Plugin {
 				undefined,
 				agentId,
 			);
-			targetViewId = container.viewId;
+			targetViewId = container?.viewId ?? null;
 		} else if (viewType === "editor-tab") {
 			const leaf = this.app.workspace.getLeaf("tab");
 			await leaf.setViewState({

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1065,7 +1065,9 @@ export default class AgentClientPlugin extends Plugin {
 					? this.findNearestEmbeddedChat(sourcePath, lineStart)
 					: null;
 			if (!targetViewId) {
-				new Notice("No embedded chat block found in this note.");
+				new Notice(
+					"[Agent Client] No embedded chat block found in this note.",
+				);
 				return;
 			}
 		} else if (viewType === "floating") {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -771,11 +771,18 @@ export default class AgentClientPlugin extends Plugin {
 	openNewFloatingChat(
 		initialExpanded = false,
 		initialPosition?: { x: number; y: number },
-	): void {
+		initialAgentId?: string,
+	): FloatingViewContainer {
 		// instanceId is just the counter (e.g., "0", "1", "2")
 		// FloatingViewContainer will create viewId as "floating-chat-{instanceId}"
 		const instanceId = String(this.floatingChatCounter++);
-		createFloatingChat(this, instanceId, initialExpanded, initialPosition);
+		return createFloatingChat(
+			this,
+			instanceId,
+			initialExpanded,
+			initialPosition,
+			initialAgentId,
+		);
 	}
 
 	findNearestEmbeddedChat(
@@ -1052,9 +1059,12 @@ export default class AgentClientPlugin extends Plugin {
 				return;
 			}
 		} else if (viewType === "floating") {
-			const counterBefore = this.floatingChatCounter;
-			this.openNewFloatingChat(true);
-			targetViewId = `floating-chat-${counterBefore}`;
+			const container = this.openNewFloatingChat(
+				true,
+				undefined,
+				agentId,
+			);
+			targetViewId = container.viewId;
 		} else if (viewType === "editor-tab") {
 			const leaf = this.app.workspace.getLeaf("tab");
 			await leaf.setViewState({

--- a/src/ui/AgentButtonBlock.tsx
+++ b/src/ui/AgentButtonBlock.tsx
@@ -54,7 +54,7 @@ function AgentButtonBlockComponent({
 			});
 		} catch (error) {
 			console.error("[Agent Client] runPromptInChat failed:", error);
-			new Notice("Failed to open chat with prompt.");
+			new Notice("[Agent Client] Failed to open chat with prompt.");
 		}
 	}, [
 		plugin,

--- a/src/ui/FloatingChatView.tsx
+++ b/src/ui/FloatingChatView.tsx
@@ -95,6 +95,7 @@ export class FloatingViewContainer implements IChatViewContainer {
 	mount(
 		initialExpanded: boolean,
 		initialPosition?: { x: number; y: number },
+		initialAgentId?: string,
 	): void {
 		this.root = createRoot(this.containerEl);
 		this.root.render(
@@ -103,6 +104,7 @@ export class FloatingViewContainer implements IChatViewContainer {
 				viewId={this.viewId}
 				initialExpanded={initialExpanded}
 				initialPosition={initialPosition}
+				initialAgentId={initialAgentId}
 				onRegisterCallbacks={(cbs) => {
 					this.callbacks = cbs;
 				}}
@@ -239,6 +241,8 @@ interface FloatingChatComponentProps {
 	viewId: string;
 	initialExpanded?: boolean;
 	initialPosition?: { x: number; y: number };
+	/** Agent to launch (from an agent button's pin); default agent when omitted. */
+	initialAgentId?: string;
 	onRegisterCallbacks?: (callbacks: ChatPanelCallbacks) => void;
 	onRegisterExpanded?: (setExpanded: (expanded: boolean) => void) => void;
 	onExpandedChange?: (expanded: boolean) => void;
@@ -250,6 +254,7 @@ function FloatingChatComponent({
 	viewId,
 	initialExpanded = false,
 	initialPosition,
+	initialAgentId,
 	onRegisterCallbacks,
 	onRegisterExpanded,
 	onExpandedChange,
@@ -517,6 +522,7 @@ function FloatingChatComponent({
 				<ChatPanel
 					variant="floating"
 					viewId={viewId}
+					initialAgentId={initialAgentId}
 					onRegisterCallbacks={onRegisterCallbacks}
 					onMinimize={handleMinimizeWindow}
 					onClose={handleCloseWindow}
@@ -534,6 +540,8 @@ function FloatingChatComponent({
  * @param plugin - The plugin instance
  * @param instanceId - The instance ID (e.g., "0", "1", "2")
  * @param initialExpanded - Whether to start expanded
+ * @param initialPosition - Initial window position (defaults to bottom-right)
+ * @param initialAgentId - Agent to launch (from an agent button's pin); default agent when omitted
  * @returns The FloatingViewContainer instance
  */
 export function createFloatingChat(
@@ -541,8 +549,9 @@ export function createFloatingChat(
 	instanceId: string,
 	initialExpanded = false,
 	initialPosition?: { x: number; y: number },
+	initialAgentId?: string,
 ): FloatingViewContainer {
 	const container = new FloatingViewContainer(plugin, instanceId);
-	container.mount(initialExpanded, initialPosition);
+	container.mount(initialExpanded, initialPosition, initialAgentId);
 	return container;
 }


### PR DESCRIPTION
## Description

Two pre-existing bugs in `runPromptInChat`'s floating branch, both surfaced by the sidebar double-init review (#363):

**The agent pin was silently dropped.** Every view type carries an agent pin on its own channel — leaf views via Obsidian's view state (`state.initialAgentId`), embedded blocks via the fence's `agent:` field — but floating chats had no channel at all: `openNewFloatingChat(initialExpanded, initialPosition)` had no agent parameter, and the floating `<ChatPanel>` render passed no `initialAgentId` prop. A button with `viewType: floating` and a pinned agent opened the **default** agent instead, and the prompt (including autoSend) was delivered there. The pin now rides the existing creation-parameter chain (`openNewFloatingChat` → `createFloatingChat` → `mount` → component props) into ChatPanel's existing `initialAgentId` prop — the same receiving end the sidebar uses, so #363's directive-based init guard applies unchanged. The branch also stops reconstructing the target view id from a counter snapshot: `openNewFloatingChat` now returns the created container and the id is read from it, matching the editor-tab and right-pane branches.

**Buttons bypassed the "Enable floating chat" setting.** The setting (off by default) gates every re-entry point — the floating button and all four floating commands — but not creation via agent buttons or the in-window "new window" action. A window created while the feature is off becomes unreachable after a minimize (collapse is `display: none`; only a Session Manager click can recover it). `openNewFloatingChat` is now the single choke point: while disabled it shows a notice and returns `null` before burning an instance id, and the button branch feeds that into the existing `if (!targetViewId) return`, so no undeliverable prompt is queued.

A third commit aligns the two remaining unprefixed notices (both from the #341 button work) with the project-wide `[Agent Client]` prefix convention (37 of 40 notices already use it).

## Related issue

None (tracked in the local backlog; found during the #363 multi-lens review).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" warnings are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed (no docs describe the broken behavior)

## Testing environment

- Agent: Claude Code + OpenCode. Verified: pinned button (pin ≠ default) with `viewType: floating` opens the pinned agent and delivers the prompt (with and without autoSend); unpinned button opens the default; commands, floating button, onload bootstrap instance, and the in-window "new window" action unchanged; with the setting disabled the button shows the notice, opens nothing, and queues nothing (re-enabling works normally); Session Manager shows the correct agent for pinned floating chats
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Floating chats can now open with a selected agent.
  * Floating chat creation respects the floating-chat setting and provides feedback when disabled.
  * Prompt actions target newly created floating chats more reliably.

* **Bug Fixes**
  * Improved messaging when no embedded chat is available.
  * Standardized error notifications for failed agent actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->