### PR TITLE
feat: add OpenCode as a preset agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Client Plugin - LLM Developer Guide
 
 ## Overview
-Obsidian plugin for AI agent interaction (Claude Code, Codex, Gemini CLI, Mistral Vibe, custom agents) via ACP.
+Obsidian plugin for AI agent interaction (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, custom agents) via ACP.
 
 **Tech**: React 19, TypeScript, Obsidian API, Agent Client Protocol (ACP)
 
@@ -334,6 +334,7 @@ interface ISettingsAccess {
 - Codex: `@zed-industries/codex-acp` (OPENAI_API_KEY)
 - Gemini CLI: `@google/gemini-cli` (GEMINI_API_KEY)
 - Mistral Vibe: `mistral-vibe` (MISTRAL_API_KEY)
+- OpenCode: `opencode-ai` (CLI-managed auth, no API key env)
 - Custom: Any ACP-compatible agent
 
 ---

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="https://www.buymeacoffee.com/rait09" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" width="180" height="50" ></a>
 </p>
 
-AIエージェント（Claude Code、Codex、Gemini CLI、Mistral Vibe）をObsidianに直接統合。Vault内からAIアシスタントとチャットできます。
+AIエージェント（Claude Code、Codex、Gemini CLI、Mistral Vibe、OpenCode）をObsidianに直接統合。Vault内からAIアシスタントとチャットできます。
 
 このプラグインは、Zed の [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/agent-client-protocol) で構築されています。
 
@@ -27,7 +27,7 @@ https://github.com/user-attachments/assets/1c538349-b3fb-44dd-a163-7331cbca7824
 - **ノートメンション**: `@ノート名`でノートを参照（ノート内の `[[wikilink]]` の解決済みパスもエージェントに渡る）
 - **画像添付**: チャットに画像をペーストまたはドラッグ&ドロップ
 - **スラッシュコマンド**: エージェントが提供する`/`コマンドを使用
-- **マルチエージェント**: Claude Code、Codex、Gemini CLI、Mistral Vibe、カスタムエージェントを切り替え
+- **マルチエージェント**: Claude Code、Codex、Gemini CLI、Mistral Vibe、OpenCode、カスタムエージェントを切り替え
 - **マルチセッション**: 複数のエージェントを別々のビューで同時実行
 - **フローティングチャット**: 素早くアクセスできる折りたたみ可能なチャットウィンドウ
 - **モード・モデル切り替え**: チャット画面からAIモデルやエージェントモードを変更
@@ -97,7 +97,8 @@ https://github.com/user-attachments/assets/1c538349-b3fb-44dd-a163-7331cbca7824
 - [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html)
 - [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html)
 - [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html)
-- [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)（OpenCode、Qwen Code、Kiroなど）
+- [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html)
+- [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)（Qwen Code、Kiroなど）
 
 **[ドキュメント全文](https://rait-09.github.io/obsidian-agent-client/)**
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://www.buymeacoffee.com/rait09" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" width="180" height="50" ></a>
 </p>
 
-Bring AI agents (Claude Code, Codex, Gemini CLI, Mistral Vibe) directly into Obsidian. Chat with your AI assistant right from your vault.
+Bring AI agents (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode) directly into Obsidian. Chat with your AI assistant right from your vault.
 
 Built on [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/agent-client-protocol) by Zed.
 
@@ -31,7 +31,7 @@ https://github.com/user-attachments/assets/1c538349-b3fb-44dd-a163-7331cbca7824
 - **Note Mentions**: Reference your notes with `@notename` syntax; the agent also sees resolved paths for `[[wikilinks]]` inside them
 - **Image Attachments**: Paste or drag-and-drop images into the chat
 - **Slash Commands**: Use `/` commands provided by your agent
-- **Multi-Agent Support**: Switch between Claude Code, Codex, Gemini CLI, Mistral Vibe, and custom agents
+- **Multi-Agent Support**: Switch between Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, and custom agents
 - **Multi-Session**: Run multiple agents simultaneously in separate views
 - **Floating Chat**: A persistent, collapsible chat window for quick access
 - **Mode & Model Switching**: Change AI models and agent modes from the chat
@@ -101,7 +101,8 @@ Open a terminal (Terminal on macOS/Linux, PowerShell on Windows) and run the fol
 - [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html)
 - [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html)
 - [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html)
-- [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html) (OpenCode, Qwen Code, Kiro, etc.)
+- [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html)
+- [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html) (Qwen Code, Kiro, etc.)
 
 **[Full Documentation](https://rait-09.github.io/obsidian-agent-client/)**
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -60,6 +60,7 @@ export default defineConfig({
           { text: "Codex", link: "/agent-setup/codex" },
           { text: "Gemini CLI", link: "/agent-setup/gemini-cli" },
           { text: "Mistral Vibe", link: "/agent-setup/mistral-vibe" },
+          { text: "OpenCode", link: "/agent-setup/opencode" },
           { text: "Custom Agents", link: "/agent-setup/custom-agents" },
         ],
       },

--- a/docs/agent-setup/custom-agents.md
+++ b/docs/agent-setup/custom-agents.md
@@ -4,7 +4,7 @@ You can use any agent that implements the [Agent Client Protocol (ACP)](https://
 
 ## Install and Configure
 
-1. Install your ACP-compatible agent (e.g., [OpenCode](https://github.com/anomalyco/opencode), [Qwen Code](https://github.com/QwenLM/qwen-code), [Kiro](https://kiro.dev/)).
+1. Install your ACP-compatible agent (e.g., [Qwen Code](https://github.com/QwenLM/qwen-code), [Kiro](https://kiro.dev/)).
 
 2. Open **Settings → Agent Client** and scroll to **Custom Agents** section.
 
@@ -13,21 +13,15 @@ You can use any agent that implements the [Agent Client Protocol (ACP)](https://
 4. Configure the agent:
    - **Agent ID**: Unique identifier (e.g., `my-agent`)
    - **Display name**: Name shown in menus (e.g., `My Agent`)
-   - **Path**: Command name or absolute path to the agent executable. The command name alone (e.g., `opencode`) works in many cases. If the agent is not found automatically, set the full path, or click **Auto-detect**.
+   - **Path**: Command name or absolute path to the agent executable. The command name alone (e.g., `qwen`) works in many cases. If the agent is not found automatically, set the full path, or click **Auto-detect**.
    - **Arguments**: Command-line arguments, one per line (if required)
    - **Environment variables**: `KEY=VALUE` pairs, one per line (if required)
 
 ## Configuration Examples
 
-### OpenCode
-
-| Field | Value |
-|-------|-------|
-| **Agent ID** | `opencode` |
-| **Display name** | `OpenCode` |
-| **Path** | `opencode` |
-| **Arguments** | `acp` |
-| **Environment variables** | (optional) |
+::: tip OpenCode
+OpenCode is now a built-in preset — see [OpenCode Setup](./opencode). If you previously configured it here as a custom agent with the id `opencode`, your settings migrate to the preset automatically.
+:::
 
 ### Qwen Code
 

--- a/docs/agent-setup/index.md
+++ b/docs/agent-setup/index.md
@@ -10,13 +10,14 @@ Agent Client supports multiple AI agents through the [Agent Client Protocol (ACP
 | [Codex](./codex) | OpenAI | `@zed-industries/codex-acp` |
 | [Gemini CLI](./gemini-cli) | Google | `@google/gemini-cli` |
 | [Mistral Vibe](./mistral-vibe) | Mistral AI | `mistral-vibe` |
+| [OpenCode](./opencode) | Multi-provider | `opencode-ai` |
 | [Custom Agents](./custom-agents) | Various | Any ACP-compatible agent |
 
 ## Common Setup Steps
 
 All agents follow a similar setup pattern:
 
-1. **Install the agent** — see each agent's setup page for the exact command (npm for Claude Code / Codex / Gemini CLI; `curl` on macOS/Linux or `uv` on Windows for Mistral Vibe)
+1. **Install the agent** — see each agent's setup page for the exact command (npm for Claude Code / Codex / Gemini CLI; `curl` on macOS/Linux or `uv` on Windows for Mistral Vibe; `curl` or npm for OpenCode)
 2. **Set up authentication** (API key or account login)
 
 The plugin resolves bare command names through your login shell's PATH, so path configuration is often not needed. If the agent is not found automatically, use `which` (macOS/Linux) or `where.exe` (Windows) to find the path and configure it in Settings → Agent Client.

--- a/docs/agent-setup/opencode.md
+++ b/docs/agent-setup/opencode.md
@@ -54,7 +54,7 @@ opencode
 Credentials are stored in `~/.local/share/opencode/auth.json` and are picked up by the `opencode acp` process that Agent Client starts. You can also configure providers from the command line with `opencode auth login`.
 
 ::: tip Migrating from a custom agent
-If you previously set up OpenCode as a custom agent with the id `opencode` (as these docs once described), your settings are migrated to the preset automatically — pinned buttons and saved sessions keep working.
+If you previously set up OpenCode as a custom agent with the id `opencode` (as these docs once described), your settings are migrated to the preset automatically — saved sessions keep working.
 :::
 
 ## Verify Setup

--- a/docs/agent-setup/opencode.md
+++ b/docs/agent-setup/opencode.md
@@ -1,0 +1,66 @@
+# OpenCode Setup
+
+OpenCode is an open-source coding agent that works with many LLM providers. It communicates via ACP through the `opencode acp` command.
+
+## Install and Configure
+
+Open a terminal (Terminal on macOS/Linux, PowerShell on Windows) and run the following commands.
+
+1. Install OpenCode:
+
+::: code-group
+
+```bash [macOS/Linux]
+curl -fsSL https://opencode.ai/install | bash
+```
+
+```powershell [Windows]
+npm install -g opencode-ai
+```
+
+:::
+
+Other installers (Homebrew, Scoop, Chocolatey) are listed in the [OpenCode docs](https://opencode.ai/docs/).
+
+2. Find the installation path:
+
+::: code-group
+
+```bash [macOS/Linux]
+which opencode
+# Example output: /Users/username/.opencode/bin/opencode
+```
+
+```cmd [Windows]
+where.exe opencode
+```
+
+:::
+
+3. Open **Settings → Agent Client**. The default command (`opencode`) works in many cases. If the agent is not found automatically, set the **OpenCode path** to the path found above, or click **Auto-detect**.
+
+## Authentication
+
+OpenCode manages provider credentials itself, so there is no API key field for it in Agent Client.
+
+1. Run OpenCode in your terminal:
+
+```bash
+opencode
+```
+
+2. Run the `/connect` command in the TUI, select a provider, and paste its API key.
+
+Credentials are stored in `~/.local/share/opencode/auth.json` and are picked up by the `opencode acp` process that Agent Client starts. You can also configure providers from the command line with `opencode auth login`.
+
+::: tip Migrating from a custom agent
+If you previously set up OpenCode as a custom agent with the id `opencode` (as these docs once described), your settings are migrated to the preset automatically — pinned buttons and saved sessions keep working.
+:::
+
+## Verify Setup
+
+1. Click the robot icon in the ribbon or use the command palette: **"Open chat view"**
+2. Switch to OpenCode from the agent dropdown in the chat header
+3. Try sending a message to verify the connection
+
+Having issues? See [Troubleshooting](/help/troubleshooting).

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -12,7 +12,8 @@ Agent Client supports multiple AI agents. Choose one to start:
 | **[Codex](/agent-setup/codex)** | OpenAI | via [Zed's adapter](https://github.com/zed-industries/codex-acp) |
 | **[Gemini CLI](/agent-setup/gemini-cli)** | Google | with `--experimental-acp` option |
 | **[Mistral Vibe](/agent-setup/mistral-vibe)** | Mistral AI | with built-in ACP support (`vibe-acp`) |
-| **[Custom](/agent-setup/custom-agents)** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., OpenCode, Qwen Code, Kiro) |
+| **[OpenCode](/agent-setup/opencode)** | Multi-provider | with built-in ACP support (`opencode acp`) |
+| **[Custom](/agent-setup/custom-agents)** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., Qwen Code, Kiro) |
 
 ## Step 2: Install and Configure the Agent
 
@@ -22,6 +23,7 @@ Follow the setup guide for your chosen agent:
 - [Codex Setup](/agent-setup/codex)
 - [Gemini CLI Setup](/agent-setup/gemini-cli)
 - [Mistral Vibe Setup](/agent-setup/mistral-vibe)
+- [OpenCode Setup](/agent-setup/opencode)
 - [Custom Agents](/agent-setup/custom-agents)
 
 Each guide covers installation, path configuration, and authentication.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -6,7 +6,7 @@ Frequently asked questions about Agent Client.
 
 ### What is Agent Client?
 
-Agent Client is an Obsidian plugin that lets you chat with AI agents directly within Obsidian. It supports Claude Code, Codex, Gemini CLI, Mistral Vibe, and any ACP-compatible agent. The plugin uses the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) to communicate with agents.
+Agent Client is an Obsidian plugin that lets you chat with AI agents directly within Obsidian. It supports Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, and any ACP-compatible agent. The plugin uses the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) to communicate with agents.
 
 ### Is this an official Anthropic/OpenAI/Google plugin?
 
@@ -81,7 +81,7 @@ Disabling only hides the agent from lists: already-open chats, restored sessions
 
 ### What is a custom agent?
 
-Any ACP-compatible agent beyond the preset ones (Claude Code, Codex, Gemini CLI, Mistral Vibe). You can add custom agents in **Settings → Agent Client → Custom agents**. See [Custom Agents](/agent-setup/custom-agents).
+Any ACP-compatible agent beyond the preset ones (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode). You can add custom agents in **Settings → Agent Client → Custom agents**. See [Custom Agents](/agent-setup/custom-agents).
 
 ### Do all agents support the same features?
 
@@ -95,7 +95,7 @@ Slash commands are provided by the agent, not the plugin. If the input placehold
 
 ### Why are the commands different from what I expected?
 
-Each agent provides its own commands. Claude Code, Codex, Gemini CLI, and Mistral Vibe all have different command sets. Refer to your agent's documentation for available commands.
+Each agent provides its own commands. Claude Code, Codex, Gemini CLI, Mistral Vibe, and OpenCode all have different command sets. Refer to your agent's documentation for available commands.
 
 ## Permissions
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -56,6 +56,9 @@ The agent requires authentication before processing requests.
 - Open **Settings → Agent Client → Preset agents → Mistral Vibe → API key**, click **Link...**, and link or create a secret. See [Mistral Vibe Setup](/agent-setup/mistral-vibe#authentication).
 - Or run `vibe` in Terminal first to authenticate with your Mistral account
 
+**For OpenCode:**
+- Run `opencode` in Terminal and use the `/connect` command to configure a provider (there is no API key field in the plugin). See [OpenCode Setup](/agent-setup/opencode#authentication).
+
 ### "No Authentication Methods" error
 
 The agent didn't provide authentication options.

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,8 @@ Agent Client is an Obsidian plugin that brings AI coding agents directly into yo
 | **[Codex](https://github.com/openai/codex)** | OpenAI | via [Zed’s adapter](https://github.com/zed-industries/codex-acp) |
 | **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** | Google | with `--experimental-acp` option |
 | **[Mistral Vibe](https://github.com/mistralai/mistral-vibe)** | Mistral AI | with built-in ACP support (`vibe-acp`) |
-| **Custom** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., OpenCode, Qwen Code, Kiro) |
+| **[OpenCode](https://github.com/anomalyco/opencode)** | Multi-provider | with built-in ACP support (`opencode acp`) |
+| **Custom** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., Qwen Code, Kiro) |
 
 ### Key Features
 

--- a/docs/reference/acp-support.md
+++ b/docs/reference/acp-support.md
@@ -6,7 +6,7 @@ This page documents which Agent Client Protocol (ACP) features are supported by 
 
 The [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) is an open standard for communication between AI agents and client applications. It defines how clients send prompts, receive responses, handle permissions, and manage sessions.
 
-Agent Client implements ACP as a **client**, communicating with ACP-compatible agents like Claude Code, Codex, Gemini CLI, and Mistral Vibe.
+Agent Client implements ACP as a **client**, communicating with ACP-compatible agents like Claude Code, Codex, Gemini CLI, Mistral Vibe, and OpenCode.
 
 ## Methods
 

--- a/docs/usage/context-files.md
+++ b/docs/usage/context-files.md
@@ -20,6 +20,7 @@ Each agent uses its own context file:
 | Codex | `AGENTS.md` |
 | Gemini CLI | `GEMINI.md` |
 | Mistral Vibe | `AGENTS.md` |
+| OpenCode | `AGENTS.md` (falls back to `CLAUDE.md`) |
 
 Place the context file in your **vault root** to have the agent read it automatically.
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -32,6 +32,7 @@ import {
 import { AgentClientSettingTab } from "./ui/SettingsTab";
 import { AcpClient } from "./acp/acp-client";
 import {
+	absorbCustomAgents,
 	normalizeCustomAgent,
 	ensureUniqueCustomAgentIds,
 	normalizePresetAgents,
@@ -1355,6 +1356,19 @@ export default class AgentClientPlugin extends Plugin {
 		const D = DEFAULT_SETTINGS;
 		let migratedSecrets = false;
 
+		// Docs-advised custom agents (e.g. the OpenCode recipe our docs
+		// carried before the preset existed) migrate into their new preset
+		// entries. Must run before ensureUniqueCustomAgentIds renames the
+		// colliding custom to "{id}-2".
+		const absorption = absorbCustomAgents(raw, PRESET_AGENTS);
+		raw.customAgents = absorption.customAgents;
+		raw.presetAgents = absorption.presetAgents;
+		for (const entry of absorption.absorbed) {
+			new Notice(
+				`[Agent Client] ${entry.displayName} is now a preset agent — your custom agent settings were migrated.`,
+			);
+		}
+
 		// Extract settings sub-objects
 		const re = obj(raw.exportSettings) ?? {};
 		const rd = obj(raw.displaySettings) ?? {};
@@ -1545,7 +1559,7 @@ export default class AgentClientPlugin extends Plugin {
 		this.ensureAtLeastOneEnabled();
 		this.ensureDefaultAgentId();
 
-		if (migratedSecrets) {
+		if (migratedSecrets || absorption.absorbed.length > 0) {
 			await this.saveSettings();
 		}
 	}

--- a/src/services/preset-agents.ts
+++ b/src/services/preset-agents.ts
@@ -76,6 +76,17 @@ export interface PresetAgentDefinition {
 	/** data.json 旧形式 top-level command-path key (claude / gemini only). */
 	legacyCommandPathKey?: string;
 	apiKey?: PresetAgentApiKey;
+	/**
+	 * Custom-agent id this preset absorbs on first load (one-shot migration).
+	 * Set ONLY for presets whose id our docs historically advised as a
+	 * custom-agent recipe — those customs are docs-followers by near
+	 * certainty, so adopting their settings preserves what the id meant
+	 * (fence pins, saved sessions, default agent). Deliberately NOT a
+	 * generic custom-id==presetId rule: customs colliding with the original
+	 * four preset ids are dead weight under preset-first resolution, and
+	 * absorbing them would overwrite live preset settings.
+	 */
+	absorbsCustomAgentId?: string;
 	installHint: PresetAgentInstallHint;
 	settingsCopy: PresetAgentSettingsCopy;
 	/** Page name under docs/agent-setup/ (for setup-guide references). */
@@ -197,6 +208,7 @@ export const PRESET_AGENTS: readonly PresetAgentDefinition[] = [
 		defaultDisplayName: "OpenCode",
 		defaultCommand: "opencode",
 		defaultArgs: ["acp"],
+		absorbsCustomAgentId: "opencode",
 		installHint: {
 			default: "curl -fsSL https://opencode.ai/install | bash",
 			nativeWindows: "npm install -g opencode-ai",

--- a/src/services/preset-agents.ts
+++ b/src/services/preset-agents.ts
@@ -192,6 +192,21 @@ export const PRESET_AGENTS: readonly PresetAgentDefinition[] = [
 		},
 		docsPage: "mistral-vibe",
 	},
+	{
+		presetId: "opencode",
+		defaultDisplayName: "OpenCode",
+		defaultCommand: "opencode",
+		defaultArgs: ["acp"],
+		installHint: {
+			default: "curl -fsSL https://opencode.ai/install | bash",
+			nativeWindows: "npm install -g opencode-ai",
+		},
+		settingsCopy: {
+			pathDesc:
+				'Command name or path to opencode. Use just "opencode" to let the login shell resolve it, or enter an absolute path.',
+		},
+		docsPage: "opencode",
+	},
 ];
 
 /**

--- a/src/services/settings-normalizer.ts
+++ b/src/services/settings-normalizer.ts
@@ -206,6 +206,57 @@ export type ApiKeyMigrator = (args: {
 	legacyPlain: string;
 }) => string;
 
+/** One absorption performed by absorbCustomAgents (drives the Notice + save). */
+export interface AbsorbedCustomAgent {
+	presetId: string;
+	displayName: string;
+}
+
+/**
+ * Absorb docs-advised custom agents into their new preset entries.
+ *
+ * Runs BEFORE custom-agent normalization: ensureUniqueCustomAgentIds would
+ * otherwise rename the colliding custom to "{id}-2", orphaning the user's
+ * settings while their pins and saved sessions silently retarget a fresh
+ * default preset. Only presets declaring `absorbsCustomAgentId` participate,
+ * and only while `raw.presetAgents` has no entry for them yet — the
+ * post-migration save writes one, which makes this a run-once migration.
+ * The matched custom becomes the preset's raw source (normalizePresetAgents
+ * then applies the usual sanitization) and is removed from customAgents.
+ */
+export const absorbCustomAgents = (
+	raw: Record<string, unknown>,
+	registry: readonly PresetAgentDefinition[],
+): {
+	customAgents: unknown[];
+	presetAgents: Record<string, unknown>;
+	absorbed: AbsorbedCustomAgent[];
+} => {
+	const customAgents: unknown[] = Array.isArray(raw.customAgents)
+		? [...(raw.customAgents as unknown[])]
+		: [];
+	const presetAgents = { ...(obj(raw.presetAgents) ?? {}) };
+	const absorbed: AbsorbedCustomAgent[] = [];
+
+	for (const def of registry) {
+		if (!def.absorbsCustomAgentId) continue;
+		if (obj(presetAgents[def.presetId])) continue;
+		const index = customAgents.findIndex(
+			(candidate) =>
+				str(obj(candidate)?.id, "") === def.absorbsCustomAgentId,
+		);
+		if (index === -1) continue;
+		const [entry] = customAgents.splice(index, 1);
+		presetAgents[def.presetId] = entry;
+		absorbed.push({
+			presetId: def.presetId,
+			displayName: def.defaultDisplayName,
+		});
+	}
+
+	return { customAgents, presetAgents, absorbed };
+};
+
 /** Registry defaults as a fresh user-settings entry (no user overrides). */
 export const defaultPresetAgentSettings = (
 	def: PresetAgentDefinition,

--- a/test/session-helpers.test.ts
+++ b/test/session-helpers.test.ts
@@ -58,6 +58,9 @@ function makeSettings(
 				args: ["--experimental-acp"],
 			}),
 			"mistral-vibe": preset("mistral-vibe", "Mistral Vibe", "vibe-acp"),
+			opencode: preset("opencode", "OpenCode", "opencode", {
+				args: ["acp"],
+			}),
 		},
 		customAgents: [],
 		defaultAgentId: "",
@@ -66,7 +69,7 @@ function makeSettings(
 }
 
 describe("getAvailableAgentsFromSettings", () => {
-	it("enumerates the four presets in order, then customs", () => {
+	it("enumerates the presets in registry order, then customs", () => {
 		const settings = makeSettings({
 			customAgents: [custom("my-custom", "My Custom")],
 		});
@@ -75,6 +78,7 @@ describe("getAvailableAgentsFromSettings", () => {
 			{ id: "codex-acp", displayName: "Codex" },
 			{ id: "gemini-cli", displayName: "Gemini CLI" },
 			{ id: "mistral-vibe", displayName: "Mistral Vibe" },
+			{ id: "opencode", displayName: "OpenCode" },
 			{ id: "my-custom", displayName: "My Custom" },
 		]);
 	});
@@ -104,6 +108,7 @@ describe("getAvailableAgentsFromSettings", () => {
 			"claude-code-acp",
 			"gemini-cli",
 			"mistral-vibe",
+			"opencode",
 			"my-custom",
 		]);
 	});
@@ -122,6 +127,7 @@ describe("getAllAgentsFromSettings", () => {
 			{ id: "codex-acp", displayName: "Codex" },
 			{ id: "gemini-cli", displayName: "Gemini CLI" },
 			{ id: "mistral-vibe", displayName: "Mistral Vibe" },
+			{ id: "opencode", displayName: "OpenCode" },
 			{ id: "off-custom", displayName: "Off Custom" },
 		]);
 	});
@@ -188,15 +194,15 @@ describe("findAgentSettings", () => {
 
 	it("does not let a preserved unknown presetAgents entry shadow a same-id custom", () => {
 		const settings = makeSettings({
-			customAgents: [custom("opencode", "My OpenCode")],
+			customAgents: [custom("future-preset", "My Future Agent")],
 		});
-		settings.presetAgents.opencode = preset(
-			"opencode",
+		settings.presetAgents["future-preset"] = preset(
+			"future-preset",
 			"Stale Synced Entry",
-			"opencode",
+			"future-preset",
 		);
-		expect(findAgentSettings(settings, "opencode")?.displayName).toBe(
-			"My OpenCode",
+		expect(findAgentSettings(settings, "future-preset")?.displayName).toBe(
+			"My Future Agent",
 		);
 	});
 

--- a/test/settings-normalizer.test.ts
+++ b/test/settings-normalizer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import {
+	absorbCustomAgents,
 	normalizePresetAgents,
 	defaultPresetAgentSettings,
 	normalizeCustomAgent,
@@ -232,6 +233,106 @@ describe("ensureUniqueCustomAgentIds with reserved ids", () => {
 			PRESET_IDS,
 		);
 		expect(result.map((a) => a.id)).toEqual(["dup", "dup-2"]);
+	});
+});
+
+describe("absorbCustomAgents", () => {
+	const docsAdvisedCustom = {
+		id: "opencode",
+		displayName: "My OpenCode",
+		command: "/opt/opencode",
+		args: ["acp", "--verbose"],
+		env: [{ key: "FOO", value: "bar" }],
+		enabled: false,
+	};
+
+	it("adopts the docs-advised custom as the preset's raw source", () => {
+		const raw = {
+			customAgents: [docsAdvisedCustom, { id: "my-agent" }],
+		};
+		const result = absorbCustomAgents(raw, PRESET_AGENTS);
+
+		expect(result.absorbed).toEqual([
+			{ presetId: "opencode", displayName: "OpenCode" },
+		]);
+		expect(result.customAgents).toEqual([{ id: "my-agent" }]);
+		expect(result.presetAgents.opencode).toBe(docsAdvisedCustom);
+
+		// The adopted entry goes through the usual preset normalization:
+		// id force-synced, apiKeySecretId defaulted, values preserved.
+		const normalized = normalizePresetAgents(
+			{ presetAgents: result.presetAgents },
+			PRESET_AGENTS,
+			noMigration,
+		);
+		expect(normalized.opencode).toEqual({
+			id: "opencode",
+			displayName: "My OpenCode",
+			apiKeySecretId: "",
+			command: "/opt/opencode",
+			args: ["acp", "--verbose"],
+			env: [{ key: "FOO", value: "bar" }],
+			enabled: false,
+		});
+	});
+
+	it("skips when the preset already has a stored entry", () => {
+		const raw = {
+			presetAgents: { opencode: { command: "opencode" } },
+			customAgents: [docsAdvisedCustom],
+		};
+		const result = absorbCustomAgents(raw, PRESET_AGENTS);
+		// The colliding custom is left for the "{id}-2" rename instead.
+		expect(result.absorbed).toEqual([]);
+		expect(result.customAgents).toEqual([docsAdvisedCustom]);
+		expect(result.presetAgents.opencode).toEqual({ command: "opencode" });
+	});
+
+	it("is a no-op without a matching custom", () => {
+		const raw = { customAgents: [{ id: "my-agent" }] };
+		const result = absorbCustomAgents(raw, PRESET_AGENTS);
+		expect(result.absorbed).toEqual([]);
+		expect(result.customAgents).toEqual([{ id: "my-agent" }]);
+	});
+
+	it("never absorbs into presets without the declaration", () => {
+		const raw = {
+			customAgents: [{ id: "mistral-vibe", command: "x" }],
+		};
+		const result = absorbCustomAgents(raw, PRESET_AGENTS);
+		expect(result.absorbed).toEqual([]);
+		expect(result.customAgents).toHaveLength(1);
+	});
+
+	it("is idempotent across a save round-trip", () => {
+		const first = absorbCustomAgents(
+			{ customAgents: [docsAdvisedCustom] },
+			PRESET_AGENTS,
+		);
+		expect(first.absorbed).toHaveLength(1);
+
+		const second = absorbCustomAgents(
+			{
+				customAgents: first.customAgents,
+				presetAgents: first.presetAgents,
+			},
+			PRESET_AGENTS,
+		);
+		expect(second.absorbed).toEqual([]);
+		expect(second.presetAgents.opencode).toBe(docsAdvisedCustom);
+	});
+
+	it("backfills empty absorbed args to the registry default", () => {
+		const result = absorbCustomAgents(
+			{ customAgents: [{ id: "opencode", command: "opencode", args: [] }] },
+			PRESET_AGENTS,
+		);
+		const normalized = normalizePresetAgents(
+			{ presetAgents: result.presetAgents },
+			PRESET_AGENTS,
+			noMigration,
+		);
+		expect(normalized.opencode.args).toEqual(["acp"]);
 	});
 });
 


### PR DESCRIPTION
## Description

PR4 of the preset-agents overhaul (#348–#351 shipped the registry, enable/disable, collapsible settings, and the "Preset agents" naming): **OpenCode becomes a preset agent**, and the custom-agent recipe our docs used to carry for it migrates automatically.

**Registry entry** (`feat(agents)`): one `PRESET_AGENTS` entry — command `opencode`, args `["acp"]`, install hint `curl -fsSL https://opencode.ai/install | bash` (npm on native Windows). Settings storage, enumeration, and the settings UI are all registry-driven, so no per-agent code exists elsewhere. OpenCode has **no API key wiring**: authentication is CLI-managed (run `/connect` in the OpenCode TUI; credentials live in `~/.local/share/opencode/auth.json` and are read by the `opencode acp` process we spawn). There is no official `OPENCODE_API_KEY`, and OpenCode is multi-provider, so a single env var would be wrong — verified against opencode.ai/docs on 2026-07-16.

**Absorption migration** (`feat(settings)`): these docs historically advised registering OpenCode as a **custom agent with id `opencode`**. Without migration, the existing load-time collision rename would move that custom to `opencode-2` while fence pins, saved sessions, and `defaultAgentId` silently retarget a fresh default preset. Instead, a new registry declaration (`absorbsCustomAgentId`) lets the pure `absorbCustomAgents` helper adopt the custom's settings (command/args/env/displayName/enabled) as the preset's raw source before custom normalization runs, remove the leftover custom, notify once, and persist — the saved preset entry makes the migration run-once. Deliberately **not** a generic `custom.id == presetId` rule: customs colliding with the original four preset ids are dead weight under preset-first resolution and must not overwrite live preset settings. Kiro (PR5) will reuse the same mechanism with a one-line declaration.

**Docs** (`docs(opencode)`): new setup page (install, `/connect` authentication, migration note), sidebar entry, and the full enumeration sweep (index/quick-start tables, FAQ, troubleshooting, ACP support, context files — `AGENTS.md` with `CLAUDE.md` fallback — READMEs, agents lists). The custom-agents page keeps Qwen Code and Kiro as examples and points OpenCode to the preset page.

Tests: 188 passing (6 new absorption tests: adoption, skip-when-present, no-op, original-ids-excluded, save-round-trip idempotency, args backfill). An adversarial multi-lens review ran post-implementation; the two doc leftovers it found are fixed in this PR, and the accepted low-severity limitation (downgrade/re-upgrade chain around the one-shot migration) is recorded in the plan document.

## Related issue

None (part of the preset overhaul plan; PR5 = Kiro follows).

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" warnings are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: OpenCode (real environment). Verified: preset appears with install hint and no API key row; spawns via `opencode acp` and chats; hand-crafted data.json migration (custom `opencode` absorbed with displayName/env preserved, Notice shown exactly once, no re-fire on reload); `agent: opencode` pins and saved sessions keep resolving after migration; preset-entry-present + custom collision falls to the existing `opencode-2` rename; existing four presets, custom agents, default-agent selection, and agent switching unaffected
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenCode as a built-in supported agent, including install, authentication, and verification in the agent flow.
  * Added automatic migration when an existing “OpenCode” custom-agent configuration is detected, moving it to the OpenCode preset.
* **Documentation**
  * Updated setup guides, Quick Start, FAQs, troubleshooting, context-file support, and ACP support docs to include OpenCode.
* **Tests**
  * Added/updated coverage for OpenCode availability and the custom→preset migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->