### PR TITLE
feat: add Kiro as a preset agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Client Plugin - LLM Developer Guide
 
 ## Overview
-Obsidian plugin for AI agent interaction (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, custom agents) via ACP.
+Obsidian plugin for AI agent interaction (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, custom agents) via ACP.
 
 **Tech**: React 19, TypeScript, Obsidian API, Agent Client Protocol (ACP)
 
@@ -335,6 +335,7 @@ interface ISettingsAccess {
 - Gemini CLI: `@google/gemini-cli` (GEMINI_API_KEY)
 - Mistral Vibe: `mistral-vibe` (MISTRAL_API_KEY)
 - OpenCode: `opencode-ai` (CLI-managed auth, no API key env)
+- Kiro: `kiro-cli` install script (KIRO_API_KEY, optional)
 - Custom: Any ACP-compatible agent
 
 ---

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@
   <a href="https://www.buymeacoffee.com/rait09" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" width="180" height="50" ></a>
 </p>
 
-AIエージェント（Claude Code、Codex、Gemini CLI、Mistral Vibe、OpenCode）をObsidianに直接統合。Vault内からAIアシスタントとチャットできます。
+AIエージェント（Claude Code、Codex、Gemini CLI、Mistral Vibe、OpenCode、Kiro）をObsidianに直接統合。Vault内からAIアシスタントとチャットできます。
 
 このプラグインは、Zed の [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/agent-client-protocol) で構築されています。
 
@@ -27,7 +27,7 @@ https://github.com/user-attachments/assets/1c538349-b3fb-44dd-a163-7331cbca7824
 - **ノートメンション**: `@ノート名`でノートを参照（ノート内の `[[wikilink]]` の解決済みパスもエージェントに渡る）
 - **画像添付**: チャットに画像をペーストまたはドラッグ&ドロップ
 - **スラッシュコマンド**: エージェントが提供する`/`コマンドを使用
-- **マルチエージェント**: Claude Code、Codex、Gemini CLI、Mistral Vibe、OpenCode、カスタムエージェントを切り替え
+- **マルチエージェント**: Claude Code、Codex、Gemini CLI、Mistral Vibe、OpenCode、Kiro、カスタムエージェントを切り替え
 - **マルチセッション**: 複数のエージェントを別々のビューで同時実行
 - **フローティングチャット**: 素早くアクセスできる折りたたみ可能なチャットウィンドウ
 - **モード・モデル切り替え**: チャット画面からAIモデルやエージェントモードを変更
@@ -98,7 +98,8 @@ https://github.com/user-attachments/assets/1c538349-b3fb-44dd-a163-7331cbca7824
 - [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html)
 - [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html)
 - [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html)
-- [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)（Qwen Code、Kiroなど）
+- [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html)
+- [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)（Qwen Codeなど）
 
 **[ドキュメント全文](https://rait-09.github.io/obsidian-agent-client/)**
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://www.buymeacoffee.com/rait09" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" width="180" height="50" ></a>
 </p>
 
-Bring AI agents (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode) directly into Obsidian. Chat with your AI assistant right from your vault.
+Bring AI agents (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro) directly into Obsidian. Chat with your AI assistant right from your vault.
 
 Built on [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/agent-client-protocol) by Zed.
 
@@ -31,7 +31,7 @@ https://github.com/user-attachments/assets/1c538349-b3fb-44dd-a163-7331cbca7824
 - **Note Mentions**: Reference your notes with `@notename` syntax; the agent also sees resolved paths for `[[wikilinks]]` inside them
 - **Image Attachments**: Paste or drag-and-drop images into the chat
 - **Slash Commands**: Use `/` commands provided by your agent
-- **Multi-Agent Support**: Switch between Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, and custom agents
+- **Multi-Agent Support**: Switch between Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, and custom agents
 - **Multi-Session**: Run multiple agents simultaneously in separate views
 - **Floating Chat**: A persistent, collapsible chat window for quick access
 - **Mode & Model Switching**: Change AI models and agent modes from the chat
@@ -102,7 +102,8 @@ Open a terminal (Terminal on macOS/Linux, PowerShell on Windows) and run the fol
 - [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html)
 - [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html)
 - [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html)
-- [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html) (Qwen Code, Kiro, etc.)
+- [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html)
+- [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html) (Qwen Code, etc.)
 
 **[Full Documentation](https://rait-09.github.io/obsidian-agent-client/)**
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -61,6 +61,7 @@ export default defineConfig({
           { text: "Gemini CLI", link: "/agent-setup/gemini-cli" },
           { text: "Mistral Vibe", link: "/agent-setup/mistral-vibe" },
           { text: "OpenCode", link: "/agent-setup/opencode" },
+          { text: "Kiro", link: "/agent-setup/kiro" },
           { text: "Custom Agents", link: "/agent-setup/custom-agents" },
         ],
       },

--- a/docs/agent-setup/custom-agents.md
+++ b/docs/agent-setup/custom-agents.md
@@ -4,7 +4,7 @@ You can use any agent that implements the [Agent Client Protocol (ACP)](https://
 
 ## Install and Configure
 
-1. Install your ACP-compatible agent (e.g., [Qwen Code](https://github.com/QwenLM/qwen-code), [Kiro](https://kiro.dev/)).
+1. Install your ACP-compatible agent (e.g., [Qwen Code](https://github.com/QwenLM/qwen-code)).
 
 2. Open **Settings → Agent Client** and scroll to **Custom Agents** section.
 
@@ -19,8 +19,8 @@ You can use any agent that implements the [Agent Client Protocol (ACP)](https://
 
 ## Configuration Examples
 
-::: tip OpenCode
-OpenCode is now a built-in preset — see [OpenCode Setup](./opencode). If you previously configured it here as a custom agent with the id `opencode`, your settings migrate to the preset automatically.
+::: tip OpenCode and Kiro
+OpenCode and Kiro are now built-in presets — see [OpenCode Setup](./opencode) and [Kiro Setup](./kiro). If you previously configured them here as custom agents (ids `opencode` / `kiro-cli`), your settings migrate to the presets automatically.
 :::
 
 ### Qwen Code
@@ -31,16 +31,6 @@ OpenCode is now a built-in preset — see [OpenCode Setup](./opencode). If you p
 | **Display name** | `Qwen Code` |
 | **Path** | `qwen` |
 | **Arguments** | `--experimental-acp` |
-| **Environment variables** | (optional) |
-
-### Kiro
-
-| Field | Value |
-|-------|-------|
-| **Agent ID** | `kiro-cli` |
-| **Display name** | `Kiro` |
-| **Path** | `kiro-cli` |
-| **Arguments** | `acp` |
 | **Environment variables** | (optional) |
 
 ## Authentication

--- a/docs/agent-setup/index.md
+++ b/docs/agent-setup/index.md
@@ -11,13 +11,14 @@ Agent Client supports multiple AI agents through the [Agent Client Protocol (ACP
 | [Gemini CLI](./gemini-cli) | Google | `@google/gemini-cli` |
 | [Mistral Vibe](./mistral-vibe) | Mistral AI | `mistral-vibe` |
 | [OpenCode](./opencode) | Multi-provider | `opencode-ai` |
+| [Kiro](./kiro) | AWS | install script |
 | [Custom Agents](./custom-agents) | Various | Any ACP-compatible agent |
 
 ## Common Setup Steps
 
 All agents follow a similar setup pattern:
 
-1. **Install the agent** — see each agent's setup page for the exact command (npm for Claude Code / Codex / Gemini CLI; `curl` on macOS/Linux or `uv` on Windows for Mistral Vibe; `curl` or npm for OpenCode)
+1. **Install the agent** — see each agent's setup page for the exact command (npm for Claude Code / Codex / Gemini CLI; `curl` on macOS/Linux or `uv` on Windows for Mistral Vibe; `curl` or npm for OpenCode; `curl` on macOS/Linux or PowerShell on Windows for Kiro)
 2. **Set up authentication** (API key or account login)
 
 The plugin resolves bare command names through your login shell's PATH, so path configuration is often not needed. If the agent is not found automatically, use `which` (macOS/Linux) or `where.exe` (Windows) to find the path and configure it in Settings → Agent Client.

--- a/docs/agent-setup/kiro.md
+++ b/docs/agent-setup/kiro.md
@@ -1,0 +1,79 @@
+# Kiro Setup
+
+Kiro is AWS's agentic coding tool. This page covers the **Kiro CLI** (`kiro-cli`) — distinct from the Kiro IDE — which communicates via ACP through the `kiro-cli acp` command (available since Kiro CLI 1.25.0).
+
+## Install and Configure
+
+Open a terminal (Terminal on macOS/Linux, PowerShell on Windows) and run the following commands.
+
+1. Install the Kiro CLI:
+
+::: code-group
+
+```bash [macOS/Linux]
+curl -fsSL https://cli.kiro.dev/install | bash
+```
+
+```powershell [Windows]
+irm 'https://cli.kiro.dev/install.ps1' | iex
+```
+
+:::
+
+::: warning Windows support
+The Kiro CLI requires **Windows 11**, and the install command must run in Windows Terminal or PowerShell (not Command Prompt). Other installers (AppImage, zip, .deb) are listed in the [Kiro CLI docs](https://kiro.dev/docs/cli/installation/).
+:::
+
+2. Find the installation path:
+
+::: code-group
+
+```bash [macOS/Linux]
+which kiro-cli
+# Example output: /Users/username/.local/bin/kiro-cli
+```
+
+```cmd [Windows]
+where.exe kiro-cli
+```
+
+:::
+
+3. Open **Settings → Agent Client**. The default command (`kiro-cli`) works in many cases. If the agent is not found automatically, set the **Kiro path** to the path found above, or click **Auto-detect**.
+
+## Authentication
+
+Choose one of the following methods:
+
+### Option A: Sign In (Interactive)
+
+1. Run the login flow in your terminal:
+
+```bash
+kiro-cli login
+```
+
+2. Sign in with GitHub, Google, AWS Builder ID, or your organization's identity provider.
+
+3. In **Settings → Agent Client**, leave the **API key field empty** — the `kiro-cli acp` process started by Agent Client reuses your session.
+
+### Option B: Kiro API Key
+
+API keys are available on Kiro Pro and higher tiers:
+
+1. Generate a key at [app.kiro.dev](https://app.kiro.dev)
+2. Enter it in **Settings → Agent Client → Kiro → API key** (stored in Obsidian's Keychain)
+
+A signed-in session takes precedence over the API key, so setting a key never breaks an existing login.
+
+::: tip Migrating from a custom agent
+If you previously set up Kiro as a custom agent with the id `kiro-cli` (as these docs once described), your settings are migrated to the preset automatically — saved sessions keep working. If your custom agent carried `KIRO_API_KEY` in its environment variables, consider moving it to the **API key** field so it is stored in Obsidian's Keychain instead of plain text.
+:::
+
+## Verify Setup
+
+1. Click the robot icon in the ribbon or use the command palette: **"Open chat view"**
+2. Switch to Kiro from the agent dropdown in the chat header
+3. Try sending a message to verify the connection
+
+Having issues? See [Troubleshooting](/help/troubleshooting).

--- a/docs/agent-setup/kiro.md
+++ b/docs/agent-setup/kiro.md
@@ -62,7 +62,7 @@ kiro-cli login
 API keys are available on Kiro Pro and higher tiers:
 
 1. Generate a key at [app.kiro.dev](https://app.kiro.dev)
-2. Enter it in **Settings → Agent Client → Kiro → API key** (stored in Obsidian's Keychain)
+2. Enter it in **Settings → Agent Client → Preset agents → Kiro → API key** (stored in Obsidian's Keychain)
 
 A signed-in session takes precedence over the API key, so setting a key never breaks an existing login.
 

--- a/docs/agent-setup/mistral-vibe.md
+++ b/docs/agent-setup/mistral-vibe.md
@@ -65,7 +65,7 @@ vibe
 If you prefer to use an API key for authentication:
 
 1. Get your API key from the [Mistral Console](https://console.mistral.ai/)
-2. Enter the API key in **Settings → Agent Client → Mistral Vibe → API key**
+2. Enter the API key in **Settings → Agent Client → Preset agents → Mistral Vibe → API key**
 
 ::: tip If the key isn't picked up
 If authentication still fails, set the key on the Vibe side instead: run `vibe --setup` in your terminal and configure your API key (it's stored in `~/.vibe/.env`). Then leave the **API key field empty** in Agent Client.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -13,7 +13,8 @@ Agent Client supports multiple AI agents. Choose one to start:
 | **[Gemini CLI](/agent-setup/gemini-cli)** | Google | with `--experimental-acp` option |
 | **[Mistral Vibe](/agent-setup/mistral-vibe)** | Mistral AI | with built-in ACP support (`vibe-acp`) |
 | **[OpenCode](/agent-setup/opencode)** | Multi-provider | with built-in ACP support (`opencode acp`) |
-| **[Custom](/agent-setup/custom-agents)** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., Qwen Code, Kiro) |
+| **[Kiro](/agent-setup/kiro)** | AWS | with built-in ACP support (`kiro-cli acp`) |
+| **[Custom](/agent-setup/custom-agents)** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., Qwen Code) |
 
 ## Step 2: Install and Configure the Agent
 
@@ -24,6 +25,7 @@ Follow the setup guide for your chosen agent:
 - [Gemini CLI Setup](/agent-setup/gemini-cli)
 - [Mistral Vibe Setup](/agent-setup/mistral-vibe)
 - [OpenCode Setup](/agent-setup/opencode)
+- [Kiro Setup](/agent-setup/kiro)
 - [Custom Agents](/agent-setup/custom-agents)
 
 Each guide covers installation, path configuration, and authentication.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -6,7 +6,7 @@ Frequently asked questions about Agent Client.
 
 ### What is Agent Client?
 
-Agent Client is an Obsidian plugin that lets you chat with AI agents directly within Obsidian. It supports Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, and any ACP-compatible agent. The plugin uses the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) to communicate with agents.
+Agent Client is an Obsidian plugin that lets you chat with AI agents directly within Obsidian. It supports Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, and any ACP-compatible agent. The plugin uses the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) to communicate with agents.
 
 ### Is this an official Anthropic/OpenAI/Google plugin?
 
@@ -81,7 +81,7 @@ Disabling only hides the agent from lists: already-open chats, restored sessions
 
 ### What is a custom agent?
 
-Any ACP-compatible agent beyond the preset ones (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode). You can add custom agents in **Settings → Agent Client → Custom agents**. See [Custom Agents](/agent-setup/custom-agents).
+Any ACP-compatible agent beyond the preset ones (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro). You can add custom agents in **Settings → Agent Client → Custom agents**. See [Custom Agents](/agent-setup/custom-agents).
 
 ### Do all agents support the same features?
 
@@ -95,7 +95,7 @@ Slash commands are provided by the agent, not the plugin. If the input placehold
 
 ### Why are the commands different from what I expected?
 
-Each agent provides its own commands. Claude Code, Codex, Gemini CLI, Mistral Vibe, and OpenCode all have different command sets. Refer to your agent's documentation for available commands.
+Each agent provides its own commands. Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, and Kiro all have different command sets. Refer to your agent's documentation for available commands.
 
 ## Permissions
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -59,6 +59,9 @@ The agent requires authentication before processing requests.
 **For OpenCode:**
 - Run `opencode` in Terminal and use the `/connect` command to configure a provider (there is no API key field in the plugin). See [OpenCode Setup](/agent-setup/opencode#authentication).
 
+**For Kiro:**
+- Run `kiro-cli login` in Terminal first to sign in, or link an API key (Kiro Pro and higher tiers) in **Settings → Agent Client → Preset agents → Kiro → API key**. See [Kiro Setup](/agent-setup/kiro#authentication).
+
 ### "No Authentication Methods" error
 
 The agent didn't provide authentication options.

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,8 @@ Agent Client is an Obsidian plugin that brings AI coding agents directly into yo
 | **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** | Google | with `--experimental-acp` option |
 | **[Mistral Vibe](https://github.com/mistralai/mistral-vibe)** | Mistral AI | with built-in ACP support (`vibe-acp`) |
 | **[OpenCode](https://github.com/anomalyco/opencode)** | Multi-provider | with built-in ACP support (`opencode acp`) |
-| **Custom** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., Qwen Code, Kiro) |
+| **[Kiro](https://kiro.dev/)** | AWS | with built-in ACP support (`kiro-cli acp`) |
+| **Custom** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., Qwen Code) |
 
 ### Key Features
 

--- a/docs/reference/acp-support.md
+++ b/docs/reference/acp-support.md
@@ -6,7 +6,7 @@ This page documents which Agent Client Protocol (ACP) features are supported by 
 
 The [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) is an open standard for communication between AI agents and client applications. It defines how clients send prompts, receive responses, handle permissions, and manage sessions.
 
-Agent Client implements ACP as a **client**, communicating with ACP-compatible agents like Claude Code, Codex, Gemini CLI, Mistral Vibe, and OpenCode.
+Agent Client implements ACP as a **client**, communicating with ACP-compatible agents like Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, and Kiro.
 
 ## Methods
 

--- a/docs/usage/context-files.md
+++ b/docs/usage/context-files.md
@@ -21,6 +21,7 @@ Each agent uses its own context file:
 | Gemini CLI | `GEMINI.md` |
 | Mistral Vibe | `AGENTS.md` |
 | OpenCode | `AGENTS.md` (falls back to `CLAUDE.md`) |
+| Kiro | `AGENTS.md` (also `.kiro/steering/*.md`) |
 
 Place the context file in your **vault root** to have the agent read it automatically.
 

--- a/src/services/preset-agents.ts
+++ b/src/services/preset-agents.ts
@@ -219,6 +219,27 @@ export const PRESET_AGENTS: readonly PresetAgentDefinition[] = [
 		},
 		docsPage: "opencode",
 	},
+	{
+		presetId: "kiro-cli",
+		defaultDisplayName: "Kiro",
+		defaultCommand: "kiro-cli",
+		defaultArgs: ["acp"],
+		absorbsCustomAgentId: "kiro-cli",
+		apiKey: {
+			envVarName: "KIRO_API_KEY",
+			settingDesc:
+				"Kiro API key (Kiro Pro and higher tiers). Required only for API-key auth — leave empty when signing in with kiro-cli login. Select from Obsidian's Keychain or create a new secret.",
+		},
+		installHint: {
+			default: "curl -fsSL https://cli.kiro.dev/install | bash",
+			nativeWindows: "irm 'https://cli.kiro.dev/install.ps1' | iex",
+		},
+		settingsCopy: {
+			pathDesc:
+				'Command name or path to kiro-cli. Use just "kiro-cli" to let the login shell resolve it, or enter an absolute path.',
+		},
+		docsPage: "kiro",
+	},
 ];
 
 /**

--- a/test/session-helpers.test.ts
+++ b/test/session-helpers.test.ts
@@ -61,6 +61,9 @@ function makeSettings(
 			opencode: preset("opencode", "OpenCode", "opencode", {
 				args: ["acp"],
 			}),
+			"kiro-cli": preset("kiro-cli", "Kiro", "kiro-cli", {
+				args: ["acp"],
+			}),
 		},
 		customAgents: [],
 		defaultAgentId: "",
@@ -79,6 +82,7 @@ describe("getAvailableAgentsFromSettings", () => {
 			{ id: "gemini-cli", displayName: "Gemini CLI" },
 			{ id: "mistral-vibe", displayName: "Mistral Vibe" },
 			{ id: "opencode", displayName: "OpenCode" },
+			{ id: "kiro-cli", displayName: "Kiro" },
 			{ id: "my-custom", displayName: "My Custom" },
 		]);
 	});
@@ -109,6 +113,7 @@ describe("getAvailableAgentsFromSettings", () => {
 			"gemini-cli",
 			"mistral-vibe",
 			"opencode",
+			"kiro-cli",
 			"my-custom",
 		]);
 	});
@@ -128,6 +133,7 @@ describe("getAllAgentsFromSettings", () => {
 			{ id: "gemini-cli", displayName: "Gemini CLI" },
 			{ id: "mistral-vibe", displayName: "Mistral Vibe" },
 			{ id: "opencode", displayName: "OpenCode" },
+			{ id: "kiro-cli", displayName: "Kiro" },
 			{ id: "off-custom", displayName: "Off Custom" },
 		]);
 	});
@@ -239,6 +245,7 @@ describe("buildAgentConfigWithApiKey", () => {
 		["codex-acp", "OPENAI_API_KEY"],
 		["gemini-cli", "GEMINI_API_KEY"],
 		["mistral-vibe", "MISTRAL_API_KEY"],
+		["kiro-cli", "KIRO_API_KEY"],
 	])("attaches the %s secret as %s", (agentId, envVarName) => {
 		const agentSettings = preset(agentId, "Name", "cmd", {
 			apiKeySecretId: "my-secret",

--- a/test/settings-normalizer.test.ts
+++ b/test/settings-normalizer.test.ts
@@ -276,6 +276,25 @@ describe("absorbCustomAgents", () => {
 		});
 	});
 
+	it("absorbs the docs-advised kiro-cli custom the same way", () => {
+		const kiroCustom = {
+			id: "kiro-cli",
+			displayName: "My Kiro",
+			command: "/opt/kiro-cli",
+			args: ["acp"],
+			env: [{ key: "KIRO_LOG_LEVEL", value: "debug" }],
+		};
+		const result = absorbCustomAgents(
+			{ customAgents: [kiroCustom] },
+			PRESET_AGENTS,
+		);
+		expect(result.absorbed).toEqual([
+			{ presetId: "kiro-cli", displayName: "Kiro" },
+		]);
+		expect(result.customAgents).toEqual([]);
+		expect(result.presetAgents["kiro-cli"]).toBe(kiroCustom);
+	});
+
 	it("skips when the preset already has a stored entry", () => {
 		const raw = {
 			presetAgents: { opencode: { command: "opencode" } },


### PR DESCRIPTION
## Description

PR5 — the final installment of the preset-agents overhaul (#348–#351 registry infrastructure, #365 OpenCode + the absorption mechanism): **Kiro becomes a preset agent**, and the custom-agent recipe our docs carried for it (id `kiro-cli`) migrates automatically.

**Registry entry** (`feat(agents)`): one `PRESET_AGENTS` entry — command `kiro-cli` (the CLI is distinct from the Kiro IDE), args `["acp"]` (ACP support shipped in Kiro CLI 1.25.0), install hint `curl -fsSL https://cli.kiro.dev/install | bash` (PowerShell `irm` script on native Windows, which requires Windows 11). The absorption is a one-line declaration (`absorbsCustomAgentId: "kiro-cli"`) riding the mechanism from #365 — this PR is the first reuse of that pattern, and it needed zero changes to the migration code, the normalizer, or the settings UI.

**API key wiring — a deliberate contrast with OpenCode.** Kiro has an official env var, `KIRO_API_KEY` (Kiro Pro and higher tiers, keys from app.kiro.dev), with documented precedence: browser session → `KIRO_API_KEY` → interactive prompt. That matches this plugin's existing optional-key pattern (Claude Code / Mistral Vibe): the preset wires `KIRO_API_KEY` as an optional Keychain-backed field — blank skips injection entirely, and a signed-in `kiro-cli login` session always wins over an injected key, so it can never break logged-in users. Kiro is the first preset with `apiKey` wiring but no `legacy` block; the normalizer takes the stored-secret path without ever calling the migrator. Docs present `kiro-cli login` as the primary flow.

**Docs** (`docs(kiro)`): new setup page (install with the Windows 11 caveat, both auth options, migration note including a nudge to move a plaintext `KIRO_API_KEY` env entry into the Keychain-backed field), sidebar entry, and the full enumeration sweep. The custom-agents page now keeps only Qwen Code as an example; context-files documents Kiro as `AGENTS.md` (plus `.kiro/steering/*.md`, no CLAUDE.md fallback). Upstream facts were cross-verified live from two independent research angles (kiro.dev docs tree + outside-in via changelog/ecosystem) with an arbiter resolving 11 discrepancies against primary sources.

Tests: 190 passing (kiro absorption case + a `["kiro-cli", "KIRO_API_KEY"]` row pinning the wiring in the `buildAgentConfigWithApiKey` characterization table). A post-implementation adversarial review ran; its finds are folded in (minimum-version note, the overview table no longer presents `kiro-cli` as a package name — the npm name is squatted by a third party — and the Keychain migration nudge), with one accepted low-severity limitation recorded in the plan document (absorbed plaintext env keys are not auto-promoted to secret storage).

## Related issue

None (completes the preset overhaul plan).

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" warnings are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Kiro CLI (installed for this PR). Verified: preset appears with API key row and install hint; spawns via `kiro-cli acp` with a logged-in session and an empty key field; hand-crafted data.json migration (custom `kiro-cli` absorbed, Notice once, no re-fire); saved sessions keep resolving after migration; bare-name resolution and Auto-detect; existing five presets, custom agents, default-agent selection, and switching unaffected
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in support for the Kiro CLI agent across agent selection and preset listings.
  * Added Kiro-compatible authentication via interactive login or API key, with automatic migration for prior custom-agent settings.

* **Documentation**
  * Added a dedicated Kiro setup guide (install, configuration, auth flows, and verification) and updated quick-start, FAQ, ACP, and context-file documentation to reference Kiro.

* **Tests**
  * Updated presets and expectations to include the `kiro-cli` agent and its API key wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->