### PR TITLE
chore: translate the leftover Japanese JSDoc comments

### DIFF
--- a/src/services/preset-agents.ts
+++ b/src/services/preset-agents.ts
@@ -71,9 +71,9 @@ export interface PresetAgentDefinition {
 	 * presets with non-empty defaults the args are effectively unclearable).
 	 */
 	defaultArgs: string[];
-	/** data.json 旧形式 per-agent sub-object key (original four presets only). */
+	/** Legacy data.json per-agent sub-object key (original four presets only). */
 	legacySettingsKey?: "claude" | "codex" | "gemini" | "mistralVibe";
-	/** data.json 旧形式 top-level command-path key (claude / gemini only). */
+	/** Legacy data.json top-level command-path key (claude / gemini only). */
 	legacyCommandPathKey?: string;
 	apiKey?: PresetAgentApiKey;
 	/**


### PR DESCRIPTION
## Description

Two JSDoc lines in `preset-agents.ts` (`legacySettingsKey` / `legacyCommandPathKey`) still carried a Japanese fragment ("data.json 旧形式 …") from the registry design sketch — the translation of the leading words was missed when the registry landed in #348. Both now read `Legacy data.json …`.

A full sweep for Japanese characters (hiragana, katakana, CJK, full-width punctuation) across `src/`, `test/`, `styles.css`, config files, `docs/` sources, and `.github/` confirmed these two lines were the only remaining occurrences — the codebase is now English-only (README.ja.md is intentionally Japanese and out of scope).

## Related issue

None.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (comment-only cleanup)

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" warnings are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian (no runtime change — comment-only)
- [x] Existing functionality still works
- [x] Documentation updated if needed (N/A)

## Testing environment

- Agent: N/A (comment-only change; build/lint/tests green)
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal documentation for legacy configuration keys.
  * Improved the formatting and relationship between related configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->