### PR TITLE
refactor: declare session.sessionId in the menu callback deps

### DIFF
--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -708,6 +708,7 @@ export const ChatPanel = React.memo(function ChatPanel({
 			agentCwd,
 			handleNewChatInDirectory,
 			handleOpenSettings,
+			session.sessionId,
 		],
 	);
 


### PR DESCRIPTION
## Description

The More menu callback reads `session.sessionId` from its closure for the **Rename session** item, but does not declare it as a dependency. It stays fresh today only because `handleNewChat` — a declared dep — depends on the whole `session` object, so any session change recreates the menu callback transitively. If `handleNewChat`'s deps are ever narrowed to individual fields (the codebase's preferred pattern), Rename would silently start writing titles to a previous session's saved entry.

This declares `session.sessionId` in the deps so the freshness is self-contained. No behavior or performance change: `sessionId` never changes without the `session` object identity changing, so the callback is already rebuilt in exactly these cases.

## Related issue

None.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" warnings are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed (N/A)

## Testing environment

- Agent: Claude Code. Verified: More menu renames the current session correctly in sidebar, floating, and embedded variants, including right after "New chat"
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the floating header menu to stay synchronized when the active session changes.
  * Ensured session actions, such as renaming, use the current session correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->