### PR TITLE
feat: focus the target embedded chat when a button delivers a prompt

### DIFF
--- a/docs/usage/embeddable-blocks.md
+++ b/docs/usage/embeddable-blocks.md
@@ -137,7 +137,7 @@ autoSend: true
 | `embedded` | `embed`, `embeddable` | The nearest embedded chat block in the same note |
 
 ::: tip How `viewType: embedded` finds its target
-`embedded` does not open a new view — it delivers the prompt to the nearest **existing** chat block in the same note (looking above the button first, then below). If the note contains no embedded chat block, a notice is shown and nothing opens.
+`embedded` does not open a new view — it delivers the prompt to the nearest **existing** chat block in the same note (looking above the button first, then below), scrolling to the block and focusing its input. If the note contains no embedded chat block, a notice is shown and nothing opens.
 :::
 
 ## Validation and Warnings {#validation-and-warnings}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1071,6 +1071,7 @@ export default class AgentClientPlugin extends Plugin {
 				);
 				return;
 			}
+			this.viewRegistry.get(targetViewId)?.focus();
 		} else if (viewType === "floating") {
 			const container = this.openNewFloatingChat(
 				true,


### PR DESCRIPTION
## Description

Agent buttons with `viewType: embedded` delivered the prompt to the nearest chat block but did nothing visually — every other viewType opens, reveals, and focuses its target. In a long note with the block off-screen, clicking the button looked like nothing happened, even though the prompt had landed in the (invisible) block.

The embedded branch of `runPromptInChat` now focuses the resolved target before delivery, reusing the container `focus()` — the same path the Session Manager uses — which scrolls to the block and focuses its input (and fronts the host tab when needed). All of its failure paths degrade silently to the previous deliver-only behavior. The `viewType: embedded` doc tip mentions the scrolling now.

If someone later wants delivery without the scroll jump, an opt-out fence option can gate this single call — deliberately not added until requested.

## Related issue

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" warnings are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Claude Code. Verified: off-screen block scrolls into view with input focused and prompt delivered (with and without autoSend); short notes focus without excessive jumping; no-block notes still show only the notice; other viewTypes and Session Manager focusing unchanged
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Embedded chat prompts now bring the nearest existing chat block into view and focus its input automatically, making it easier to continue typing immediately.

* **Documentation**
  * Updated embedded block guidance to explain that prompts target the nearest existing chat block and that the interface scrolls to and focuses the selected block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->