### PR TITLE
feat: add the Hermes Agent preset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Client Plugin - LLM Developer Guide
 
 ## Overview
-Obsidian plugin for AI agent interaction (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, custom agents) via ACP.
+Obsidian plugin for AI agent interaction (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, custom agents) via ACP.
 
 **Tech**: React 19, TypeScript, Obsidian API, Agent Client Protocol (ACP)
 
@@ -336,6 +336,7 @@ interface ISettingsAccess {
 - Mistral Vibe: `mistral-vibe` (MISTRAL_API_KEY)
 - OpenCode: `opencode-ai` (CLI-managed auth, no API key env)
 - Kiro: `kiro-cli` install script (KIRO_API_KEY, optional)
+- Hermes Agent: install script (CLI-managed auth, no API key env)
 - Custom: Any ACP-compatible agent
 
 ---

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,7 +40,7 @@ Zed の [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/age
 
 **管制室。** Session Manager が、サイドバー・タブ・フローティング・ノート内に開いている全会話をステータスアイコン付きで一覧します（権限待ちも見えます）。クリックでその場へジャンプ。
 
-**どの ACP エージェントでも。** 6つのプリセット — Claude Code、Codex、Gemini CLI、Mistral Vibe、OpenCode、Kiro — に加えて、ACP 互換エージェントならカスタムエージェントとして追加できます。明日新しいエージェントが ACP 対応しても、カスタムエージェントに登録するだけ — プラグインの更新を待つ必要はありません。
+**どの ACP エージェントでも。** 7つのプリセット — Claude Code、Codex、Gemini CLI、Mistral Vibe、OpenCode、Kiro、Hermes Agent — に加えて、ACP 互換エージェントならカスタムエージェントとして追加できます。明日新しいエージェントが ACP 対応しても、カスタムエージェントに登録するだけ — プラグインの更新を待つ必要はありません。
 
 ## 機能
 
@@ -69,7 +69,7 @@ Zed の [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/age
 
 1. 使いたいエージェントをセットアップガイドに従ってインストール・認証します:
 
-   [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html) · [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html) · [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html) · [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html) · [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html) · [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html) · [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)
+   [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html) · [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html) · [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html) · [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html) · [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html) · [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html) · [Hermes Agent](https://rait-09.github.io/obsidian-agent-client/agent-setup/hermes.html) · [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)
 
 2. **設定 → Agent Client** でエージェントのパスを確認します — **Auto-detect** でほとんどの場合見つかります
 3. リボンのロボットアイコンをクリックしてチャット開始

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Built on the [Agent Client Protocol (ACP)](https://github.com/agentclientprotoco
 
 **Mission control.** The Session Manager lists every open conversation across sidebar, tabs, floating windows, and notes, with live status icons — including "waiting for permission". Click any entry to jump straight there.
 
-**Any ACP agent.** Six presets — Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro — plus any ACP-compatible agent as a custom entry. New agent ships ACP support tomorrow? Add it as a custom entry — no plugin update needed.
+**Any ACP agent.** Seven presets — Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent — plus any ACP-compatible agent as a custom entry. New agent ships ACP support tomorrow? Add it as a custom entry — no plugin update needed.
 
 ## Features
 
@@ -69,7 +69,7 @@ Built on the [Agent Client Protocol (ACP)](https://github.com/agentclientprotoco
 
 1. Install and authenticate an agent, following its setup guide:
 
-   [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html) · [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html) · [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html) · [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html) · [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html) · [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html) · [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)
+   [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html) · [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html) · [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html) · [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html) · [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html) · [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html) · [Hermes Agent](https://rait-09.github.io/obsidian-agent-client/agent-setup/hermes.html) · [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)
 
 2. Open **Settings → Agent Client** and check the agent's path — **Auto-detect** usually finds it
 3. Click the robot icon in the ribbon and start chatting

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -62,6 +62,7 @@ export default defineConfig({
           { text: "Mistral Vibe", link: "/agent-setup/mistral-vibe" },
           { text: "OpenCode", link: "/agent-setup/opencode" },
           { text: "Kiro", link: "/agent-setup/kiro" },
+          { text: "Hermes Agent", link: "/agent-setup/hermes" },
           { text: "Custom Agents", link: "/agent-setup/custom-agents" },
         ],
       },

--- a/docs/agent-setup/hermes.md
+++ b/docs/agent-setup/hermes.md
@@ -1,0 +1,72 @@
+# Hermes Agent Setup
+
+Hermes Agent is the self-improving agent built by Nous Research. It works with many LLM providers and communicates via ACP through the `hermes acp` command (available since v0.2.0).
+
+## Install and Configure
+
+Open a terminal (Terminal on macOS/Linux, PowerShell on Windows) and run the following commands.
+
+1. Install Hermes Agent:
+
+::: code-group
+
+```bash [macOS/Linux]
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+```
+
+```powershell [Windows]
+iex (irm https://hermes-agent.nousresearch.com/install.ps1)
+```
+
+:::
+
+The desktop installer and other options are listed in the [Hermes Agent docs](https://hermes-agent.nousresearch.com/docs/getting-started/installation). Note that the `hermes-agent` package on npm is not an official distribution.
+
+2. Find the installation path:
+
+::: code-group
+
+```bash [macOS/Linux]
+which hermes
+# Example output: /Users/username/.local/bin/hermes
+```
+
+```cmd [Windows]
+where.exe hermes
+```
+
+:::
+
+3. Open **Settings → Agent Client**. The default command (`hermes`) works in many cases. If the agent is not found automatically, set the **Hermes Agent path** to the path found above, or click **Auto-detect**.
+
+## Authentication
+
+Hermes Agent manages provider credentials itself, so there is no API key field for it in Agent Client.
+
+1. Run the interactive provider selector in your terminal:
+
+```bash
+hermes model
+```
+
+Follow the prompts to pick a provider and paste an API key or complete an OAuth sign-in. Alternatively, `hermes setup --portal` signs in to Nous Portal with OAuth in one step.
+
+2. Verify that a normal chat works in the terminal:
+
+```bash
+hermes
+```
+
+Credentials are stored under `~/.hermes/` and are picked up by the `hermes acp` process that Agent Client starts.
+
+::: tip Migrating from a custom agent
+If you previously ran Hermes Agent as a custom agent, its settings are not migrated automatically. A custom agent with the id `hermes-agent` is renamed to `hermes-agent-2` to make room for the preset — copy any custom path or environment variables into the preset settings, then delete the leftover custom entry.
+:::
+
+## Verify Setup
+
+1. Click the robot icon in the ribbon or use the command palette: **"Open chat view"**
+2. Switch to Hermes Agent from the agent dropdown in the chat header
+3. Try sending a message to verify the connection
+
+Having issues? See [Troubleshooting](/help/troubleshooting).

--- a/docs/agent-setup/index.md
+++ b/docs/agent-setup/index.md
@@ -12,13 +12,14 @@ Agent Client supports multiple AI agents through the [Agent Client Protocol (ACP
 | [Mistral Vibe](./mistral-vibe) | Mistral AI | `mistral-vibe` |
 | [OpenCode](./opencode) | Multi-provider | `opencode-ai` |
 | [Kiro](./kiro) | AWS | install script |
+| [Hermes Agent](./hermes) | Multi-provider | install script |
 | [Custom Agents](./custom-agents) | Various | Any ACP-compatible agent |
 
 ## Common Setup Steps
 
 All agents follow a similar setup pattern:
 
-1. **Install the agent** — see each agent's setup page for the exact command (npm for Claude Code / Codex / Gemini CLI; `curl` on macOS/Linux or `uv` on Windows for Mistral Vibe; `curl` or npm for OpenCode; `curl` on macOS/Linux or PowerShell on Windows for Kiro)
+1. **Install the agent** — see each agent's setup page for the exact command (npm for Claude Code / Codex / Gemini CLI; `curl` on macOS/Linux or `uv` on Windows for Mistral Vibe; `curl` or npm for OpenCode; `curl` on macOS/Linux or PowerShell on Windows for Kiro and Hermes Agent)
 2. **Set up authentication** (API key or account login)
 
 The plugin resolves bare command names through your login shell's PATH, so path configuration is often not needed. If the agent is not found automatically, use `which` (macOS/Linux) or `where.exe` (Windows) to find the path and configure it in Settings → Agent Client.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -14,6 +14,7 @@ Agent Client supports multiple AI agents. Choose one to start:
 | **[Mistral Vibe](/agent-setup/mistral-vibe)** | Mistral AI | with built-in ACP support (`vibe-acp`) |
 | **[OpenCode](/agent-setup/opencode)** | Multi-provider | with built-in ACP support (`opencode acp`) |
 | **[Kiro](/agent-setup/kiro)** | AWS | with built-in ACP support (`kiro-cli acp`) |
+| **[Hermes Agent](/agent-setup/hermes)** | Multi-provider | with built-in ACP support (`hermes acp`) |
 | **[Custom](/agent-setup/custom-agents)** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., Qwen Code) |
 
 ## Step 2: Install and Configure the Agent
@@ -26,6 +27,7 @@ Follow the setup guide for your chosen agent:
 - [Mistral Vibe Setup](/agent-setup/mistral-vibe)
 - [OpenCode Setup](/agent-setup/opencode)
 - [Kiro Setup](/agent-setup/kiro)
+- [Hermes Agent Setup](/agent-setup/hermes)
 - [Custom Agents](/agent-setup/custom-agents)
 
 Each guide covers installation, path configuration, and authentication.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -6,7 +6,7 @@ Frequently asked questions about Agent Client.
 
 ### What is Agent Client?
 
-Agent Client is an Obsidian plugin that lets you chat with AI agents directly within Obsidian. It supports Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, and any ACP-compatible agent. The plugin uses the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) to communicate with agents.
+Agent Client is an Obsidian plugin that lets you chat with AI agents directly within Obsidian. It supports Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, and any ACP-compatible agent. The plugin uses the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) to communicate with agents.
 
 ### Is this an official Anthropic/OpenAI/Google plugin?
 
@@ -81,7 +81,7 @@ Disabling only hides the agent from lists: already-open chats, restored sessions
 
 ### What is a custom agent?
 
-Any ACP-compatible agent beyond the preset ones (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro). You can add custom agents in **Settings → Agent Client → Custom agents**. See [Custom Agents](/agent-setup/custom-agents).
+Any ACP-compatible agent beyond the preset ones (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent). You can add custom agents in **Settings → Agent Client → Custom agents**. See [Custom Agents](/agent-setup/custom-agents).
 
 ### Do all agents support the same features?
 
@@ -95,7 +95,7 @@ Slash commands are provided by the agent, not the plugin. If the input placehold
 
 ### Why are the commands different from what I expected?
 
-Each agent provides its own commands. Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, and Kiro all have different command sets. Refer to your agent's documentation for available commands.
+Each agent provides its own commands. Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, and Hermes Agent all have different command sets. Refer to your agent's documentation for available commands.
 
 ## Permissions
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -62,6 +62,9 @@ The agent requires authentication before processing requests.
 **For Kiro:**
 - Run `kiro-cli login` in Terminal first to sign in, or link an API key (Kiro Pro and higher tiers) in **Settings → Agent Client → Preset agents → Kiro → API key**. See [Kiro Setup](/agent-setup/kiro#authentication).
 
+**For Hermes Agent:**
+- Run `hermes model` in Terminal to configure a provider (there is no API key field in the plugin). See [Hermes Agent Setup](/agent-setup/hermes#authentication).
+
 ### "No Authentication Methods" error
 
 The agent didn't provide authentication options.

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,7 @@ Agent Client is an Obsidian plugin that brings AI coding agents directly into yo
 | **[Mistral Vibe](https://github.com/mistralai/mistral-vibe)** | Mistral AI | with built-in ACP support (`vibe-acp`) |
 | **[OpenCode](https://github.com/anomalyco/opencode)** | Multi-provider | with built-in ACP support (`opencode acp`) |
 | **[Kiro](https://kiro.dev/)** | AWS | with built-in ACP support (`kiro-cli acp`) |
+| **[Hermes Agent](https://github.com/NousResearch/hermes-agent)** | Multi-provider | with built-in ACP support (`hermes acp`) |
 | **Custom** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., Qwen Code) |
 
 ### Key Features

--- a/docs/reference/acp-support.md
+++ b/docs/reference/acp-support.md
@@ -6,7 +6,7 @@ This page documents which Agent Client Protocol (ACP) features are supported by 
 
 The [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) is an open standard for communication between AI agents and client applications. It defines how clients send prompts, receive responses, handle permissions, and manage sessions.
 
-Agent Client implements ACP as a **client**, communicating with ACP-compatible agents like Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, and Kiro.
+Agent Client implements ACP as a **client**, communicating with ACP-compatible agents like Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, and Hermes Agent.
 
 ## Methods
 

--- a/docs/usage/context-files.md
+++ b/docs/usage/context-files.md
@@ -22,6 +22,7 @@ Each agent uses its own context file:
 | Mistral Vibe | `AGENTS.md` |
 | OpenCode | `AGENTS.md` (falls back to `CLAUDE.md`) |
 | Kiro | `AGENTS.md` (also `.kiro/steering/*.md`) |
+| Hermes Agent | `AGENTS.md` (falls back to `CLAUDE.md`) |
 
 Place the context file in your **vault root** to have the agent read it automatically.
 

--- a/src/services/preset-agents.ts
+++ b/src/services/preset-agents.ts
@@ -240,6 +240,23 @@ export const PRESET_AGENTS: readonly PresetAgentDefinition[] = [
 		},
 		docsPage: "kiro",
 	},
+	{
+		presetId: "hermes-agent",
+		defaultDisplayName: "Hermes Agent",
+		defaultCommand: "hermes",
+		defaultArgs: ["acp"],
+		installHint: {
+			default:
+				"curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash",
+			nativeWindows:
+				"iex (irm https://hermes-agent.nousresearch.com/install.ps1)",
+		},
+		settingsCopy: {
+			pathDesc:
+				'Command name or path to hermes. Use just "hermes" to let the login shell resolve it, or enter an absolute path.',
+		},
+		docsPage: "hermes",
+	},
 ];
 
 /**

--- a/test/session-helpers.test.ts
+++ b/test/session-helpers.test.ts
@@ -64,6 +64,9 @@ function makeSettings(
 			"kiro-cli": preset("kiro-cli", "Kiro", "kiro-cli", {
 				args: ["acp"],
 			}),
+			"hermes-agent": preset("hermes-agent", "Hermes Agent", "hermes", {
+				args: ["acp"],
+			}),
 		},
 		customAgents: [],
 		defaultAgentId: "",
@@ -83,6 +86,7 @@ describe("getAvailableAgentsFromSettings", () => {
 			{ id: "mistral-vibe", displayName: "Mistral Vibe" },
 			{ id: "opencode", displayName: "OpenCode" },
 			{ id: "kiro-cli", displayName: "Kiro" },
+			{ id: "hermes-agent", displayName: "Hermes Agent" },
 			{ id: "my-custom", displayName: "My Custom" },
 		]);
 	});
@@ -114,6 +118,7 @@ describe("getAvailableAgentsFromSettings", () => {
 			"mistral-vibe",
 			"opencode",
 			"kiro-cli",
+			"hermes-agent",
 			"my-custom",
 		]);
 	});
@@ -134,6 +139,7 @@ describe("getAllAgentsFromSettings", () => {
 			{ id: "mistral-vibe", displayName: "Mistral Vibe" },
 			{ id: "opencode", displayName: "OpenCode" },
 			{ id: "kiro-cli", displayName: "Kiro" },
+			{ id: "hermes-agent", displayName: "Hermes Agent" },
 			{ id: "off-custom", displayName: "Off Custom" },
 		]);
 	});


### PR DESCRIPTION
## Description

Add Hermes Agent (Nous Research) as the seventh preset agent.

- Registry entry only — no per-agent code elsewhere. The preset spawns `hermes` with the `acp` argument (ACP server mode, available since Hermes Agent v0.2.0).
- Login-only preset: Hermes manages provider credentials itself (`hermes model` / `hermes setup --portal`) and has no single official API-key environment variable, so the preset shows no API key field (same as OpenCode).
- No custom-agent absorption: the docs never prescribed a custom-agent id for Hermes, so existing custom entries are left untouched. A custom agent with the id `hermes-agent` is renamed to `hermes-agent-2` by the existing collision handling, and the setup page explains how to migrate manually.
- New setup page (`docs/agent-setup/hermes.md`) plus listings in the agent tables, FAQ, troubleshooting, README (en/ja), and AGENTS.md. Install instructions point to the official install scripts only — the `hermes-agent` package on npm is third-party and deliberately not referenced.

## Related issue

None

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Hermes Agent (v0.18.2)
- OS: macOS

## Screenshots

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hermes Agent as a built-in ACP agent preset.
  * Added installation, configuration, authentication, troubleshooting, and verification guidance for Hermes Agent.
  * Added Hermes Agent to supported-agent lists, setup links, navigation, FAQs, and context-file documentation.
* **Documentation**
  * Updated English and Japanese getting-started materials to include Hermes Agent.
* **Tests**
  * Updated agent availability checks to include Hermes Agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->