### PR TITLE
feat: add MiniMax ACP agent preset

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,9 +1,4 @@
-import {
-	Plugin,
-	WorkspaceLeaf,
-	Notice,
-	requestUrl,
-} from "obsidian";
+import { Plugin, WorkspaceLeaf, Notice, requestUrl } from "obsidian";
 import * as semver from "semver";
 import { ChatView, VIEW_TYPE_CHAT } from "./ui/ChatView";
 import {
@@ -41,6 +36,7 @@ import {
 	AgentEnvVar,
 	GeminiAgentSettings,
 	ClaudeAgentSettings,
+	MiniMaxAgentSettings,
 	CodexAgentSettings,
 	CustomAgentSettings,
 } from "./types/agent";
@@ -48,7 +44,7 @@ import type { SavedSessionInfo } from "./types/session";
 import { initializeLogger, getLogger } from "./utils/logger";
 
 // Re-export for backward compatibility
-export type { AgentEnvVar, CustomAgentSettings };
+export type { AgentEnvVar, MiniMaxAgentSettings, CustomAgentSettings };
 
 /**
  * Send message shortcut configuration.
@@ -73,6 +69,7 @@ export type ChatViewLocation =
 export interface AgentClientPluginSettings {
 	gemini: GeminiAgentSettings;
 	claude: ClaudeAgentSettings;
+	minimax: MiniMaxAgentSettings;
 	codex: CodexAgentSettings;
 	customAgents: CustomAgentSettings[];
 	/** Default agent ID for new views (renamed from activeAgentId for multi-session) */
@@ -145,6 +142,20 @@ const DEFAULT_SETTINGS: AgentClientPluginSettings = {
 		command: "claude-agent-acp",
 		args: [],
 		env: [],
+	},
+	minimax: {
+		id: "minimax",
+		displayName: "MiniMax",
+		apiKeySecretId: "",
+		command: "claude-agent-acp",
+		args: [],
+		env: [
+			{
+				key: "ANTHROPIC_BASE_URL",
+				value: "https://api.minimax.io/anthropic",
+			},
+			{ key: "ANTHROPIC_MODEL", value: "MiniMax-M3" },
+		],
 	},
 	codex: {
 		id: "codex-acp",
@@ -707,7 +718,7 @@ export default class AgentClientPlugin extends Plugin {
 	}
 
 	/**
-	 * Get all available agents (claude, codex, gemini, custom)
+	 * Get all available agents.
 	 */
 	getAvailableAgents(): Array<{ id: string; displayName: string }> {
 		return [
@@ -725,6 +736,12 @@ export default class AgentClientPlugin extends Plugin {
 				id: this.settings.gemini.id,
 				displayName:
 					this.settings.gemini.displayName || this.settings.gemini.id,
+			},
+			{
+				id: this.settings.minimax.id,
+				displayName:
+					this.settings.minimax.displayName ||
+					this.settings.minimax.id,
 			},
 			...this.settings.customAgents.map((agent) => ({
 				id: agent.id,
@@ -929,6 +946,7 @@ export default class AgentClientPlugin extends Plugin {
 		const rc = obj(raw.claude) ?? {};
 		const rk = obj(raw.codex) ?? {};
 		const rg = obj(raw.gemini) ?? {};
+		const rm = obj(raw.minimax) ?? {};
 		const re = obj(raw.exportSettings) ?? {};
 		const rd = obj(raw.displaySettings) ?? {};
 
@@ -946,6 +964,7 @@ export default class AgentClientPlugin extends Plugin {
 			D.claude.id,
 			D.codex.id,
 			D.gemini.id,
+			D.minimax.id,
 			...customAgents.map((a) => a.id),
 		];
 		const rawDefaultId =
@@ -1018,6 +1037,26 @@ export default class AgentClientPlugin extends Plugin {
 						: D.gemini.args,
 				env: normalizeEnvVars(rg.env),
 			},
+			minimax: {
+				id: D.minimax.id,
+				displayName: str(rm.displayName, D.minimax.displayName),
+				apiKeySecretId: this.migrateLegacyApiKey(
+					"minimax-api-key",
+					"agent-client-minimax-api-key",
+					str(rm.apiKeySecretId, D.minimax.apiKeySecretId),
+					str(rm.apiKey, ""),
+					"MiniMax",
+					() => {
+						migratedSecrets = true;
+					},
+				),
+				command: str(rm.command, "") || D.minimax.command,
+				args: sanitizeArgs(rm.args),
+				env:
+					"env" in rm
+						? normalizeEnvVars(rm.env)
+						: D.minimax.env.map((entry) => ({ ...entry })),
+			},
 			customAgents,
 			defaultAgentId,
 			autoAllowPermissions: bool(
@@ -1037,7 +1076,7 @@ export default class AgentClientPlugin extends Plugin {
 				return {
 					enabled: bool(rp.enabled, D.promptInjection.enabled),
 					latex: bool(rp.latex, D.promptInjection.latex),
-				wikiLinks: bool(rp.wikiLinks, D.promptInjection.wikiLinks),
+					wikiLinks: bool(rp.wikiLinks, D.promptInjection.wikiLinks),
 					tables: bool(rp.tables, D.promptInjection.tables),
 				};
 			})(),
@@ -1326,6 +1365,7 @@ export default class AgentClientPlugin extends Plugin {
 		ids.add(this.settings.claude.id);
 		ids.add(this.settings.codex.id);
 		ids.add(this.settings.gemini.id);
+		ids.add(this.settings.minimax.id);
 		for (const agent of this.settings.customAgents) {
 			if (agent.id && agent.id.length > 0) {
 				ids.add(agent.id);

--- a/src/services/session-helpers.ts
+++ b/src/services/session-helpers.ts
@@ -7,6 +7,7 @@ import type { AgentClientPluginSettings } from "../plugin";
 import type {
 	BaseAgentSettings,
 	ClaudeAgentSettings,
+	MiniMaxAgentSettings,
 	GeminiAgentSettings,
 	CodexAgentSettings,
 } from "../types/agent";
@@ -61,6 +62,10 @@ export function getAvailableAgentsFromSettings(
 			id: settings.gemini.id,
 			displayName: settings.gemini.displayName || settings.gemini.id,
 		},
+		{
+			id: settings.minimax.id,
+			displayName: settings.minimax.displayName || settings.minimax.id,
+		},
 		...settings.customAgents.map((agent) => ({
 			id: agent.id,
 			displayName: agent.displayName || agent.id,
@@ -104,6 +109,9 @@ export function findAgentSettings(
 	}
 	if (agentId === settings.gemini.id) {
 		return settings.gemini;
+	}
+	if (agentId === settings.minimax.id) {
+		return settings.minimax;
 	}
 	// Search in custom agents
 	const customAgent = settings.customAgents.find(
@@ -156,6 +164,16 @@ export function buildAgentConfigWithApiKey(
 			apiKey: {
 				secretId: geminiSettings.apiKeySecretId,
 				envVarName: "GEMINI_API_KEY",
+			},
+		};
+	}
+	if (agentId === settings.minimax.id) {
+		const minimaxSettings = agentSettings as MiniMaxAgentSettings;
+		return {
+			...baseConfig,
+			apiKey: {
+				secretId: minimaxSettings.apiKeySecretId,
+				envVarName: "ANTHROPIC_API_KEY",
 			},
 		};
 	}

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -78,6 +78,17 @@ export interface ClaudeAgentSettings extends BaseAgentSettings {
 }
 
 /**
+ * Configuration for the MiniMax agent profile.
+ *
+ * The API key is stored in Obsidian's secret storage and referenced by ID.
+ * Empty string means no API key is configured.
+ */
+export interface MiniMaxAgentSettings extends BaseAgentSettings {
+	/** Secret storage ID containing the MiniMax API key */
+	apiKeySecretId: string;
+}
+
+/**
  * Configuration for Codex CLI agent.
  *
  * Extends base settings with Codex-specific requirements.

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -272,6 +272,12 @@ export function ChatPanel({
 				plugin.settings.gemini.displayName || plugin.settings.gemini.id
 			);
 		}
+		if (activeId === plugin.settings.minimax.id) {
+			return (
+				plugin.settings.minimax.displayName ||
+				plugin.settings.minimax.id
+			);
+		}
 		const custom = plugin.settings.customAgents.find(
 			(agent) => agent.id === activeId,
 		);

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -106,9 +106,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.sendMessageShortcut)
 					.onChange(async (value) => {
 						await this.plugin.settingsService.updateSettings({
-							sendMessageShortcut: value as
-								| "enter"
-								| "cmd-enter",
+							sendMessageShortcut: value as "enter" | "cmd-enter",
 						});
 					}),
 			);
@@ -601,6 +599,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 		this.renderClaudeSettings(containerEl);
 		this.renderCodexSettings(containerEl);
 		this.renderGeminiSettings(containerEl);
+		this.renderMiniMaxSettings(containerEl);
 
 		new Setting(containerEl).setName("Custom agents").setHeading();
 
@@ -918,6 +917,11 @@ export class AgentClientSettingTab extends PluginSettingTab {
 				this.plugin.settings.gemini.displayName ||
 					this.plugin.settings.gemini.id,
 			),
+			toOption(
+				this.plugin.settings.minimax.id,
+				this.plugin.settings.minimax.displayName ||
+					this.plugin.settings.minimax.id,
+			),
 		];
 		for (const agent of this.plugin.settings.customAgents) {
 			if (agent.id && agent.id.length > 0) {
@@ -1116,6 +1120,101 @@ export class AgentClientSettingTab extends PluginSettingTab {
 						await this.plugin.settingsService.updateSettings({
 							claude: {
 								...this.plugin.settings.claude,
+								env: this.parseEnv(value),
+							},
+						});
+					});
+				text.inputEl.rows = 3;
+			});
+	}
+
+	private renderMiniMaxSettings(sectionEl: HTMLElement) {
+		const minimax = this.plugin.settings.minimax;
+
+		new Setting(sectionEl)
+			.setName(minimax.displayName || "MiniMax")
+			.setHeading();
+
+		new Setting(sectionEl)
+			.setName("API key")
+			.setDesc(
+				"MiniMax API key. Select from Obsidian's Keychain or create a new secret.",
+			)
+			.addComponent((el) =>
+				new SecretComponent(this.app, el)
+					.setValue(minimax.apiKeySecretId)
+					.onChange(async (value) => {
+						await this.plugin.settingsService.updateSettings({
+							minimax: {
+								...this.plugin.settings.minimax,
+								apiKeySecretId: value,
+							},
+						});
+					}),
+			);
+
+		const minimaxPathSetting = new Setting(sectionEl)
+			.setName("Path")
+			.setDesc(
+				'Command name or path to claude-agent-acp. Use just "claude-agent-acp" to let the login shell resolve it, or enter an absolute path.',
+			)
+			.addText((text) => {
+				text.setPlaceholder("claude-agent-acp")
+					.setValue(minimax.command)
+					.onChange(async (value) => {
+						await this.plugin.settingsService.updateSettings({
+							minimax: {
+								...this.plugin.settings.minimax,
+								command: value.trim(),
+							},
+						});
+					});
+			});
+		this.addAutoDetectButton(
+			minimaxPathSetting,
+			"claude-agent-acp",
+			async (path) => {
+				await this.plugin.settingsService.updateSettings({
+					minimax: {
+						...this.plugin.settings.minimax,
+						command: path,
+					},
+				});
+			},
+		);
+		this.addInstallHint(sectionEl, "@agentclientprotocol/claude-agent-acp");
+
+		new Setting(sectionEl)
+			.setName("Arguments")
+			.setDesc(
+				"Enter one argument per line. Leave empty to run without arguments.",
+			)
+			.addTextArea((text) => {
+				text.setPlaceholder("")
+					.setValue(this.formatArgs(minimax.args))
+					.onChange(async (value) => {
+						await this.plugin.settingsService.updateSettings({
+							minimax: {
+								...this.plugin.settings.minimax,
+								args: this.parseArgs(value),
+							},
+						});
+					});
+				text.inputEl.rows = 3;
+			});
+
+		new Setting(sectionEl)
+			.setName("Environment variables")
+			.setDesc(
+				"Defaults to the global MiniMax endpoint and MiniMax-M3. For China access, set ANTHROPIC_BASE_URL to https://api.minimaxi.com/anthropic.",
+			)
+			.addTextArea((text) => {
+				text.setPlaceholder("KEY=VALUE")
+					.setValue(this.formatEnv(minimax.env))
+					.onChange(async (value) => {
+						await this.plugin.settingsService.updateSettings({
+							minimax: {
+								...this.plugin.settings.minimax,
 								env: this.parseEnv(value),
 							},
 						});

--- a/test/session-helpers.test.ts
+++ b/test/session-helpers.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { AgentClientPluginSettings } from "../src/plugin";
+import type { MiniMaxAgentSettings } from "../src/types/agent";
+import {
+	buildAgentConfigWithApiKey,
+	findAgentSettings,
+	getAvailableAgentsFromSettings,
+} from "../src/services/session-helpers";
+
+const minimax: MiniMaxAgentSettings = {
+	id: "minimax",
+	displayName: "MiniMax",
+	apiKeySecretId: "minimax-key",
+	command: "claude-agent-acp",
+	args: [],
+	env: [
+		{
+			key: "ANTHROPIC_BASE_URL",
+			value: "https://api.minimax.io/anthropic",
+		},
+		{ key: "ANTHROPIC_MODEL", value: "MiniMax-M3" },
+	],
+};
+
+const settings = {
+	minimax,
+	claude: { id: "agent-a", displayName: "Agent A" },
+	codex: { id: "agent-b", displayName: "Agent B" },
+	gemini: { id: "agent-c", displayName: "Agent C" },
+	customAgents: [],
+	defaultAgentId: minimax.id,
+} as AgentClientPluginSettings;
+
+describe("MiniMax agent profile", () => {
+	it("is available and resolves to its settings", () => {
+		expect(getAvailableAgentsFromSettings(settings)).toContainEqual({
+			id: "minimax",
+			displayName: "MiniMax",
+		});
+		expect(findAgentSettings(settings, "minimax")).toBe(minimax);
+	});
+
+	it("keeps the endpoint and model defaults while injecting the API key", () => {
+		expect(
+			buildAgentConfigWithApiKey(settings, minimax, minimax.id, "/vault"),
+		).toEqual({
+			id: "minimax",
+			displayName: "MiniMax",
+			command: "claude-agent-acp",
+			args: [],
+			env: {
+				ANTHROPIC_BASE_URL: "https://api.minimax.io/anthropic",
+				ANTHROPIC_MODEL: "MiniMax-M3",
+			},
+			workingDirectory: "/vault",
+			apiKey: {
+				secretId: "minimax-key",
+				envVarName: "ANTHROPIC_API_KEY",
+			},
+		});
+	});
+});


### PR DESCRIPTION
Reason: Add a MiniMax ACP preset for the Anthropic-compatible endpoint.

This change:

- Adds a MiniMax agent profile with the default global endpoint and MiniMax-M3 model.
- Stores the MiniMax API key through Obsidian secret storage.
- Exposes the profile in agent selection, commands, session lookup, and settings.
- Documents the China endpoint as an editable environment override.
- Adds focused coverage for MiniMax agent discovery and runtime configuration.

Checks:

- `npx prettier --check src/types/agent.ts src/plugin.ts src/services/session-helpers.ts src/ui/ChatPanel.tsx src/ui/SettingsTab.ts test/session-helpers.test.ts`
- `npm run test` (49 tests passed)
- `npm run build`
- Secret scan passed.
- Existing repository-wide ESLint and formatting findings remain unchanged from `HEAD`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as a built-in agent option.
  * Added MiniMax configuration in Settings, including API key, command path, auto-detection, arguments, and environment variables.
  * Added MiniMax to available-agent lists and default-agent selection.
  * Improved display of the active MiniMax agent in chat.

* **Bug Fixes**
  * Preserved MiniMax endpoint and model defaults when loading settings.
  * Added automatic API-key configuration for MiniMax sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->