### PR TITLE
fix: drop non-string scalar aliases in metadata conversion

### DIFF
--- a/src/services/vault-service.ts
+++ b/src/services/vault-service.ts
@@ -120,12 +120,15 @@ export interface IVaultAccess {
  *
  * Frontmatter is user-controlled YAML: `aliases` may be a string, an array,
  * or — via malformed YAML (e.g. a trailing colon turning an entry into an
- * object) — anything else. Non-string values are dropped so downstream
- * consumers (fuzzy search, NoteMetadata) only ever see strings (#354).
+ * object) — anything else. Non-string and empty-string values are dropped so
+ * downstream consumers (fuzzy search, NoteMetadata) only ever see usable
+ * strings (#354).
  */
 function normalizeFrontmatterAliases(value: unknown): string[] {
-	const list = Array.isArray(value) ? value : value ? [value] : [];
-	return list.filter((a): a is string => typeof a === "string");
+	const list = Array.isArray(value) ? value : [value];
+	return list.filter(
+		(a): a is string => typeof a === "string" && a.length > 0,
+	);
 }
 
 /**

--- a/src/services/vault-service.ts
+++ b/src/services/vault-service.ts
@@ -116,6 +116,19 @@ export interface IVaultAccess {
 }
 
 /**
+ * Normalize a frontmatter `aliases` value into a string array.
+ *
+ * Frontmatter is user-controlled YAML: `aliases` may be a string, an array,
+ * or — via malformed YAML (e.g. a trailing colon turning an entry into an
+ * object) — anything else. Non-string values are dropped so downstream
+ * consumers (fuzzy search, NoteMetadata) only ever see strings (#354).
+ */
+function normalizeFrontmatterAliases(value: unknown): string[] {
+	const list = Array.isArray(value) ? value : value ? [value] : [];
+	return list.filter((a): a is string => typeof a === "string");
+}
+
+/**
  * Unified vault service for note access, fuzzy search, and selection tracking.
  *
  * Implements IVaultAccess port by wrapping Obsidian's Vault API,
@@ -237,17 +250,11 @@ export class VaultService implements IVaultAccess, IWikilinkResolver {
 				const path = file.path;
 				const fileCache =
 					this.plugin.app.metadataCache.getFileCache(file);
-				const aliases = fileCache?.frontmatter?.aliases as
-					| string[]
-					| string
-					| undefined;
-				const aliasArray: string[] = Array.isArray(aliases)
-					? aliases
-					: aliases
-						? [aliases]
-						: [];
+				const aliases = normalizeFrontmatterAliases(
+					fileCache?.frontmatter?.aliases,
+				);
 
-				const searchFields = [basename, path, ...aliasArray.filter((a): a is string => typeof a === 'string')];
+				const searchFields = [basename, path, ...aliases];
 				let bestScore = -Infinity;
 
 				for (const field of searchFields) {
@@ -553,10 +560,9 @@ export class VaultService implements IVaultAccess, IWikilinkResolver {
 	 */
 	private convertToMetadata(file: TFile): NoteMetadata {
 		const cache = this.plugin.app.metadataCache.getFileCache(file);
-		const aliases = cache?.frontmatter?.aliases as
-			| string[]
-			| string
-			| undefined;
+		const aliases = normalizeFrontmatterAliases(
+			cache?.frontmatter?.aliases,
+		);
 
 		return {
 			path: file.path,
@@ -564,11 +570,7 @@ export class VaultService implements IVaultAccess, IWikilinkResolver {
 			extension: file.extension,
 			created: file.stat.ctime,
 			modified: file.stat.mtime,
-			aliases: Array.isArray(aliases)
-				? aliases.filter((a) => typeof a === 'string')
-				: aliases
-					? [aliases]
-					: undefined,
+			aliases: aliases.length > 0 ? aliases : undefined,
 		};
 	}
 }


### PR DESCRIPTION
## Description

Follow-up to #377, covering the remaining CodeRabbit comment: the scalar branch of `convertToMetadata()` was still unfiltered, so a truthy non-string scalar (e.g. `aliases: 42`) leaked into `NoteMetadata` as `[42]`.

Instead of patching that one branch, this centralizes frontmatter alias normalization into a single module-level helper (`normalizeFrontmatterAliases`) used by both `searchNotes()` and `convertToMetadata()` — the duplicated, slightly different normalization is what let the two sites drift apart in the first place. The helper takes `unknown` and proves stringness with a type predicate, which also removes the misleading `as string[] | string | undefined` casts (the root cause behind the crash in #354).

Also included:

- "No aliases" is now consistently represented as `undefined` in `NoteMetadata` (previously `undefined` or `[]` depending on the input shape; the field has no consumers).
- Prettier normalization of the lines introduced in #377 (quotes / line width).

Verified in Obsidian with the repro notes from #354 (`aliases: [null, "TestAlias"]`, `aliases: 42`, and the trailing-colon YAML template): no crash, filtering narrows correctly, and normal alias search is unaffected. `npm test` passes (190/190).

## Related issue

Follow-up to #377. Related: #354.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: N/A (the change only affects the @-mention search path; no agent connection involved)
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved note search and metadata handling for aliases.
  * Consistently excludes malformed, empty, or unsupported alias values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->