### PR TITLE
fix: migrate Codex references to @agentclientprotocol/codex-acp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,7 +331,7 @@ interface ISettingsAccess {
 
 **Agents**:
 - Claude Code: `@agentclientprotocol/claude-agent-acp` (ANTHROPIC_API_KEY)
-- Codex: `@zed-industries/codex-acp` (OPENAI_API_KEY)
+- Codex: `@agentclientprotocol/codex-acp` (OPENAI_API_KEY)
 - Gemini CLI: `@google/gemini-cli` (GEMINI_API_KEY)
 - Mistral Vibe: `mistral-vibe` (MISTRAL_API_KEY)
 - OpenCode: `opencode-ai` (CLI-managed auth, no API key env)

--- a/docs/agent-setup/codex.md
+++ b/docs/agent-setup/codex.md
@@ -9,8 +9,16 @@ Open a terminal (Terminal on macOS/Linux, PowerShell on Windows) and run the fol
 1. Install codex-acp:
 
 ```bash
-npm install -g @zed-industries/codex-acp
+npm install -g @agentclientprotocol/codex-acp
 ```
+
+::: tip Migrating from @zed-industries/codex-acp
+The previous package is deprecated on npm and replaced by `@agentclientprotocol/codex-acp`. If you installed it, remove it first so the two packages don't conflict over the same `codex-acp` command:
+
+```bash
+npm uninstall -g @zed-industries/codex-acp
+```
+:::
 
 2. Find the installation path:
 

--- a/docs/agent-setup/index.md
+++ b/docs/agent-setup/index.md
@@ -7,7 +7,7 @@ Agent Client supports multiple AI agents through the [Agent Client Protocol (ACP
 | Agent | Provider | Package |
 |-------|----------|---------|
 | [Claude Code](./claude-code) | Anthropic | `@agentclientprotocol/claude-agent-acp` |
-| [Codex](./codex) | OpenAI | `@zed-industries/codex-acp` |
+| [Codex](./codex) | OpenAI | `@agentclientprotocol/codex-acp` |
 | [Gemini CLI](./gemini-cli) | Google | `@google/gemini-cli` |
 | [Mistral Vibe](./mistral-vibe) | Mistral AI | `mistral-vibe` |
 | [OpenCode](./opencode) | Multi-provider | `opencode-ai` |

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -9,7 +9,7 @@ Agent Client supports multiple AI agents. Choose one to start:
 | Agent | Provider | Integration |
 |-------|----------|-------------|
 | **[Claude Code](/agent-setup/claude-code)** | Anthropic | via [ACP adapter](https://github.com/agentclientprotocol/claude-agent-acp) |
-| **[Codex](/agent-setup/codex)** | OpenAI | via [Zed's adapter](https://github.com/zed-industries/codex-acp) |
+| **[Codex](/agent-setup/codex)** | OpenAI | via [ACP adapter](https://github.com/agentclientprotocol/codex-acp) |
 | **[Gemini CLI](/agent-setup/gemini-cli)** | Google | with `--experimental-acp` option |
 | **[Mistral Vibe](/agent-setup/mistral-vibe)** | Mistral AI | with built-in ACP support (`vibe-acp`) |
 | **[OpenCode](/agent-setup/opencode)** | Multi-provider | with built-in ACP support (`opencode acp`) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ Agent Client is an Obsidian plugin that brings AI coding agents directly into yo
 | Agent | Provider | Integration |
 |-------|----------|-------------|
 | **[Claude Code](https://github.com/anthropics/claude-code)** | Anthropic | via [ACP adapter](https://github.com/agentclientprotocol/claude-agent-acp) |
-| **[Codex](https://github.com/openai/codex)** | OpenAI | via [Zed’s adapter](https://github.com/zed-industries/codex-acp) |
+| **[Codex](https://github.com/openai/codex)** | OpenAI | via [ACP adapter](https://github.com/agentclientprotocol/codex-acp) |
 | **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** | Google | with `--experimental-acp` option |
 | **[Mistral Vibe](https://github.com/mistralai/mistral-vibe)** | Mistral AI | with built-in ACP support (`vibe-acp`) |
 | **[OpenCode](https://github.com/anomalyco/opencode)** | Multi-provider | with built-in ACP support (`opencode acp`) |

--- a/src/acp/acp-client.ts
+++ b/src/acp/acp-client.ts
@@ -441,6 +441,10 @@ export class AcpClient {
 			this.logger.log(
 				`[AcpClient] ✅ Connected to agent (protocol v${initResult.protocolVersion})`,
 			);
+			// Adapters differ in the name/version they report (e.g. the
+			// codex-acp package move kept the bin name) — surface it so
+			// update-checker behavior can be verified from the debug log.
+			this.logger.log("[AcpClient] Agent info:", initResult.agentInfo);
 
 			this.isInitializedFlag = true;
 			this.currentAgentId = config.id;

--- a/src/services/preset-agents.ts
+++ b/src/services/preset-agents.ts
@@ -138,7 +138,7 @@ export const PRESET_AGENTS: readonly PresetAgentDefinition[] = [
 			},
 		},
 		installHint: {
-			default: "npm install -g @zed-industries/codex-acp@latest",
+			default: "npm install -g @agentclientprotocol/codex-acp@latest",
 		},
 		settingsCopy: {
 			pathDesc:

--- a/src/services/update-checker.ts
+++ b/src/services/update-checker.ts
@@ -45,17 +45,55 @@ export interface AgentUpdateNotification {
 const KNOWN_AGENT_PACKAGES: Readonly<Record<string, string>> = {
 	"@agentclientprotocol/claude-agent-acp":
 		"@agentclientprotocol/claude-agent-acp",
-	"codex-acp": "@zed-industries/codex-acp",
+	"codex-acp": "@agentclientprotocol/codex-acp",
+	"@agentclientprotocol/codex-acp": "@agentclientprotocol/codex-acp",
 };
 
 /**
- * Deprecated agentInfo.name → replacement npm package name.
- * Used to detect users still running old/renamed packages.
+ * A deprecated adapter package and its replacement.
+ *
+ * `name` is the agentInfo.name the deprecated adapter reports — not always
+ * the npm package name (codex-acp reports its unscoped bin name), so the
+ * uninstall target is carried separately as `oldPackage`.
  */
-const DEPRECATED_PACKAGES: Readonly<Record<string, string>> = {
-	"@zed-industries/claude-code-acp": "@agentclientprotocol/claude-agent-acp",
-	"@zed-industries/claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
-};
+interface DeprecationRule {
+	/** agentInfo.name reported by the deprecated adapter. */
+	name: string;
+	/** npm package the user should uninstall. */
+	oldPackage: string;
+	/** npm package that replaces it. */
+	replacement: string;
+	/**
+	 * Only versions strictly below this are deprecated. Needed when the old
+	 * and new adapters report the SAME name (codex-acp kept its bin name
+	 * across the package move): the old package never published this
+	 * version, so the boundary tells them apart. Undefined = deprecated at
+	 * every version.
+	 */
+	onlyBelow?: string;
+}
+
+const DEPRECATION_RULES: readonly DeprecationRule[] = [
+	{
+		name: "@zed-industries/claude-code-acp",
+		oldPackage: "@zed-industries/claude-code-acp",
+		replacement: "@agentclientprotocol/claude-agent-acp",
+	},
+	{
+		name: "@zed-industries/claude-agent-acp",
+		oldPackage: "@zed-industries/claude-agent-acp",
+		replacement: "@agentclientprotocol/claude-agent-acp",
+	},
+	{
+		// @zed-industries/codex-acp → @agentclientprotocol/codex-acp (#380).
+		// Both adapters report "codex-acp"; the old package topped out at
+		// 0.16.0 and never published 1.x, so < 1.0.0 identifies it.
+		name: "codex-acp",
+		oldPackage: "@zed-industries/codex-acp",
+		replacement: "@agentclientprotocol/codex-acp",
+		onlyBelow: "1.0.0",
+	},
+];
 
 // ============================================================================
 // Public API
@@ -75,13 +113,13 @@ export async function checkAgentUpdate(agentInfo: {
 	version?: string;
 }): Promise<AgentUpdateNotification | null> {
 	// 1. Check for deprecated package (migration takes priority)
-	const replacement = DEPRECATED_PACKAGES[agentInfo.name];
-	if (replacement) {
+	const rule = DEPRECATION_RULES.find((r) => r.name === agentInfo.name);
+	if (rule && isDeprecatedVersion(agentInfo.version, rule.onlyBelow)) {
 		return {
 			variant: "info",
 			title: "Package Migration Required",
-			message: `"${agentInfo.name}" has been renamed to "${replacement}".\nRun the following in your terminal:`,
-			suggestion: `npm uninstall -g ${agentInfo.name} && npm install -g ${replacement}`,
+			message: `"${rule.oldPackage}" has been renamed to "${rule.replacement}".\nRun the following in your terminal:`,
+			suggestion: `npm uninstall -g ${rule.oldPackage} && npm install -g ${rule.replacement}`,
 		};
 	}
 
@@ -125,4 +163,22 @@ async function fetchLatestVersion(packageName: string): Promise<string | null> {
 	});
 	const data = response.json as { version?: string };
 	return data.version ? (semver.clean(data.version) ?? null) : null;
+}
+
+/**
+ * Whether a reported version falls under a rule's `onlyBelow` boundary.
+ * No boundary = always deprecated. With a boundary, an absent or non-semver
+ * version is NOT treated as deprecated — we only notify when the version
+ * proves the adapter is the old package.
+ */
+function isDeprecatedVersion(
+	version: string | undefined,
+	onlyBelow: string | undefined,
+): boolean {
+	if (!onlyBelow) return true;
+	return (
+		version !== undefined &&
+		semver.valid(version) !== null &&
+		semver.lt(version, onlyBelow)
+	);
 }

--- a/test/stubs/obsidian.ts
+++ b/test/stubs/obsidian.ts
@@ -9,6 +9,7 @@
  *   `src/utils/paths.ts`. Tests mutate these to exercise platform branches.
  * - `parseYaml`: YAML parser used by `src/utils/agent-block-parser.ts`,
  *   delegated to the `yaml` package.
+ * - `requestUrl`: network stand-in that always rejects (see below).
  */
 
 import { parse as parseYamlImpl } from "yaml";
@@ -53,4 +54,13 @@ export function parseLinktext(linktext: string): {
 	const hash = linktext.indexOf("#");
 	if (hash === -1) return { path: linktext, subpath: "" };
 	return { path: linktext.slice(0, hash), subpath: linktext.slice(hash) };
+}
+
+/**
+ * Network stand-in. Always rejects: unit tests must not reach the npm
+ * registry, and update-checker treats a network failure as "no result",
+ * which keeps version-check paths deterministic in tests.
+ */
+export function requestUrl(): Promise<never> {
+	return Promise.reject(new Error("requestUrl is not available in tests"));
 }

--- a/test/update-checker.test.ts
+++ b/test/update-checker.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for the update checker's package-migration rules.
+ *
+ * Only the local (no-network) migration branch is meaningful here: the
+ * stubbed `requestUrl` always rejects, so version-check paths resolve to
+ * null through checkAgentUpdate's catch — deterministically, offline.
+ */
+
+import { describe, it, expect } from "vitest";
+import { checkAgentUpdate } from "../src/services/update-checker";
+
+describe("checkAgentUpdate — package migration rules", () => {
+	it("flags the renamed Claude adapter at any version", async () => {
+		const result = await checkAgentUpdate({
+			name: "@zed-industries/claude-code-acp",
+		});
+		expect(result?.title).toBe("Package Migration Required");
+		expect(result?.suggestion).toBe(
+			"npm uninstall -g @zed-industries/claude-code-acp && npm install -g @agentclientprotocol/claude-agent-acp",
+		);
+	});
+
+	it("flags codex-acp below 1.0.0 and targets the old npm package", async () => {
+		const result = await checkAgentUpdate({
+			name: "codex-acp",
+			version: "0.16.0",
+		});
+		expect(result?.title).toBe("Package Migration Required");
+		expect(result?.message).toContain("@zed-industries/codex-acp");
+		expect(result?.suggestion).toBe(
+			"npm uninstall -g @zed-industries/codex-acp && npm install -g @agentclientprotocol/codex-acp",
+		);
+	});
+
+	it("does not flag codex-acp 1.x (the successor package)", async () => {
+		expect(
+			await checkAgentUpdate({ name: "codex-acp", version: "1.1.9" }),
+		).toBeNull();
+	});
+
+	it("does not flag codex-acp when the version cannot prove the old package", async () => {
+		expect(await checkAgentUpdate({ name: "codex-acp" })).toBeNull();
+		expect(
+			await checkAgentUpdate({ name: "codex-acp", version: "unknown" }),
+		).toBeNull();
+	});
+
+	it("returns null for unknown agents", async () => {
+		expect(
+			await checkAgentUpdate({ name: "some-agent", version: "1.0.0" }),
+		).toBeNull();
+	});
+});


### PR DESCRIPTION
## Description

`@zed-industries/codex-acp` is deprecated on npm ("replaced by @agentclientprotocol/codex-acp" — same maintainer team, `codex-acp` bin name unchanged). This updates every reference to the successor package:

- Setup guide install command, plus a migration tip for removing the old package first (both ship the same `codex-acp` binary)
- Agent tables aligned with the Claude row ("via ACP adapter")
- In-app install hint (preset registry)
- Update checker: version checks now query the new package, and users still on the old adapter get an in-app "Package Migration Required" notice

The migration notice needed some care: the adapter kept its bin name across the move, so the reported name alone can't always tell old from new. `DEPRECATED_PACKAGES` became structured `DEPRECATION_RULES` with an `onlyBelow: "1.0.0"` version gate for codex (the old package never published 1.x), and the uninstall target is carried separately from the reported name. The Claude rules are behavior-identical. Added offline unit tests for the rules (195 tests total), and a debug log of the connected agent's reported name/version.

## Related issue

#380 — keeping it open until the fix ships with the release (the docs site deploys from `master`).

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Codex — full migration path verified end-to-end: the old adapter (0.16.0) shows the migration notice, running the suggested command migrates cleanly, and the new adapter (reports `@agentclientprotocol/codex-acp` 1.1.9) connects with no false notice
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Codex setup instructions, links, and supported-agent references to use the current ACP adapter package.
  * Added migration guidance for replacing the deprecated Codex package.

* **Bug Fixes**
  * Added automatic detection and migration guidance for deprecated agent packages, including version-aware checks.
  * Improved connection diagnostics by reporting metadata from connected agents.

* **Tests**
  * Added coverage for package migrations, supported versions, unknown agents, and indeterminate versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->