### PR TITLE
feat: preserve and render standard ACP tool content

### DIFF
--- a/src/acp/acp-handler.ts
+++ b/src/acp/acp-handler.ts
@@ -87,19 +87,39 @@ export class AcpHandler {
 				break;
 
 			case "tool_call":
-			case "tool_call_update":
 				this.emitSessionUpdate({
-					type: update.sessionUpdate,
+					type: "tool_call",
 					sessionId,
 					toolCallId: update.toolCallId,
-					title: update.title ?? undefined,
+					title: update.title,
 					status: update.status || "pending",
 					kind: update.kind ?? undefined,
 					content: AcpTypeConverter.toToolCallContent(update.content),
-					locations: update.locations ?? undefined,
+					locations: update.locations ?? [],
 					rawInput: update.rawInput as
 						| { [k: string]: unknown }
 						| undefined,
+					rawOutput: update.rawOutput,
+				});
+				break;
+
+			case "tool_call_update":
+				this.emitSessionUpdate({
+					type: "tool_call_update",
+					sessionId,
+					toolCallId: update.toolCallId,
+					title: update.title,
+					status: update.status ?? undefined,
+					kind: update.kind ?? undefined,
+					content: AcpTypeConverter.toToolCallContent(update.content),
+					locations:
+						update.locations === undefined
+							? undefined
+							: (update.locations ?? []),
+					rawInput: update.rawInput as
+						| { [k: string]: unknown }
+						| undefined,
+					rawOutput: update.rawOutput,
 				});
 				break;
 

--- a/src/acp/type-converter.ts
+++ b/src/acp/type-converter.ts
@@ -34,9 +34,7 @@ export class AcpTypeConverter {
 	/**
 	 * Convert ACP ToolCallContent to domain ToolCallContent.
 	 *
-	 * Filters out content types that are not supported by the domain model:
-	 * - Supports: "diff", "terminal"
-	 * - Ignores: "content" (not implemented in UI)
+	 * Preserves standard ACP content blocks as well as diffs and terminals.
 	 *
 	 * @param acpContent - Tool call content from ACP protocol
 	 * @returns Domain model tool call content, or undefined if input is null/empty
@@ -57,12 +55,84 @@ export class AcpTypeConverter {
 	static toToolCallContent(
 		acpContent: acp.ToolCallContent[] | undefined | null,
 	): ToolCallContent[] | undefined {
-		if (!acpContent) return undefined;
+		if (acpContent === undefined) return undefined;
+		if (acpContent === null || acpContent.length === 0) return [];
 
 		const converted: ToolCallContent[] = [];
 
 		for (const item of acpContent) {
-			if (item.type === "diff") {
+			if (item.type === "content") {
+				const content = item.content;
+				switch (content.type) {
+					case "text":
+						converted.push({
+							type: "content",
+							content: { type: "text", text: content.text },
+						});
+						break;
+					case "image":
+						converted.push({
+							type: "content",
+							content: {
+								type: "image",
+								data: content.data,
+								mimeType: content.mimeType,
+								uri: content.uri ?? undefined,
+							},
+						});
+						break;
+					case "audio":
+						converted.push({
+							type: "content",
+							content: {
+								type: "audio",
+								data: content.data,
+								mimeType: content.mimeType,
+							},
+						});
+						break;
+					case "resource_link":
+						converted.push({
+							type: "content",
+							content: {
+								type: "resource_link",
+								uri: content.uri,
+								name: content.name,
+								title: content.title ?? undefined,
+								description: content.description ?? undefined,
+								mimeType: content.mimeType ?? undefined,
+								size: content.size ?? undefined,
+							},
+						});
+						break;
+					case "resource": {
+						const resource = content.resource;
+						converted.push({
+							type: "content",
+							content: {
+								type: "resource",
+								resource:
+									"text" in resource
+										? {
+												uri: resource.uri,
+												mimeType:
+													resource.mimeType ??
+													undefined,
+												text: resource.text,
+											}
+										: {
+												uri: resource.uri,
+												mimeType:
+													resource.mimeType ??
+													undefined,
+												blob: resource.blob,
+											},
+							},
+						});
+						break;
+					}
+				}
+			} else if (item.type === "diff") {
 				converted.push({
 					type: "diff",
 					path: item.path,
@@ -75,10 +145,9 @@ export class AcpTypeConverter {
 					terminalId: item.terminalId,
 				});
 			}
-			// "content" type is intentionally ignored (not implemented in UI)
 		}
 
-		return converted.length > 0 ? converted : undefined;
+		return converted;
 	}
 
 	/**

--- a/src/services/message-state.ts
+++ b/src/services/message-state.ts
@@ -23,6 +23,13 @@ export type ToolCallMessageContent = Extract<
 	MessageContent,
 	{ type: "tool_call" }
 >;
+export type ToolCallMessageUpdate = Omit<
+	Partial<ToolCallMessageContent>,
+	"type" | "toolCallId"
+> & {
+	type: "tool_call";
+	toolCallId: string;
+};
 
 // ============================================================================
 // Tool Call Merge
@@ -34,23 +41,10 @@ export type ToolCallMessageContent = Extract<
  */
 export function mergeToolCallContent(
 	existing: ToolCallMessageContent,
-	update: ToolCallMessageContent,
+	update: ToolCallMessageUpdate,
 ): ToolCallMessageContent {
-	// Merge content arrays
-	let mergedContent = existing.content || [];
-	if (update.content !== undefined) {
-		const newContent = update.content || [];
-
-		// If new content contains diff, replace all old diffs
-		const hasDiff = newContent.some((item) => item.type === "diff");
-		if (hasDiff) {
-			mergedContent = mergedContent.filter(
-				(item) => item.type !== "diff",
-			);
-		}
-
-		mergedContent = [...mergedContent, ...newContent];
-	}
+	const mergedContent =
+		update.content !== undefined ? update.content : existing.content;
 
 	return {
 		...existing,
@@ -68,6 +62,10 @@ export function mergeToolCallContent(
 			Object.keys(update.rawInput).length > 0
 				? update.rawInput
 				: existing.rawInput,
+		rawOutput:
+			update.rawOutput !== undefined
+				? update.rawOutput
+				: existing.rawOutput,
 		permissionRequest:
 			update.permissionRequest !== undefined
 				? update.permissionRequest
@@ -190,7 +188,7 @@ export function applyUpdateUserMessage(
  */
 export function applyUpsertToolCall(
 	prev: ChatMessage[],
-	content: ToolCallMessageContent,
+	content: ToolCallMessageUpdate,
 	toolCallIndex: Map<string, number>,
 ): ChatMessage[] {
 	// O(1) lookup via index
@@ -253,7 +251,12 @@ export function applyUpsertToolCall(
 		{
 			id: crypto.randomUUID(),
 			role: "assistant" as const,
-			content: [content],
+			content: [
+				{
+					...content,
+					status: content.status ?? "pending",
+				},
+			],
 			timestamp: new Date(),
 		},
 	];
@@ -302,6 +305,22 @@ export function applySingleUpdate(
 				text: update.text,
 			});
 		case "tool_call":
+			return applyUpsertToolCall(
+				prev,
+				{
+					type: "tool_call",
+					toolCallId: update.toolCallId,
+					title: update.title,
+					status: update.status,
+					kind: update.kind,
+					content: update.content,
+					locations: update.locations,
+					rawInput: update.rawInput,
+					rawOutput: update.rawOutput,
+					permissionRequest: update.permissionRequest,
+				},
+				toolCallIndex,
+			);
 		case "tool_call_update":
 			return applyUpsertToolCall(
 				prev,
@@ -309,11 +328,12 @@ export function applySingleUpdate(
 					type: "tool_call",
 					toolCallId: update.toolCallId,
 					title: update.title,
-					status: update.status || "pending",
+					status: update.status,
 					kind: update.kind,
 					content: update.content,
 					locations: update.locations,
 					rawInput: update.rawInput,
+					rawOutput: update.rawOutput,
 					permissionRequest: update.permissionRequest,
 				},
 				toolCallIndex,

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -44,9 +44,58 @@ export type ToolKind =
 
 /**
  * Content that can be included in a tool call result.
- * Currently supports diffs and terminal output.
+ * Supports ACP standard content blocks, diffs, and terminal output.
  */
-export type ToolCallContent = DiffContent | TerminalContent;
+export type ToolCallContent =
+	| StandardToolCallContent
+	| DiffContent
+	| TerminalContent;
+
+/** A displayable ACP content block returned by a tool. */
+export type ToolResultContentBlock =
+	| {
+			type: "text";
+			text: string;
+	  }
+	| {
+			type: "image";
+			data: string;
+			mimeType: string;
+			uri?: string;
+	  }
+	| {
+			type: "audio";
+			data: string;
+			mimeType: string;
+	  }
+	| {
+			type: "resource_link";
+			uri: string;
+			name: string;
+			title?: string;
+			description?: string;
+			mimeType?: string;
+			size?: number;
+	  }
+	| {
+			type: "resource";
+			resource:
+				| {
+						uri: string;
+						mimeType?: string;
+						text: string;
+				  }
+				| {
+						uri: string;
+						mimeType?: string;
+						blob: string;
+				  };
+	  };
+
+export interface StandardToolCallContent {
+	type: "content";
+	content: ToolResultContentBlock;
+}
 
 /**
  * Represents a file modification with before/after content.
@@ -121,7 +170,7 @@ export interface ToolCallInfo {
 	content?: ToolCallContent[] | null;
 	locations?: ToolCallLocation[] | null;
 	rawInput?: { [k: string]: unknown }; // Tool's input parameters
-	rawOutput?: { [k: string]: unknown }; // Tool's output data
+	rawOutput?: unknown; // Tool's output data
 }
 
 // ============================================================================
@@ -197,7 +246,7 @@ export type MessageContent =
 			content?: ToolCallContent[];
 			locations?: ToolCallLocation[];
 			rawInput?: { [k: string]: unknown };
-			rawOutput?: { [k: string]: unknown };
+			rawOutput?: unknown;
 			permissionRequest?: {
 				requestId: string;
 				options: PermissionOption[];

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -297,12 +297,13 @@ export interface UserMessageChunk extends SessionUpdateBase {
 export interface ToolCall extends SessionUpdateBase {
 	type: "tool_call";
 	toolCallId: string;
-	title?: string;
+	title?: string | null;
 	status: ToolCallStatus;
 	kind?: ToolKind;
 	content?: ToolCallContent[];
 	locations?: ToolCallLocation[];
 	rawInput?: { [k: string]: unknown };
+	rawOutput?: unknown;
 	permissionRequest?: {
 		requestId: string;
 		options: PermissionOption[];
@@ -320,12 +321,13 @@ export interface ToolCall extends SessionUpdateBase {
 export interface ToolCallUpdate extends SessionUpdateBase {
 	type: "tool_call_update";
 	toolCallId: string;
-	title?: string;
+	title?: string | null;
 	status?: ToolCallStatus;
 	kind?: ToolKind;
 	content?: ToolCallContent[];
 	locations?: ToolCallLocation[];
 	rawInput?: { [k: string]: unknown };
+	rawOutput?: unknown;
 	permissionRequest?: {
 		requestId: string;
 		options: PermissionOption[];

--- a/src/ui/ToolCallBlock.tsx
+++ b/src/ui/ToolCallBlock.tsx
@@ -9,6 +9,7 @@ import { PermissionBanner } from "./PermissionBanner";
 import { LucideIcon } from "./shared/IconButton";
 import { toRelativePath } from "../utils/paths";
 import * as Diff from "diff";
+import { ToolResultContent } from "./ToolResultContent";
 // import { MarkdownRenderer } from "./shared/MarkdownRenderer";
 
 interface ToolCallBlockProps {
@@ -35,6 +36,7 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 		permissionRequest,
 		locations,
 		rawInput,
+		rawOutput,
 		content: toolContent,
 	} = content;
 
@@ -139,6 +141,14 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 			{/* Tool call content (diffs, terminal output, etc.) */}
 			{toolContent &&
 				toolContent.map((item, index) => {
+					if (item.type === "content") {
+						return (
+							<ToolResultContent
+								key={index}
+								content={item.content}
+							/>
+						);
+					}
 					if (item.type === "terminal") {
 						return (
 							<TerminalBlock
@@ -167,6 +177,18 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 					}
 					return null;
 				})}
+
+			{rawOutput !== undefined &&
+				(!toolContent || toolContent.length === 0) && (
+					<details className="agent-client-tool-result-raw">
+						<summary>Raw output</summary>
+						<pre>
+							{typeof rawOutput === "string"
+								? rawOutput
+								: JSON.stringify(rawOutput, null, 2)}
+						</pre>
+					</details>
+				)}
 
 			{/* Permission request section */}
 			{permissionRequest && (

--- a/src/ui/ToolResultContent.tsx
+++ b/src/ui/ToolResultContent.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import type { ToolResultContentBlock } from "../types/chat";
+
+interface ToolResultContentProps {
+	content: ToolResultContentBlock;
+}
+
+/** Render ACP standard tool result content inside the existing tool block. */
+export function ToolResultContent({ content }: ToolResultContentProps) {
+	switch (content.type) {
+		case "text":
+			return (
+				<pre className="agent-client-tool-result-text">
+					{content.text}
+				</pre>
+			);
+		case "image":
+			return (
+				<img
+					className="agent-client-tool-result-image"
+					src={`data:${content.mimeType};base64,${content.data}`}
+					alt="Tool result"
+				/>
+			);
+		case "audio":
+			return (
+				<audio
+					className="agent-client-tool-result-audio"
+					controls
+					src={`data:${content.mimeType};base64,${content.data}`}
+					aria-label="Tool result audio"
+				/>
+			);
+		case "resource_link":
+			return (
+				<a
+					className="agent-client-tool-result-resource"
+					href={content.uri}
+					target="_blank"
+					rel="noreferrer"
+					title={content.uri}
+				>
+					<strong>{content.title || content.name}</strong>
+					{content.description && (
+						<small>{content.description}</small>
+					)}
+				</a>
+			);
+		case "resource": {
+			const { resource } = content;
+			return (
+				<details className="agent-client-tool-result-resource-embedded">
+					<summary>{resource.uri}</summary>
+					{"text" in resource ? (
+						<pre>{resource.text}</pre>
+					) : (
+						<p>
+							Binary resource ·{" "}
+							{resource.mimeType || "unknown type"}
+						</p>
+					)}
+				</details>
+			);
+		}
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -1534,6 +1534,68 @@ If your plugin does not need CSS, delete this file.
 	word-break: break-word;
 }
 
+.agent-client-tool-result-text,
+.agent-client-tool-result-resource-embedded pre,
+.agent-client-tool-result-raw pre {
+	max-height: 320px;
+	margin: 6px 0 0;
+	padding: 8px;
+	overflow: auto;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	background-color: var(--background-primary);
+	font-family: var(--font-monospace);
+	font-size: 0.9em;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.agent-client-tool-result-image {
+	display: block;
+	max-width: 100%;
+	max-height: 384px;
+	margin-top: 6px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	object-fit: contain;
+}
+
+.agent-client-tool-result-audio {
+	width: min(100%, 448px);
+	margin-top: 6px;
+}
+
+.agent-client-tool-result-resource {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 2px;
+	max-width: 100%;
+	margin-top: 6px;
+	padding: 8px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	color: var(--text-normal);
+	text-decoration: none;
+	overflow-wrap: anywhere;
+}
+
+.agent-client-tool-result-resource small,
+.agent-client-tool-result-resource-embedded p {
+	color: var(--text-muted);
+}
+
+.agent-client-tool-result-resource-embedded,
+.agent-client-tool-result-raw {
+	margin-top: 6px;
+}
+
+.agent-client-tool-result-resource-embedded summary,
+.agent-client-tool-result-raw summary {
+	cursor: pointer;
+	overflow-wrap: anywhere;
+}
+
 /* ===== Attachment Preview Strip ===== */
 .agent-client-attachment-preview-strip {
 	display: flex;

--- a/test/tool-call-content.test.ts
+++ b/test/tool-call-content.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import type * as acp from "@agentclientprotocol/sdk";
+import { AcpTypeConverter } from "../src/acp/type-converter";
+import { mergeToolCallContent } from "../src/services/message-state";
+import type { MessageContent } from "../src/types/chat";
+
+type ToolCallMessage = Extract<MessageContent, { type: "tool_call" }>;
+
+function tool(overrides: Partial<ToolCallMessage> = {}): ToolCallMessage {
+	return {
+		type: "tool_call",
+		toolCallId: "tool-1",
+		status: "in_progress",
+		...overrides,
+	};
+}
+
+describe("AcpTypeConverter.toToolCallContent", () => {
+	it("preserves all ACP standard content, diff, and terminal blocks", () => {
+		const input: acp.ToolCallContent[] = [
+			{ type: "content", content: { type: "text", text: "result" } },
+			{
+				type: "content",
+				content: {
+					type: "image",
+					data: "abc",
+					mimeType: "image/png",
+					uri: null,
+				},
+			},
+			{
+				type: "content",
+				content: {
+					type: "audio",
+					data: "audio",
+					mimeType: "audio/mpeg",
+				},
+			},
+			{
+				type: "content",
+				content: {
+					type: "resource_link",
+					uri: "file:///result.txt",
+					name: "result.txt",
+				},
+			},
+			{
+				type: "content",
+				content: {
+					type: "resource",
+					resource: {
+						uri: "file:///embedded.txt",
+						mimeType: "text/plain",
+						text: "resource body",
+					},
+				},
+			},
+			{
+				type: "diff",
+				path: "src/App.tsx",
+				oldText: "old",
+				newText: "new",
+			},
+			{ type: "terminal", terminalId: "terminal-1" },
+		];
+
+		const converted = AcpTypeConverter.toToolCallContent(input);
+		expect(converted).toHaveLength(7);
+		expect(converted?.map((item) => item.type)).toEqual([
+			"content",
+			"content",
+			"content",
+			"content",
+			"content",
+			"diff",
+			"terminal",
+		]);
+		expect(converted?.[0]).toEqual({
+			type: "content",
+			content: { type: "text", text: "result" },
+		});
+		expect(converted?.[3]).toEqual({
+			type: "content",
+			content: {
+				type: "resource_link",
+				uri: "file:///result.txt",
+				name: "result.txt",
+				title: undefined,
+				description: undefined,
+				mimeType: undefined,
+				size: undefined,
+			},
+		});
+	});
+
+	it("distinguishes an omitted update from an explicit clear", () => {
+		expect(AcpTypeConverter.toToolCallContent(undefined)).toBeUndefined();
+		expect(AcpTypeConverter.toToolCallContent(null)).toEqual([]);
+		expect(AcpTypeConverter.toToolCallContent([])).toEqual([]);
+	});
+});
+
+describe("mergeToolCallContent", () => {
+	it("replaces content collections and retains omitted raw output", () => {
+		const existing = tool({
+			content: [{ type: "terminal", terminalId: "old-terminal" }],
+			rawOutput: { stdout: "done" },
+		});
+		const update = {
+			type: "tool_call" as const,
+			toolCallId: "tool-1",
+			status: "completed" as const,
+			content: [
+				{
+					type: "content" as const,
+					content: { type: "text" as const, text: "final result" },
+				},
+			],
+		};
+
+		const merged = mergeToolCallContent(existing, update);
+		expect(merged.content).toEqual(update.content);
+		expect(merged.rawOutput).toEqual({ stdout: "done" });
+	});
+
+	it("retains status when a partial update omits it", () => {
+		const merged = mergeToolCallContent(tool(), {
+			type: "tool_call",
+			toolCallId: "tool-1",
+			rawOutput: { stdout: "still running" },
+		});
+		expect(merged.status).toBe("in_progress");
+	});
+
+	it("honors an explicitly empty content collection", () => {
+		const merged = mergeToolCallContent(
+			tool({ content: [{ type: "terminal", terminalId: "terminal-1" }] }),
+			{
+				type: "tool_call",
+				toolCallId: "tool-1",
+				content: [],
+			},
+		);
+		expect(merged.content).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

- preserve ACP standard tool-result content instead of dropping it in the protocol converter
- render text, image, audio, resource-link, and embedded-resource blocks inside the existing tool-call UI
- preserve `rawOutput` as `unknown` and expose it as a collapsed fallback when structured content is absent
- distinguish omitted content from an explicit empty collection
- treat `tool_call_update.content` as replacement data to prevent duplicate streamed results
- retain the existing diff and terminal renderers

Closes #386.

## Scope

This PR intentionally stays within the existing `ToolCallBlock`. It does not include conversation-turn grouping, activity timelines, or broader visual changes.

## Tests

- `npm test` — full suite passed
- `npm run build` — passed
- `npm run lint` — 0 errors (existing sentence-case warnings remain)
- changed-file Prettier check — passed
- conversion tests cover all five standard ACP content block types plus diff and terminal blocks
- message-state tests cover replacement, explicit clearing, partial updates, and `rawOutput` retention

## Draft checklist

- [x] Protocol conversion and state regression coverage
- [x] Existing diff and terminal behavior retained
- [x] Maintainer feedback on rendering and replacement semantics
- [x] Final manual UI verification before marking ready


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying structured tool results, including text, images, audio, links, and embedded resources.
  * Added collapsible raw output for tool calls without structured content.
  * Tool-call updates now preserve richer content and output details.

* **Bug Fixes**
  * Improved handling of pending and partial tool-call updates.
  * Correctly distinguishes omitted, empty, and null result content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->