### PR TITLE
feat: add conversation turn navigation

### DIFF
--- a/src/services/conversation-navigation.ts
+++ b/src/services/conversation-navigation.ts
@@ -1,0 +1,149 @@
+import type { ChatMessage, MessageContent } from "../types/chat";
+
+const QUESTION_SUMMARY_LIMIT = 160;
+const RESPONSE_SUMMARY_LIMIT = 280;
+
+export interface ConversationNavigationItem {
+	id: string;
+	messageIndex: number;
+	question: string;
+	response: string;
+}
+
+export interface ConversationMessagePosition {
+	index: number;
+	start: number;
+	end: number;
+}
+
+function normalizeSummary(value: string): string {
+	return value.replace(/\s+/g, " ").trim();
+}
+
+function truncateSummary(value: string, limit: number): string {
+	return value.length <= limit ? value : `${value.slice(0, limit - 1)}…`;
+}
+
+function textFromContent(content: MessageContent[]): string | undefined {
+	const text = content
+		.flatMap((item) => {
+			switch (item.type) {
+				case "text":
+				case "text_with_context":
+					return [item.text];
+				default:
+					return [];
+			}
+		})
+		.join(" ");
+	const normalized = normalizeSummary(text);
+	return normalized || undefined;
+}
+
+function getUserFallback(message: ChatMessage): string {
+	if (message.content.some((item) => item.type === "image")) {
+		return "Image message";
+	}
+	const resource = message.content.find(
+		(item) => item.type === "resource_link",
+	);
+	if (resource?.type === "resource_link") {
+		return `Attachment: ${resource.name}`;
+	}
+	return "User message";
+}
+
+function getAssistantFallback(messages: ChatMessage[]): string {
+	const toolCall = messages
+		.flatMap((message) => message.content)
+		.find((item) => item.type === "tool_call");
+	if (toolCall?.type === "tool_call") {
+		return toolCall.title
+			? `Tool activity: ${toolCall.title}`
+			: "Assistant used tools in this turn.";
+	}
+	if (
+		messages.some((message) =>
+			message.content.some((item) => item.type === "image"),
+		)
+	) {
+		return "Assistant response includes an image.";
+	}
+	if (
+		messages.some((message) =>
+			message.content.some((item) => item.type === "resource_link"),
+		)
+	) {
+		return "Assistant response includes an attachment.";
+	}
+	return "No text response in this turn.";
+}
+
+export function getConversationNavigationItems(
+	messages: ChatMessage[],
+): ConversationNavigationItem[] {
+	const items: ConversationNavigationItem[] = [];
+
+	for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+		const userMessage = messages[messageIndex];
+		if (userMessage.role !== "user") continue;
+
+		let nextUserIndex = messageIndex + 1;
+		while (
+			nextUserIndex < messages.length &&
+			messages[nextUserIndex].role !== "user"
+		) {
+			nextUserIndex++;
+		}
+		const assistantMessages = messages
+			.slice(messageIndex + 1, nextUserIndex)
+			.filter((message) => message.role === "assistant");
+		const assistantText = assistantMessages
+			.map((message) => textFromContent(message.content))
+			.filter((value): value is string => Boolean(value))
+			.join(" ");
+
+		items.push({
+			id: userMessage.id,
+			messageIndex,
+			question: truncateSummary(
+				textFromContent(userMessage.content) ??
+					getUserFallback(userMessage),
+				QUESTION_SUMMARY_LIMIT,
+			),
+			response: truncateSummary(
+				normalizeSummary(assistantText) ||
+					getAssistantFallback(assistantMessages),
+				RESPONSE_SUMMARY_LIMIT,
+			),
+		});
+	}
+
+	return items;
+}
+
+export function selectActiveNavigationIndex(
+	items: ConversationNavigationItem[],
+	positions: ConversationMessagePosition[],
+	anchorOffset: number,
+	isAtBottom: boolean,
+): number {
+	if (items.length === 0) return -1;
+	if (isAtBottom) return items.length - 1;
+	if (positions.length === 0) return 0;
+
+	let anchorMessageIndex = positions[0].index;
+	for (const position of positions) {
+		if (anchorOffset >= position.start) {
+			anchorMessageIndex = position.index;
+		}
+		if (anchorOffset < position.end) break;
+	}
+
+	let activeIndex = 0;
+	for (let index = 0; index < items.length; index++) {
+		if (items[index].messageIndex > anchorMessageIndex) break;
+		activeIndex = index;
+	}
+	return activeIndex;
+}

--- a/src/ui/ConversationTurnNavigator.tsx
+++ b/src/ui/ConversationTurnNavigator.tsx
@@ -1,0 +1,96 @@
+import * as React from "react";
+import type { ConversationNavigationItem } from "../services/conversation-navigation";
+
+interface ConversationTurnNavigatorProps {
+	items: ConversationNavigationItem[];
+	activeIndex: number;
+	onNavigate: (item: ConversationNavigationItem, index: number) => void;
+	onWheel: (deltaY: number) => void;
+}
+
+export const ConversationTurnNavigator = React.memo(
+	function ConversationTurnNavigator({
+		items,
+		activeIndex,
+		onNavigate,
+		onWheel,
+	}: ConversationTurnNavigatorProps) {
+		const [isInteracting, setIsInteracting] = React.useState(false);
+		const collapseTimerRef = React.useRef<number | null>(null);
+
+		const activate = React.useCallback(() => {
+			if (collapseTimerRef.current !== null) {
+				window.clearTimeout(collapseTimerRef.current);
+				collapseTimerRef.current = null;
+			}
+			setIsInteracting(true);
+		}, []);
+
+		const scheduleCollapse = React.useCallback(() => {
+			if (collapseTimerRef.current !== null) {
+				window.clearTimeout(collapseTimerRef.current);
+			}
+			collapseTimerRef.current = window.setTimeout(() => {
+				setIsInteracting(false);
+				collapseTimerRef.current = null;
+			}, 160);
+		}, []);
+
+		React.useEffect(
+			() => () => {
+				if (collapseTimerRef.current !== null) {
+					window.clearTimeout(collapseTimerRef.current);
+				}
+			},
+			[],
+		);
+
+		return (
+			<nav
+				className={`agent-client-turn-navigator ${isInteracting ? "agent-client-is-interacting" : ""}`}
+				aria-label="Conversation turns"
+				onMouseLeave={scheduleCollapse}
+				onFocus={activate}
+				onBlur={(event) => {
+					if (!event.currentTarget.contains(event.relatedTarget)) {
+						scheduleCollapse();
+					}
+				}}
+			>
+				{items.map((item, index) => (
+					<button
+						key={item.id}
+						type="button"
+						className={`agent-client-turn-navigator-item ${index === activeIndex ? "agent-client-is-active" : ""}`}
+						aria-current={
+							index === activeIndex ? "step" : undefined
+						}
+						aria-label={`Go to turn ${index + 1}: ${item.question}`}
+						onClick={() => onNavigate(item, index)}
+						onMouseEnter={activate}
+						onWheel={(event) => {
+							event.preventDefault();
+							onWheel(event.deltaY);
+						}}
+					>
+						<span
+							className="agent-client-turn-navigator-line"
+							aria-hidden="true"
+						/>
+						<span
+							className="agent-client-turn-navigator-preview"
+							role="tooltip"
+						>
+							<span className="agent-client-turn-navigator-question">
+								{item.question}
+							</span>
+							<span className="agent-client-turn-navigator-response">
+								{item.response}
+							</span>
+						</span>
+					</button>
+				))}
+			</nav>
+		);
+	},
+);

--- a/src/ui/ConversationTurnNavigator.tsx
+++ b/src/ui/ConversationTurnNavigator.tsx
@@ -17,6 +17,7 @@ export const ConversationTurnNavigator = React.memo(
 	}: ConversationTurnNavigatorProps) {
 		const [isInteracting, setIsInteracting] = React.useState(false);
 		const collapseTimerRef = React.useRef<number | null>(null);
+		const previewIdPrefix = React.useId();
 
 		const activate = React.useCallback(() => {
 			if (collapseTimerRef.current !== null) {
@@ -56,40 +57,45 @@ export const ConversationTurnNavigator = React.memo(
 						scheduleCollapse();
 					}
 				}}
+				onWheel={(event) => {
+					event.preventDefault();
+					onWheel(event.deltaY);
+				}}
 			>
-				{items.map((item, index) => (
-					<button
-						key={item.id}
-						type="button"
-						className={`agent-client-turn-navigator-item ${index === activeIndex ? "agent-client-is-active" : ""}`}
-						aria-current={
-							index === activeIndex ? "step" : undefined
-						}
-						aria-label={`Go to turn ${index + 1}: ${item.question}`}
-						onClick={() => onNavigate(item, index)}
-						onMouseEnter={activate}
-						onWheel={(event) => {
-							event.preventDefault();
-							onWheel(event.deltaY);
-						}}
-					>
-						<span
-							className="agent-client-turn-navigator-line"
-							aria-hidden="true"
-						/>
-						<span
-							className="agent-client-turn-navigator-preview"
-							role="tooltip"
+				{items.map((item, index) => {
+					const previewId = `${previewIdPrefix}-turn-${index}`;
+					return (
+						<button
+							key={item.id}
+							type="button"
+							className={`agent-client-turn-navigator-item ${index === activeIndex ? "agent-client-is-active" : ""}`}
+							aria-current={
+								index === activeIndex ? "step" : undefined
+							}
+							aria-label={`Go to turn ${index + 1}: ${item.question}`}
+							aria-describedby={previewId}
+							onClick={() => onNavigate(item, index)}
+							onMouseEnter={activate}
 						>
-							<span className="agent-client-turn-navigator-question">
-								{item.question}
+							<span
+								className="agent-client-turn-navigator-line"
+								aria-hidden="true"
+							/>
+							<span
+								id={previewId}
+								className="agent-client-turn-navigator-preview"
+								role="tooltip"
+							>
+								<span className="agent-client-turn-navigator-question">
+									{item.question}
+								</span>
+								<span className="agent-client-turn-navigator-response">
+									{item.response}
+								</span>
 							</span>
-							<span className="agent-client-turn-navigator-response">
-								{item.response}
-							</span>
-						</span>
-					</button>
-				))}
+						</button>
+					);
+				})}
 			</nav>
 		);
 	},

--- a/src/ui/MessageList.tsx
+++ b/src/ui/MessageList.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-const { useRef, useState, useEffect, useCallback } = React;
+const { useRef, useState, useEffect, useCallback, useMemo } = React;
 
 import type { ChatMessage } from "../types/chat";
 import type { AcpClient } from "../acp/acp-client";
@@ -7,7 +7,12 @@ import type AgentClientPlugin from "../plugin";
 import type { IChatViewHost } from "./view-host";
 import { setIcon } from "obsidian";
 import { MessageBubble } from "./MessageBubble";
+import { ConversationTurnNavigator } from "./ConversationTurnNavigator";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+	getConversationNavigationItems,
+	selectActiveNavigationIndex,
+} from "../services/conversation-navigation";
 
 // How long (ms) after a tab is re-shown we refuse to shrink measured item
 // sizes. Right after re-show the items briefly re-measure small while their
@@ -70,7 +75,15 @@ export function MessageList({
 	hasActivePermission,
 }: MessageListProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
+	const navigationItems = useMemo(
+		() => getConversationNavigationItems(messages),
+		[messages],
+	);
+	const navigationItemsRef = useRef(navigationItems);
+	navigationItemsRef.current = navigationItems;
+	const showTurnNavigator = navigationItems.length >= 3;
 	const [isAtBottom, setIsAtBottom] = useState(true);
+	const [activeNavigationIndex, setActiveNavigationIndex] = useState(0);
 	const isAtBottomRef = useRef(true);
 	const prevIsSendingRef = useRef(false);
 	// Last measured height per message id. Used to keep the virtualizer's total
@@ -157,6 +170,27 @@ export function MessageList({
 		return isNearBottom;
 	}, []);
 
+	const updateActiveNavigation = useCallback(
+		(isNearBottom = isAtBottomRef.current) => {
+			const container = containerRef.current;
+			const currentNavigationItems = navigationItemsRef.current;
+			if (!container || currentNavigationItems.length === 0) return;
+
+			const anchorOffset =
+				container.scrollTop + container.clientHeight * 0.2;
+			const nextIndex = selectActiveNavigationIndex(
+				currentNavigationItems,
+				virtualizer.getVirtualItems(),
+				anchorOffset,
+				isNearBottom,
+			);
+			setActiveNavigationIndex((current) =>
+				current === nextIndex ? current : nextIndex,
+			);
+		},
+		[virtualizer],
+	);
+
 	// Reset scroll state and drop the per-message size cache when messages are
 	// cleared (new chat / restore / fork / restart all funnel through an empty
 	// array first). Prevents stale msgId→height entries from accumulating
@@ -165,6 +199,7 @@ export function MessageList({
 		if (messages.length === 0) {
 			setIsAtBottom(true);
 			isAtBottomRef.current = true;
+			setActiveNavigationIndex(0);
 			sizeCacheRef.current.clear();
 		}
 	}, [messages.length]);
@@ -211,14 +246,23 @@ export function MessageList({
 		if (!container) return;
 
 		const handleScroll = () => {
-			checkIfAtBottom();
+			const isNearBottom = checkIfAtBottom();
+			updateActiveNavigation(isNearBottom);
 		};
 
 		view.registerDomEvent(container, "scroll", handleScroll);
 
 		// Initial check
-		checkIfAtBottom();
-	}, [view, checkIfAtBottom]);
+		const isNearBottom = checkIfAtBottom();
+		updateActiveNavigation(isNearBottom);
+	}, [view, checkIfAtBottom, updateActiveNavigation]);
+
+	useEffect(() => {
+		const frame = window.requestAnimationFrame(() => {
+			updateActiveNavigation();
+		});
+		return () => window.cancelAnimationFrame(frame);
+	}, [navigationItems, updateActiveNavigation]);
 
 	// ============================================================
 	// Render
@@ -242,77 +286,96 @@ export function MessageList({
 	const virtualItems = virtualizer.getVirtualItems();
 
 	return (
-		<div ref={containerRef} className="agent-client-chat-view-messages">
-			{/* Virtualized message list */}
-			<div
-				className="agent-client-virtual-list-inner"
-				style={{
-					height: virtualizer.getTotalSize(),
-					position: "relative",
-				}}
-			>
-				{virtualItems.map((virtualItem) => {
-					const message = messages[virtualItem.index];
-					return (
-						<div
-							key={message.id}
-							ref={virtualizer.measureElement}
-							data-index={virtualItem.index}
-							data-msg-id={message.id}
-							className="agent-client-virtual-item"
-							style={{
-								position: "absolute",
-								top: 0,
-								left: 0,
-								width: "100%",
-								transform: `translateY(${virtualItem.start}px)`,
-							}}
-						>
-							<MessageBubble
-								message={message}
-								plugin={plugin}
-								terminalClient={terminalClient}
-								onApprovePermission={onApprovePermission}
-							/>
-						</div>
-					);
-				})}
-			</div>
-
-			{/* Loading indicator — outside virtualizer */}
-			<div
-				className={`agent-client-loading-indicator ${!isSending ? "agent-client-hidden" : ""}`}
-			>
-				<div className="agent-client-loading-dots">
-					<div className="agent-client-loading-dot"></div>
-					<div className="agent-client-loading-dot"></div>
-					<div className="agent-client-loading-dot"></div>
-					<div className="agent-client-loading-dot"></div>
-					<div className="agent-client-loading-dot"></div>
-					<div className="agent-client-loading-dot"></div>
-					<div className="agent-client-loading-dot"></div>
-					<div className="agent-client-loading-dot"></div>
-					<div className="agent-client-loading-dot"></div>
+		<div className="agent-client-message-list-shell">
+			<div ref={containerRef} className="agent-client-chat-view-messages">
+				{/* Virtualized message list */}
+				<div
+					className="agent-client-virtual-list-inner"
+					style={{
+						height: virtualizer.getTotalSize(),
+						position: "relative",
+					}}
+				>
+					{virtualItems.map((virtualItem) => {
+						const message = messages[virtualItem.index];
+						return (
+							<div
+								key={message.id}
+								ref={virtualizer.measureElement}
+								data-index={virtualItem.index}
+								data-msg-id={message.id}
+								className="agent-client-virtual-item"
+								style={{
+									position: "absolute",
+									top: 0,
+									left: 0,
+									width: "100%",
+									transform: `translateY(${virtualItem.start}px)`,
+								}}
+							>
+								<MessageBubble
+									message={message}
+									plugin={plugin}
+									terminalClient={terminalClient}
+									onApprovePermission={onApprovePermission}
+								/>
+							</div>
+						);
+					})}
 				</div>
-				{hasActivePermission && (
-					<span className="agent-client-loading-status">
-						Waiting for permission...
-					</span>
+
+				{/* Loading indicator — outside virtualizer */}
+				<div
+					className={`agent-client-loading-indicator ${!isSending ? "agent-client-hidden" : ""}`}
+				>
+					<div className="agent-client-loading-dots">
+						<div className="agent-client-loading-dot"></div>
+						<div className="agent-client-loading-dot"></div>
+						<div className="agent-client-loading-dot"></div>
+						<div className="agent-client-loading-dot"></div>
+						<div className="agent-client-loading-dot"></div>
+						<div className="agent-client-loading-dot"></div>
+						<div className="agent-client-loading-dot"></div>
+						<div className="agent-client-loading-dot"></div>
+						<div className="agent-client-loading-dot"></div>
+					</div>
+					{hasActivePermission && (
+						<span className="agent-client-loading-status">
+							Waiting for permission...
+						</span>
+					)}
+				</div>
+
+				{/* Scroll to bottom button */}
+				{!isAtBottom && (
+					<button
+						className="agent-client-scroll-to-bottom"
+						onClick={() => {
+							virtualizer.scrollToIndex(messages.length - 1, {
+								align: "end",
+								behavior: "smooth",
+							});
+						}}
+						ref={(el) => {
+							if (el) setIcon(el, "chevron-down");
+						}}
+					/>
 				)}
 			</div>
 
-			{/* Scroll to bottom button */}
-			{!isAtBottom && (
-				<button
-					className="agent-client-scroll-to-bottom"
-					onClick={() => {
-						virtualizer.scrollToIndex(messages.length - 1, {
-							align: "end",
+			{showTurnNavigator && (
+				<ConversationTurnNavigator
+					items={navigationItems}
+					activeIndex={activeNavigationIndex}
+					onNavigate={(item, index) => {
+						setActiveNavigationIndex(index);
+						virtualizer.scrollToIndex(item.messageIndex, {
+							align: "start",
 							behavior: "smooth",
 						});
 					}}
-					ref={(el) => {
-						if (el) setIcon(el, "chevron-down");
+					onWheel={(deltaY) => {
+						containerRef.current?.scrollBy({ top: deltaY });
 					}}
 				/>
 			)}

--- a/src/ui/MessageList.tsx
+++ b/src/ui/MessageList.tsx
@@ -287,7 +287,12 @@ export function MessageList({
 
 	return (
 		<div className="agent-client-message-list-shell">
-			<div ref={containerRef} className="agent-client-chat-view-messages">
+			<div
+				ref={containerRef}
+				className={`agent-client-chat-view-messages ${
+					showTurnNavigator ? "agent-client-has-turn-navigator" : ""
+				}`}
+			>
 				{/* Virtualized message list */}
 				<div
 					className="agent-client-virtual-list-inner"

--- a/styles.css
+++ b/styles.css
@@ -633,6 +633,14 @@ If your plugin does not need CSS, delete this file.
 }
 
 /* Messages container */
+.agent-client-message-list-shell {
+	position: relative;
+	display: flex;
+	flex: 1;
+	min-height: 0;
+	container-type: inline-size;
+}
+
 .agent-client-chat-view-messages {
 	flex: 1;
 	padding: 16px 8px;
@@ -641,6 +649,174 @@ If your plugin does not need CSS, delete this file.
 	font-size: var(--ac-chat-font-size);
 	min-height: 0;
 	position: relative;
+}
+
+/* Conversation turn navigator */
+.agent-client-turn-navigator {
+	position: absolute;
+	z-index: 20;
+	top: 50%;
+	inset-inline-start: 9px;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	justify-content: center;
+	width: 11px;
+	max-height: min(50%, 320px);
+	padding: 6px 0;
+	gap: 8px;
+	transform: translateY(-50%);
+	overscroll-behavior: none;
+	pointer-events: none;
+	transition:
+		width 140ms ease,
+		gap 140ms ease,
+		padding 140ms ease;
+}
+
+.agent-client-turn-navigator.agent-client-is-interacting {
+	width: 36px;
+	padding: 8px 0;
+	gap: 0;
+	pointer-events: auto;
+}
+
+.agent-client-turn-navigator-item {
+	position: relative;
+	display: block !important;
+	flex: 0 0 2px;
+	width: 11px;
+	min-width: 0;
+	height: 2px;
+	min-height: 2px !important;
+	margin: 0 !important;
+	padding: 0 !important;
+	border: none !important;
+	border-radius: 0;
+	background: transparent !important;
+	box-shadow: none !important;
+	color: var(--text-normal);
+	cursor: pointer;
+	pointer-events: auto;
+	transition:
+		width 140ms ease,
+		height 140ms ease;
+}
+
+.agent-client-turn-navigator.agent-client-is-interacting
+	.agent-client-turn-navigator-item {
+	flex: 0 0 12px;
+	width: 36px;
+	height: 12px;
+	min-height: 12px !important;
+}
+
+.agent-client-turn-navigator-line {
+	display: block;
+	width: 11px;
+	height: 2px;
+	border-radius: 2px;
+	background-color: var(--text-normal);
+	opacity: 0.2;
+	transition:
+		width 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+		height 160ms ease,
+		opacity 160ms ease;
+	pointer-events: none;
+}
+
+.agent-client-turn-navigator-item.agent-client-is-active
+	.agent-client-turn-navigator-line {
+	opacity: 0.62;
+}
+
+.agent-client-turn-navigator
+	.agent-client-turn-navigator-item:hover
+	.agent-client-turn-navigator-line,
+.agent-client-turn-navigator
+	.agent-client-turn-navigator-item:focus-visible
+	.agent-client-turn-navigator-line {
+	width: 27px;
+	height: 3px;
+	opacity: 1;
+}
+
+.agent-client-turn-navigator.agent-client-is-interacting
+	.agent-client-turn-navigator-line {
+	width: 20px;
+	opacity: 0.4;
+}
+
+.agent-client-turn-navigator.agent-client-is-interacting
+	.agent-client-turn-navigator-item:hover
+	.agent-client-turn-navigator-line,
+.agent-client-turn-navigator.agent-client-is-interacting
+	.agent-client-turn-navigator-item:focus-visible
+	.agent-client-turn-navigator-line {
+	width: 32px;
+	opacity: 1;
+}
+
+.agent-client-turn-navigator-preview {
+	pointer-events: none;
+	position: absolute;
+	z-index: 2;
+	top: 50%;
+	inset-inline-start: 44px;
+	display: block;
+	width: min(360px, calc(100cqw - 92px));
+	padding: 13px 15px 14px;
+	visibility: hidden;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 14px;
+	background-color: var(--background-primary);
+	box-shadow: var(--shadow-s);
+	color: var(--text-normal);
+	font-size: 0.9em;
+	line-height: 1.5;
+	text-align: start;
+	opacity: 0;
+	transform: translate(6px, -50%);
+	transition:
+		opacity 100ms ease,
+		transform 140ms ease,
+		visibility 0s linear 140ms;
+}
+
+.agent-client-turn-navigator-question,
+.agent-client-turn-navigator-response {
+	display: -webkit-box;
+	overflow: hidden;
+	-webkit-box-orient: vertical;
+	white-space: normal;
+	word-break: break-word;
+}
+
+.agent-client-turn-navigator-question {
+	-webkit-line-clamp: 2;
+	font-weight: var(--font-semibold);
+}
+
+.agent-client-turn-navigator-response {
+	margin-top: 0.4em;
+	-webkit-line-clamp: 3;
+	color: var(--text-muted);
+}
+
+.agent-client-turn-navigator-item:hover .agent-client-turn-navigator-preview,
+.agent-client-turn-navigator-item:focus-visible
+	.agent-client-turn-navigator-preview {
+	visibility: visible;
+	opacity: 1;
+	transform: translate(0, -50%);
+	transition-delay: 0s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.agent-client-turn-navigator-line,
+	.agent-client-turn-navigator-preview {
+		transition: none;
+	}
 }
 
 /* Virtual item spacing (replaces flex gap: 2px) */

--- a/styles.css
+++ b/styles.css
@@ -667,7 +667,7 @@ If your plugin does not need CSS, delete this file.
 	gap: 8px;
 	transform: translateY(-50%);
 	overscroll-behavior: none;
-	pointer-events: none;
+	pointer-events: auto;
 	transition:
 		width 140ms ease,
 		gap 140ms ease,

--- a/styles.css
+++ b/styles.css
@@ -651,6 +651,10 @@ If your plugin does not need CSS, delete this file.
 	position: relative;
 }
 
+.agent-client-chat-view-messages.agent-client-has-turn-navigator {
+	padding-inline-start: 48px;
+}
+
 /* Conversation turn navigator */
 .agent-client-turn-navigator {
 	position: absolute;

--- a/test/conversation-navigation.test.ts
+++ b/test/conversation-navigation.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+	getConversationNavigationItems,
+	selectActiveNavigationIndex,
+} from "../src/services/conversation-navigation";
+import type { ChatMessage, MessageContent } from "../src/types/chat";
+
+function message(
+	id: string,
+	role: ChatMessage["role"],
+	content: MessageContent[],
+): ChatMessage {
+	return { id, role, content, timestamp: new Date("2026-08-07T00:00:00Z") };
+}
+
+describe("conversation navigation projection", () => {
+	it("maps each user turn to its message index and response", () => {
+		const items = getConversationNavigationItems([
+			message("a0", "assistant", [{ type: "text", text: "Welcome" }]),
+			message("u1", "user", [{ type: "text", text: "First question" }]),
+			message("a1", "assistant", [
+				{ type: "text", text: "First answer" },
+			]),
+			message("u2", "user", [{ type: "text", text: "Second question" }]),
+			message("a2", "assistant", [
+				{ type: "text", text: "Second answer" },
+			]),
+		]);
+
+		expect(items).toEqual([
+			{
+				id: "u1",
+				messageIndex: 1,
+				question: "First question",
+				response: "First answer",
+			},
+			{
+				id: "u2",
+				messageIndex: 3,
+				question: "Second question",
+				response: "Second answer",
+			},
+		]);
+	});
+
+	it("normalizes whitespace, truncates summaries, and uses fallbacks", () => {
+		const longQuestion = `  ${"question ".repeat(30)} `;
+		const longResponse = `\n${"response ".repeat(50)}\n`;
+		const textItems = getConversationNavigationItems([
+			message("u1", "user", [
+				{ type: "text_with_context", text: longQuestion },
+			]),
+			message("a1", "assistant", [{ type: "text", text: longResponse }]),
+		]);
+
+		expect(textItems[0].question).toHaveLength(160);
+		expect(textItems[0].question.endsWith("…")).toBe(true);
+		expect(textItems[0].response).toHaveLength(280);
+		expect(textItems[0].response.endsWith("…")).toBe(true);
+		expect(textItems[0].question).not.toMatch(/\s{2,}/);
+
+		const fallbackItems = getConversationNavigationItems([
+			message("u2", "user", [
+				{ type: "image", data: "image", mimeType: "image/png" },
+			]),
+			message("a2", "assistant", [
+				{ type: "image", data: "image", mimeType: "image/png" },
+			]),
+		]);
+
+		expect(fallbackItems[0].question).toBe("Image message");
+		expect(fallbackItems[0].response).toBe(
+			"Assistant response includes an image.",
+		);
+	});
+});
+
+describe("active conversation navigation selection", () => {
+	const items = [
+		{ id: "u1", messageIndex: 1, question: "one", response: "answer" },
+		{ id: "u2", messageIndex: 3, question: "two", response: "answer" },
+		{ id: "u3", messageIndex: 5, question: "three", response: "answer" },
+	];
+	const positions = [
+		{ index: 0, start: 0, end: 100 },
+		{ index: 1, start: 100, end: 300 },
+		{ index: 2, start: 300, end: 420 },
+		{ index: 3, start: 420, end: 620 },
+		{ index: 4, start: 620, end: 720 },
+		{ index: 5, start: 720, end: 920 },
+	];
+
+	it("selects the user turn at the reading anchor", () => {
+		expect(selectActiveNavigationIndex(items, positions, 20, false)).toBe(
+			0,
+		);
+		expect(selectActiveNavigationIndex(items, positions, 450, false)).toBe(
+			1,
+		);
+		expect(selectActiveNavigationIndex(items, positions, 800, false)).toBe(
+			2,
+		);
+	});
+
+	it("selects the final turn when the viewport is at the bottom", () => {
+		expect(selectActiveNavigationIndex(items, positions, 120, true)).toBe(
+			2,
+		);
+	});
+});


### PR DESCRIPTION
## Description

Add a compact navigator for long chat sessions. Each marker represents a user turn, follows the current reading position, and jumps to the corresponding virtualized message when clicked. Hovering or focusing a marker shows a short question/response preview. Scrolling over the navigator continues to scroll the conversation.

The navigation projection and active-index selection are pure service helpers covered by unit tests. The existing per-message virtualizer and tab scroll-position safeguards remain in place.

The navigator appears after a conversation has at least three user turns.

## Related issue

Closes #392

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes (existing sentence-case warnings only)
- [x] `npm run build` passes
- [ ] Tested in Obsidian
- [x] Existing functionality still works (`npm test`: 204 tests passed)
- [x] Documentation updated if needed (no user-facing setup or configuration changes)

## Testing environment

- Agent: N/A (client-side navigation)
- OS: macOS

## Screenshots

Not included; the control uses the existing Obsidian theme variables and only appears for conversations with at least three user turns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a conversation turn navigator for quickly browsing questions and responses.
  * Displays previews, active-turn indicators, and accessible navigation controls.
  * Updates the highlighted turn while scrolling and supports wheel-based navigation.
  * Includes responsive hover, focus, and reduced-motion behavior.

* **Bug Fixes**
  * Improved conversation previews for empty responses, images, attachments, and tool activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->