### PR TITLE
feat: queue messages during active turns

### DIFF
--- a/src/hooks/useAgent.ts
+++ b/src/hooks/useAgent.ts
@@ -26,7 +26,12 @@ export type { AgentDisplayInfo } from "../services/session-helpers";
 // Types
 // ============================================================================
 
-import type { ChatMessage, ActivePermission } from "../types/chat";
+import type {
+	ChatMessage,
+	ActivePermission,
+	AttachedFile,
+	QueuedPrompt,
+} from "../types/chat";
 import type {
 	ChatSession,
 	SessionModeState,
@@ -46,6 +51,8 @@ export interface UseAgentReturn {
 	messages: ChatMessage[];
 	isSending: boolean;
 	lastUserMessage: string | null;
+	queuedPrompts: QueuedPrompt[];
+	isQueuePaused: boolean;
 
 	// Combined error
 	errorInfo: ErrorInfo | null;
@@ -89,6 +96,14 @@ export interface UseAgentReturn {
 	setMessagesFromLocal: (localMessages: ChatMessage[]) => void;
 	clearError: () => void;
 	setIgnoreUpdates: (ignore: boolean) => void;
+	updateQueuedPrompt: (
+		id: string,
+		content: string,
+		attachments: AttachedFile[],
+	) => void;
+	removeQueuedPrompt: (id: string) => void;
+	resumeQueue: () => void;
+	pauseQueue: () => void;
 	// Permission
 	activePermission: ActivePermission | null;
 	hasActivePermission: boolean;
@@ -182,6 +197,8 @@ export function useAgent(
 			messages: agentMessages.messages,
 			isSending: agentMessages.isSending,
 			lastUserMessage: agentMessages.lastUserMessage,
+			queuedPrompts: agentMessages.queuedPrompts,
+			isQueuePaused: agentMessages.isQueuePaused,
 
 			// Combined error
 			errorInfo,
@@ -206,6 +223,10 @@ export function useAgent(
 			setMessagesFromLocal: agentMessages.setMessagesFromLocal,
 			clearError: agentMessages.clearError,
 			setIgnoreUpdates: agentMessages.setIgnoreUpdates,
+			updateQueuedPrompt: agentMessages.updateQueuedPrompt,
+			removeQueuedPrompt: agentMessages.removeQueuedPrompt,
+			resumeQueue: agentMessages.resumeQueue,
+			pauseQueue: agentMessages.pauseQueue,
 
 			// Permission
 			activePermission: agentMessages.activePermission,
@@ -220,6 +241,8 @@ export function useAgent(
 			agentMessages.messages,
 			agentMessages.isSending,
 			agentMessages.lastUserMessage,
+			agentMessages.queuedPrompts,
+			agentMessages.isQueuePaused,
 			errorInfo,
 			agentSession.createSession,
 			agentSession.restartSession,
@@ -236,6 +259,10 @@ export function useAgent(
 			agentMessages.setMessagesFromLocal,
 			agentMessages.clearError,
 			agentMessages.setIgnoreUpdates,
+			agentMessages.updateQueuedPrompt,
+			agentMessages.removeQueuedPrompt,
+			agentMessages.resumeQueue,
+			agentMessages.pauseQueue,
 			agentMessages.activePermission,
 			agentMessages.hasActivePermission,
 			agentMessages.approvePermission,

--- a/src/hooks/useAgentMessages.ts
+++ b/src/hooks/useAgentMessages.ts
@@ -14,6 +14,8 @@ import type {
 	ActivePermission,
 	ImagePromptContent,
 	ResourceLinkPromptContent,
+	AttachedFile,
+	QueuedPrompt,
 } from "../types/chat";
 import type { ChatSession, SessionUpdate } from "../types/session";
 import type { AcpClient } from "../acp/acp-client";
@@ -31,6 +33,11 @@ import {
 	findActivePermission,
 	selectOption,
 } from "../services/message-state";
+import {
+	createQueuedPrompt,
+	removeQueuedPromptItem,
+	updateQueuedPromptItem,
+} from "../services/message-queue";
 
 // ============================================================================
 // Types
@@ -52,6 +59,8 @@ export interface SendMessageOptions {
 	resourceLinks?: ResourceLinkPromptContent[];
 	/** Whether this is the first message in the session */
 	isFirstMessage?: boolean;
+	/** Original attachments retained for queue display and editing. */
+	attachments?: AttachedFile[];
 }
 
 export interface UseAgentMessagesReturn {
@@ -59,6 +68,8 @@ export interface UseAgentMessagesReturn {
 	messages: ChatMessage[];
 	isSending: boolean;
 	lastUserMessage: string | null;
+	queuedPrompts: QueuedPrompt[];
+	isQueuePaused: boolean;
 
 	// Message operations
 	sendMessage: (
@@ -78,6 +89,14 @@ export interface UseAgentMessagesReturn {
 	setIgnoreUpdates: (ignore: boolean) => void;
 	/** Discard any pending RAF updates and reset streaming state (call after stop/cancel). */
 	clearPendingUpdates: () => void;
+	updateQueuedPrompt: (
+		id: string,
+		content: string,
+		attachments: AttachedFile[],
+	) => void;
+	removeQueuedPrompt: (id: string) => void;
+	resumeQueue: () => void;
+	pauseQueue: () => void;
 
 	// Permission
 	activePermission: ActivePermission | null;
@@ -108,6 +127,16 @@ export function useAgentMessages(
 	const [messages, setMessages] = useState<ChatMessage[]>([]);
 	const [isSending, setIsSending] = useState(false);
 	const [lastUserMessage, setLastUserMessage] = useState<string | null>(null);
+	const [queuedPrompts, setQueuedPrompts] = useState<QueuedPrompt[]>([]);
+	const [isQueuePaused, setIsQueuePaused] = useState(false);
+	const [queueDrainVersion, setQueueDrainVersion] = useState(0);
+	const isSendingRef = useRef(false);
+	const dispatchInProgressRef = useRef(false);
+	type QueuedPromptJob = {
+		prompt: QueuedPrompt;
+		options: SendMessageOptions;
+	};
+	const queuedPromptJobsRef = useRef<QueuedPromptJob[]>([]);
 
 	// Tool call index: toolCallId → message index for O(1) lookup
 	const toolCallIndexRef = useRef<Map<string, number>>(new Map());
@@ -121,9 +150,86 @@ export function useAgentMessages(
 	// generation hasn't changed (fixes Issue #200).
 	const generationRef = useRef(0);
 
-	// Track the current send promise so a new sendMessage() can wait for
-	// the previous one to settle before starting (avoids interleaved sends).
+	// Track the active ACP prompt separately from prompt preparation so queue
+	// draining cannot overlap either phase.
 	const sendPromiseRef = useRef<Promise<void> | null>(null);
+
+	const setSending = useCallback((sending: boolean) => {
+		isSendingRef.current = sending;
+		setIsSending(sending);
+	}, []);
+
+	const setQueuePaused = useCallback((paused: boolean) => {
+		setIsQueuePaused(paused);
+	}, []);
+
+	const clearQueue = useCallback(() => {
+		queuedPromptJobsRef.current = [];
+		setQueuedPrompts([]);
+		setQueuePaused(false);
+	}, [setQueuePaused]);
+
+	const pauseQueue = useCallback(() => {
+		if (queuedPromptJobsRef.current.length > 0) {
+			setQueuePaused(true);
+		}
+	}, [setQueuePaused]);
+
+	const resumeQueue = useCallback(() => {
+		setQueuePaused(false);
+	}, [setQueuePaused]);
+
+	const removeQueuedPrompt = useCallback(
+		(id: string) => {
+			queuedPromptJobsRef.current = queuedPromptJobsRef.current.filter(
+				(job) => job.prompt.id !== id,
+			);
+			setQueuedPrompts((queue) => removeQueuedPromptItem(queue, id));
+			if (queuedPromptJobsRef.current.length === 0) {
+				setQueuePaused(false);
+			}
+		},
+		[setQueuePaused],
+	);
+
+	const updateQueuedPrompt = useCallback(
+		(id: string, content: string, attachments: AttachedFile[]) => {
+			const job = queuedPromptJobsRef.current.find(
+				(candidate) => candidate.prompt.id === id,
+			);
+			if (!job) return;
+
+			const previousAttachments = job.prompt.attachments;
+			const retainedIds = new Set(attachments.map((file) => file.id));
+			const previousImages = previousAttachments.filter(
+				(file) => file.kind === "image",
+			);
+			const previousResources = previousAttachments.filter(
+				(file) => file.kind === "file",
+			);
+
+			job.prompt = {
+				...job.prompt,
+				content,
+				attachments: [...attachments],
+			};
+			job.options = {
+				...job.options,
+				attachments: [...attachments],
+				images: job.options.images?.filter((_image, index) =>
+					retainedIds.has(previousImages[index]?.id ?? ""),
+				),
+				resourceLinks: job.options.resourceLinks?.filter(
+					(_link, index) =>
+						retainedIds.has(previousResources[index]?.id ?? ""),
+				),
+			};
+			setQueuedPrompts((queue) =>
+				updateQueuedPromptItem(queue, id, { content, attachments }),
+			);
+		},
+		[],
+	);
 
 	// ============================================================
 	// Streaming Update Batching
@@ -169,6 +275,7 @@ export function useAgentMessages(
 			pendingUpdatesRef.current = [];
 			flushScheduledRef.current = false;
 			toolCallIndexRef.current.clear();
+			queuedPromptJobsRef.current = [];
 		};
 	}, []);
 
@@ -219,16 +326,17 @@ export function useAgentMessages(
 			});
 		}
 
-		setIsSending(false);
-	}, []);
+		setSending(false);
+	}, [setSending]);
 
 	const clearMessages = useCallback((): void => {
 		setMessages([]);
 		toolCallIndexRef.current.clear();
 		setLastUserMessage(null);
-		setIsSending(false);
+		setSending(false);
+		clearQueue();
 		setErrorInfo(null);
-	}, [setErrorInfo]);
+	}, [clearQueue, setErrorInfo, setSending]);
 
 	const setInitialMessages = useCallback(
 		(
@@ -250,20 +358,22 @@ export function useAgentMessages(
 
 			setMessages(chatMessages);
 			rebuildToolCallIndex(chatMessages, toolCallIndexRef.current);
-			setIsSending(false);
+			setSending(false);
+			clearQueue();
 			setErrorInfo(null);
 		},
-		[setErrorInfo],
+		[clearQueue, setErrorInfo, setSending],
 	);
 
 	const setMessagesFromLocal = useCallback(
 		(localMessages: ChatMessage[]): void => {
 			setMessages(localMessages);
 			rebuildToolCallIndex(localMessages, toolCallIndexRef.current);
-			setIsSending(false);
+			setSending(false);
+			clearQueue();
 			setErrorInfo(null);
 		},
-		[setErrorInfo],
+		[clearQueue, setErrorInfo, setSending],
 	);
 
 	const clearError = useCallback((): void => {
@@ -275,7 +385,7 @@ export function useAgentMessages(
 		return Platform.isWin && settings.windowsWslMode;
 	}, [settingsAccess]);
 
-	const sendMessage = useCallback(
+	const dispatchMessage = useCallback(
 		async (content: string, options: SendMessageOptions): Promise<void> => {
 			if (!session.sessionId) {
 				setErrorInfo({
@@ -285,143 +395,149 @@ export function useAgentMessages(
 				return;
 			}
 
-			// Wait for any in-flight send to settle (e.g. after cancel/stop)
-			// before starting a new one to avoid interleaved state updates.
-			if (sendPromiseRef.current) {
-				try { await sendPromiseRef.current; } catch { /* ignore */ }
-			}
-
+			dispatchInProgressRef.current = true;
 			const currentSessionId = session.sessionId;
 			const generation = ++generationRef.current;
 			const settings = settingsAccess.getSnapshot();
+			setSending(true);
 
-			const prepared = await preparePrompt(
-				{
-					message: content,
-					images: options.images,
-					resourceLinks: options.resourceLinks,
-					activeNote: options.activeNote,
-					vaultBasePath: options.vaultBasePath,
-					isAutoMentionDisabled: options.isAutoMentionDisabled,
-					convertToWsl: shouldConvertToWsl,
-					supportsEmbeddedContext:
-						session.promptCapabilities?.embeddedContext ?? false,
-					maxNoteLength: settings.displaySettings.maxNoteLength,
-					maxSelectionLength:
-						settings.displaySettings.maxSelectionLength,
-					isFirstMessage: options.isFirstMessage,
-					promptInjection: settings.promptInjection.enabled
-						? {
-								latex: settings.promptInjection.latex,
-								wikiLinks: settings.promptInjection.wikiLinks,
-								tables: settings.promptInjection.tables,
-							}
-						: undefined,
-					expandWikilinkContext: settings.expandWikilinkContext,
-					wikilinkResolver: vaultAccess,
-				},
-				vaultAccess,
-				vaultAccess, // IMentionService (same object)
-			);
+			try {
+				const prepared = await preparePrompt(
+					{
+						message: content,
+						images: options.images,
+						resourceLinks: options.resourceLinks,
+						activeNote: options.activeNote,
+						vaultBasePath: options.vaultBasePath,
+						isAutoMentionDisabled: options.isAutoMentionDisabled,
+						convertToWsl: shouldConvertToWsl,
+						supportsEmbeddedContext:
+							session.promptCapabilities?.embeddedContext ??
+							false,
+						maxNoteLength: settings.displaySettings.maxNoteLength,
+						maxSelectionLength:
+							settings.displaySettings.maxSelectionLength,
+						isFirstMessage: options.isFirstMessage,
+						promptInjection: settings.promptInjection.enabled
+							? {
+									latex: settings.promptInjection.latex,
+									wikiLinks:
+										settings.promptInjection.wikiLinks,
+									tables: settings.promptInjection.tables,
+								}
+							: undefined,
+						expandWikilinkContext: settings.expandWikilinkContext,
+						wikilinkResolver: vaultAccess,
+					},
+					vaultAccess,
+					vaultAccess, // IMentionService (same object)
+				);
 
-			const userMessageContent: MessageContent[] = [];
+				const userMessageContent: MessageContent[] = [];
 
-			if (prepared.autoMentionContext) {
-				userMessageContent.push({
-					type: "text_with_context",
-					text: content,
-					autoMentionContext: prepared.autoMentionContext,
-				});
-			} else {
-				userMessageContent.push({
-					type: "text",
-					text: content,
-				});
-			}
-
-			if (options.images && options.images.length > 0) {
-				for (const img of options.images) {
+				if (prepared.autoMentionContext) {
 					userMessageContent.push({
-						type: "image",
-						data: img.data,
-						mimeType: img.mimeType,
+						type: "text_with_context",
+						text: content,
+						autoMentionContext: prepared.autoMentionContext,
+					});
+				} else {
+					userMessageContent.push({
+						type: "text",
+						text: content,
 					});
 				}
-			}
 
-			if (options.resourceLinks && options.resourceLinks.length > 0) {
-				for (const link of options.resourceLinks) {
-					userMessageContent.push({
-						type: "resource_link",
-						uri: link.uri,
-						name: link.name,
-						mimeType: link.mimeType,
-						size: link.size,
-					});
-				}
-			}
-
-			const userMessage: ChatMessage = {
-				id: crypto.randomUUID(),
-				role: "user",
-				content: userMessageContent,
-				timestamp: new Date(),
-			};
-			addMessage(userMessage);
-
-			setIsSending(true);
-			setLastUserMessage(content);
-
-			const sendPromise = (async () => {
-				try {
-					const result = await sendPreparedPrompt(
-						{
-							sessionId: currentSessionId,
-							agentContent: prepared.agentContent,
-							displayContent: prepared.displayContent,
-							authMethods: session.authMethods,
-						},
-						agentClient,
-					);
-
-					// Discard results if a newer send has started
-					if (generationRef.current !== generation) return;
-
-					if (result.success) {
-						setIsSending(false);
-						setLastUserMessage(null);
-					} else {
-						setIsSending(false);
-						setErrorInfo(
-							result.error
-								? {
-										title: result.error.title,
-										message: result.error.message,
-										suggestion: result.error.suggestion,
-									}
-								: {
-										title: "Send Message Failed",
-										message: "Failed to send message",
-									},
-						);
+				if (options.images && options.images.length > 0) {
+					for (const img of options.images) {
+						userMessageContent.push({
+							type: "image",
+							data: img.data,
+							mimeType: img.mimeType,
+						});
 					}
-				} catch (error) {
-					if (generationRef.current !== generation) return;
-					setIsSending(false);
+				}
+
+				if (options.resourceLinks && options.resourceLinks.length > 0) {
+					for (const link of options.resourceLinks) {
+						userMessageContent.push({
+							type: "resource_link",
+							uri: link.uri,
+							name: link.name,
+							mimeType: link.mimeType,
+							size: link.size,
+						});
+					}
+				}
+
+				const userMessage: ChatMessage = {
+					id: crypto.randomUUID(),
+					role: "user",
+					content: userMessageContent,
+					timestamp: new Date(),
+				};
+				addMessage(userMessage);
+				setLastUserMessage(content);
+
+				const sendPromise = (async () => {
+					try {
+						const result = await sendPreparedPrompt(
+							{
+								sessionId: currentSessionId,
+								agentContent: prepared.agentContent,
+								displayContent: prepared.displayContent,
+								authMethods: session.authMethods,
+							},
+							agentClient,
+						);
+
+						if (generationRef.current !== generation) return;
+
+						if (result.success) {
+							setSending(false);
+							setLastUserMessage(null);
+						} else {
+							setSending(false);
+							pauseQueue();
+							setErrorInfo(
+								result.error
+									? {
+											title: result.error.title,
+											message: result.error.message,
+											suggestion: result.error.suggestion,
+										}
+									: {
+											title: "Send Message Failed",
+											message: "Failed to send message",
+										},
+							);
+						}
+					} catch (error) {
+						if (generationRef.current !== generation) return;
+						setSending(false);
+						pauseQueue();
+						setErrorInfo({
+							title: "Send Message Failed",
+							message: `Failed to send message: ${extractErrorMessage(error)}`,
+						});
+					}
+				})();
+
+				sendPromiseRef.current = sendPromise;
+				await sendPromise;
+			} catch (error) {
+				if (generationRef.current === generation) {
+					setSending(false);
+					pauseQueue();
 					setErrorInfo({
 						title: "Send Message Failed",
-						message: `Failed to send message: ${extractErrorMessage(error)}`,
+						message: `Failed to prepare message: ${extractErrorMessage(error)}`,
 					});
 				}
-			})();
-
-			sendPromiseRef.current = sendPromise;
-			try {
-				await sendPromise;
-			} catch {
-				// Error already handled inside sendPromise
 			} finally {
 				sendPromiseRef.current = null;
+				dispatchInProgressRef.current = false;
+				setQueueDrainVersion((version) => version + 1);
 			}
 		},
 		[
@@ -434,8 +550,67 @@ export function useAgentMessages(
 			shouldConvertToWsl,
 			addMessage,
 			setErrorInfo,
+			setSending,
+			pauseQueue,
 		],
 	);
+
+	const sendMessage = useCallback(
+		async (content: string, options: SendMessageOptions): Promise<void> => {
+			if (!session.sessionId) {
+				setErrorInfo({
+					title: "Cannot Send Message",
+					message: "No active session. Please wait for connection.",
+				});
+				return;
+			}
+
+			if (
+				isSendingRef.current ||
+				dispatchInProgressRef.current ||
+				sendPromiseRef.current !== null ||
+				queuedPromptJobsRef.current.length > 0
+			) {
+				const prompt = createQueuedPrompt(content, options.attachments);
+				queuedPromptJobsRef.current.push({
+					prompt,
+					options: { ...options, isFirstMessage: false },
+				});
+				setQueuedPrompts((queue) => [...queue, prompt]);
+				return;
+			}
+
+			await dispatchMessage(content, options);
+		},
+		[dispatchMessage, session.sessionId, setErrorInfo],
+	);
+
+	useEffect(() => {
+		if (
+			isSending ||
+			isQueuePaused ||
+			dispatchInProgressRef.current ||
+			sendPromiseRef.current !== null ||
+			queuedPrompts.length === 0 ||
+			!session.sessionId
+		) {
+			return;
+		}
+
+		const job = queuedPromptJobsRef.current.shift();
+		if (!job) return;
+		setQueuedPrompts((queue) =>
+			removeQueuedPromptItem(queue, job.prompt.id),
+		);
+		void dispatchMessage(job.prompt.content, job.options);
+	}, [
+		dispatchMessage,
+		isQueuePaused,
+		isSending,
+		queuedPrompts.length,
+		queueDrainVersion,
+		session.sessionId,
+	]);
 
 	// ============================================================
 	// Permission State & Operations
@@ -497,6 +672,8 @@ export function useAgentMessages(
 		messages,
 		isSending,
 		lastUserMessage,
+		queuedPrompts,
+		isQueuePaused,
 		sendMessage,
 		clearMessages,
 		setInitialMessages,
@@ -504,6 +681,10 @@ export function useAgentMessages(
 		clearError,
 		setIgnoreUpdates,
 		clearPendingUpdates,
+		updateQueuedPrompt,
+		removeQueuedPrompt,
+		resumeQueue,
+		pauseQueue,
 		activePermission,
 		hasActivePermission,
 		approvePermission,

--- a/src/hooks/useAgentMessages.ts
+++ b/src/hooks/useAgentMessages.ts
@@ -202,10 +202,10 @@ export function useAgentMessages(
 			const previousAttachments = job.prompt.attachments;
 			const retainedIds = new Set(attachments.map((file) => file.id));
 			const previousImages = previousAttachments.filter(
-				(file) => file.kind === "image",
+				(file) => file.kind === "image" && Boolean(file.data),
 			);
 			const previousResources = previousAttachments.filter(
-				(file) => file.kind === "file",
+				(file) => file.kind === "file" && Boolean(file.path),
 			);
 
 			job.prompt = {
@@ -326,8 +326,9 @@ export function useAgentMessages(
 			});
 		}
 
+		pauseQueue();
 		setSending(false);
-	}, [setSending]);
+	}, [pauseQueue, setSending]);
 
 	const clearMessages = useCallback((): void => {
 		setMessages([]);

--- a/src/hooks/useChatActions.ts
+++ b/src/hooks/useChatActions.ts
@@ -188,6 +188,7 @@ export function useChatActions(
 				resourceLinks:
 					resourceLinks.length > 0 ? resourceLinks : undefined,
 				isFirstMessage,
+				attachments: attachments ? [...attachments] : undefined,
 			});
 
 			// Save session metadata locally on first message

--- a/src/services/message-queue.ts
+++ b/src/services/message-queue.ts
@@ -1,5 +1,6 @@
 import type { AttachedFile, QueuedPrompt } from "../types/chat";
 
+/** Create an isolated queued-prompt snapshot for later dispatch. */
 export function createQueuedPrompt(
 	content: string,
 	attachments: AttachedFile[] = [],
@@ -14,6 +15,7 @@ export function createQueuedPrompt(
 	};
 }
 
+/** Update a queued prompt without mutating or reordering the source queue. */
 export function updateQueuedPromptItem(
 	queue: QueuedPrompt[],
 	id: string,
@@ -30,6 +32,7 @@ export function updateQueuedPromptItem(
 	);
 }
 
+/** Remove a queued prompt by id while preserving the order of all others. */
 export function removeQueuedPromptItem(
 	queue: QueuedPrompt[],
 	id: string,

--- a/src/services/message-queue.ts
+++ b/src/services/message-queue.ts
@@ -1,0 +1,38 @@
+import type { AttachedFile, QueuedPrompt } from "../types/chat";
+
+export function createQueuedPrompt(
+	content: string,
+	attachments: AttachedFile[] = [],
+	id = crypto.randomUUID(),
+	createdAt = new Date(),
+): QueuedPrompt {
+	return {
+		id,
+		content,
+		attachments: [...attachments],
+		createdAt,
+	};
+}
+
+export function updateQueuedPromptItem(
+	queue: QueuedPrompt[],
+	id: string,
+	updates: Pick<QueuedPrompt, "content" | "attachments">,
+): QueuedPrompt[] {
+	return queue.map((item) =>
+		item.id === id
+			? {
+					...item,
+					content: updates.content,
+					attachments: [...updates.attachments],
+				}
+			: item,
+	);
+}
+
+export function removeQueuedPromptItem(
+	queue: QueuedPrompt[],
+	id: string,
+): QueuedPrompt[] {
+	return queue.filter((item) => item.id !== id);
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -296,6 +296,14 @@ export interface AttachedFile {
 	size?: number;
 }
 
+/** A prompt waiting for the current agent turn to finish. */
+export interface QueuedPrompt {
+	id: string;
+	content: string;
+	attachments: AttachedFile[];
+	createdAt: Date;
+}
+
 /**
  * ChatInput component state that can be shared between views.
  * Used for broadcast-prompt command.

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -1508,6 +1508,12 @@ export const ChatPanel = React.memo(function ChatPanel({
 			geminiNotice={effectiveGeminiNotice}
 			onClearGeminiNotice={handleClearGeminiNotice}
 			messages={messages}
+			queuedPrompts={agent.queuedPrompts}
+			isQueuePaused={agent.isQueuePaused}
+			onUpdateQueuedPrompt={agent.updateQueuedPrompt}
+			onRemoveQueuedPrompt={agent.removeQueuedPrompt}
+			onResumeQueue={agent.resumeQueue}
+			onPauseQueue={agent.pauseQueue}
 		/>
 	);
 

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -877,7 +877,10 @@ export function InputArea({
 
 				if (shouldSend) {
 					e.preventDefault();
-					if (!isButtonDisabled) {
+					const hasContent =
+						inputValue.trim().length > 0 ||
+						attachedFiles.length > 0;
+					if (hasContent && isSessionReady && !isRestoringSession) {
 						void handleSendOrStop();
 					}
 				}
@@ -887,7 +890,10 @@ export function InputArea({
 		[
 			handleDropdownKeyPress,
 			handleHistoryKeyDown,
-			isButtonDisabled,
+			inputValue,
+			attachedFiles,
+			isSessionReady,
+			isRestoringSession,
 			handleSendOrStop,
 			settings.sendMessageShortcut,
 		],

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -11,12 +11,13 @@ import type {
 	SessionUsage,
 	SessionConfigOption,
 } from "../types/session";
-import type { AttachedFile, ChatMessage } from "../types/chat";
+import type { AttachedFile, ChatMessage, QueuedPrompt } from "../types/chat";
 import type { UseSuggestionsReturn } from "../hooks/useSuggestions";
 import { SuggestionPopup } from "./SuggestionPopup";
 import { ErrorBanner } from "./ErrorBanner";
 import { AttachmentStrip } from "./shared/AttachmentStrip";
 import { InputToolbar } from "./InputToolbar";
+import { QueuedPromptList } from "./QueuedPromptList";
 import { getLogger } from "../utils/logger";
 import type { ErrorInfo } from "../types/errors";
 import type { AgentUpdateNotification } from "../services/update-checker";
@@ -244,6 +245,16 @@ export interface InputAreaProps {
 	onClearGeminiNotice: () => void;
 	/** Messages array for input history navigation */
 	messages: ChatMessage[];
+	queuedPrompts: QueuedPrompt[];
+	isQueuePaused: boolean;
+	onUpdateQueuedPrompt: (
+		id: string,
+		content: string,
+		attachments: AttachedFile[],
+	) => void;
+	onRemoveQueuedPrompt: (id: string) => void;
+	onResumeQueue: () => void;
+	onPauseQueue: () => void;
 }
 
 /**
@@ -295,6 +306,12 @@ export function InputArea({
 	onClearGeminiNotice,
 	// Input history
 	messages,
+	queuedPrompts,
+	isQueuePaused,
+	onUpdateQueuedPrompt,
+	onRemoveQueuedPrompt,
+	onResumeQueue,
+	onPauseQueue,
 }: InputAreaProps) {
 	const { mentions, commands: slashCommands } = suggestions;
 	const logger = getLogger();
@@ -719,7 +736,9 @@ export function InputArea({
 	 * Handle sending or stopping based on current state.
 	 */
 	const handleSendOrStop = useCallback(async () => {
-		if (isSending) {
+		const hasContent =
+			inputValue.trim().length > 0 || attachedFiles.length > 0;
+		if (isSending && !hasContent) {
 			await onStopGeneration();
 			return;
 		}
@@ -858,7 +877,7 @@ export function InputArea({
 
 				if (shouldSend) {
 					e.preventDefault();
-					if (!isButtonDisabled && !isSending) {
+					if (!isButtonDisabled) {
 						void handleSendOrStop();
 					}
 				}
@@ -868,7 +887,6 @@ export function InputArea({
 		[
 			handleDropdownKeyPress,
 			handleHistoryKeyDown,
-			isSending,
 			isButtonDisabled,
 			handleSendOrStop,
 			settings.sendMessageShortcut,
@@ -974,6 +992,15 @@ export function InputArea({
 					variant={geminiNotice.variant}
 				/>
 			)}
+
+			<QueuedPromptList
+				prompts={queuedPrompts}
+				isPaused={isQueuePaused}
+				onUpdate={onUpdateQueuedPrompt}
+				onRemove={onRemoveQueuedPrompt}
+				onResume={onResumeQueue}
+				onPause={onPauseQueue}
+			/>
 
 			{/* Mention Dropdown */}
 			{mentions.isOpen && (

--- a/src/ui/InputToolbar.tsx
+++ b/src/ui/InputToolbar.tsx
@@ -179,7 +179,7 @@ export function InputToolbar({
 				"agent-client-icon-inactive",
 			);
 
-			if (isSending) {
+			if (isSending && !hasContent) {
 				svg.classList.add("agent-client-icon-sending");
 			} else {
 				svg.classList.add(
@@ -194,14 +194,15 @@ export function InputToolbar({
 
 	useEffect(() => {
 		if (sendButtonRef.current) {
-			const iconName = isSending ? "square" : "send-horizontal";
+			const iconName =
+				isSending && !hasContent ? "square" : "send-horizontal";
 			setIcon(sendButtonRef.current, iconName);
 			const svg = sendButtonRef.current.querySelector("svg");
 			if (svg) {
 				updateIconColor(svg);
 			}
 		}
-	}, [isSending, updateIconColor]);
+	}, [hasContent, isSending, updateIconColor]);
 
 	useEffect(() => {
 		if (sendButtonRef.current) {
@@ -326,14 +327,24 @@ export function InputToolbar({
 			{/* Send/Stop Button */}
 			<button
 				ref={sendButtonRef}
+				type="button"
 				onClick={onSendOrStop}
 				disabled={isButtonDisabled}
-				className={`agent-client-chat-send-button ${isSending ? "sending" : ""} ${isButtonDisabled ? "agent-client-disabled" : ""}`}
+				className={`agent-client-chat-send-button ${isSending && !hasContent ? "sending" : ""} ${isButtonDisabled ? "agent-client-disabled" : ""}`}
+				aria-label={
+					isSending
+						? hasContent
+							? "Queue message"
+							: "Stop generation"
+						: "Send message"
+				}
 				title={
 					!isSessionReady
 						? "Connecting..."
 						: isSending
-							? "Stop generation"
+							? hasContent
+								? "Queue message"
+								: "Stop generation"
 							: "Send message"
 				}
 			></button>

--- a/src/ui/InputToolbar.tsx
+++ b/src/ui/InputToolbar.tsx
@@ -332,11 +332,13 @@ export function InputToolbar({
 				disabled={isButtonDisabled}
 				className={`agent-client-chat-send-button ${isSending && !hasContent ? "sending" : ""} ${isButtonDisabled ? "agent-client-disabled" : ""}`}
 				aria-label={
-					isSending
-						? hasContent
-							? "Queue message"
-							: "Stop generation"
-						: "Send message"
+					!isSessionReady
+						? "Connecting"
+						: isSending
+							? hasContent
+								? "Queue message"
+								: "Stop generation"
+							: "Send message"
 				}
 				title={
 					!isSessionReady

--- a/src/ui/QueuedPromptList.tsx
+++ b/src/ui/QueuedPromptList.tsx
@@ -31,11 +31,20 @@ export const QueuedPromptList = React.memo(function QueuedPromptList({
 		[],
 	);
 	const [resumeAfterEdit, setResumeAfterEdit] = useState(false);
+	const canSave = draft.trim().length > 0 || draftAttachments.length > 0;
 	const finishEditing = useCallback(() => {
 		setEditingId(null);
 		if (resumeAfterEdit) onResume();
 		setResumeAfterEdit(false);
 	}, [onResume, resumeAfterEdit]);
+	const saveEditing = useCallback(
+		(id: string) => {
+			if (!canSave) return;
+			onUpdate(id, draft.trim(), draftAttachments);
+			finishEditing();
+		},
+		[canSave, draft, draftAttachments, finishEditing, onUpdate],
+	);
 
 	useEffect(() => {
 		if (editingId && !prompts.some((prompt) => prompt.id === editingId)) {
@@ -86,6 +95,21 @@ export const QueuedPromptList = React.memo(function QueuedPromptList({
 											onChange={(event) =>
 												setDraft(event.target.value)
 											}
+											onKeyDown={(event) => {
+												if (event.key === "Escape") {
+													event.preventDefault();
+													finishEditing();
+													return;
+												}
+												if (
+													event.key === "Enter" &&
+													(event.metaKey ||
+														event.ctrlKey)
+												) {
+													event.preventDefault();
+													saveEditing(prompt.id);
+												}
+											}}
 											rows={2}
 											aria-label="Edit queued message"
 											autoFocus
@@ -104,19 +128,10 @@ export const QueuedPromptList = React.memo(function QueuedPromptList({
 										<div className="agent-client-queued-prompt-edit-actions">
 											<button
 												type="button"
-												onClick={() => {
-													onUpdate(
-														prompt.id,
-														draft.trim(),
-														draftAttachments,
-													);
-													finishEditing();
-												}}
-												disabled={
-													!draft.trim() &&
-													draftAttachments.length ===
-														0
+												onClick={() =>
+													saveEditing(prompt.id)
 												}
+												disabled={!canSave}
 											>
 												Save
 											</button>

--- a/src/ui/QueuedPromptList.tsx
+++ b/src/ui/QueuedPromptList.tsx
@@ -1,0 +1,191 @@
+import * as React from "react";
+const { useCallback, useEffect, useState } = React;
+import { setIcon } from "obsidian";
+import type { AttachedFile, QueuedPrompt } from "../types/chat";
+import { AttachmentStrip } from "./shared/AttachmentStrip";
+
+interface QueuedPromptListProps {
+	prompts: QueuedPrompt[];
+	isPaused: boolean;
+	onUpdate: (
+		id: string,
+		content: string,
+		attachments: AttachedFile[],
+	) => void;
+	onRemove: (id: string) => void;
+	onResume: () => void;
+	onPause: () => void;
+}
+
+export const QueuedPromptList = React.memo(function QueuedPromptList({
+	prompts,
+	isPaused,
+	onUpdate,
+	onRemove,
+	onResume,
+	onPause,
+}: QueuedPromptListProps) {
+	const [editingId, setEditingId] = useState<string | null>(null);
+	const [draft, setDraft] = useState("");
+	const [draftAttachments, setDraftAttachments] = useState<AttachedFile[]>(
+		[],
+	);
+	const [resumeAfterEdit, setResumeAfterEdit] = useState(false);
+	const finishEditing = useCallback(() => {
+		setEditingId(null);
+		if (resumeAfterEdit) onResume();
+		setResumeAfterEdit(false);
+	}, [onResume, resumeAfterEdit]);
+
+	useEffect(() => {
+		if (editingId && !prompts.some((prompt) => prompt.id === editingId)) {
+			finishEditing();
+		}
+	}, [editingId, finishEditing, prompts]);
+
+	if (prompts.length === 0) return null;
+
+	return (
+		<section
+			className="agent-client-queued-prompts"
+			aria-label="Queued messages"
+		>
+			<header className="agent-client-queued-prompts-header">
+				<span>
+					{prompts.length} queued message
+					{prompts.length === 1 ? "" : "s"}
+				</span>
+				{isPaused && (
+					<button type="button" onClick={onResume}>
+						<span
+							className="agent-client-queued-prompt-action-icon"
+							ref={(element) => {
+								if (element) setIcon(element, "play");
+							}}
+						/>
+						Resume
+					</button>
+				)}
+			</header>
+			<div className="agent-client-queued-prompts-list">
+				{prompts.map((prompt, index) => {
+					const isEditing = prompt.id === editingId;
+					return (
+						<article
+							key={prompt.id}
+							className="agent-client-queued-prompt"
+						>
+							<span className="agent-client-queued-prompt-index">
+								{index + 1}
+							</span>
+							<div className="agent-client-queued-prompt-body">
+								{isEditing ? (
+									<>
+										<textarea
+											value={draft}
+											onChange={(event) =>
+												setDraft(event.target.value)
+											}
+											rows={2}
+											aria-label="Edit queued message"
+											autoFocus
+										/>
+										<AttachmentStrip
+											files={draftAttachments}
+											onRemove={(id) =>
+												setDraftAttachments((files) =>
+													files.filter(
+														(file) =>
+															file.id !== id,
+													),
+												)
+											}
+										/>
+										<div className="agent-client-queued-prompt-edit-actions">
+											<button
+												type="button"
+												onClick={() => {
+													onUpdate(
+														prompt.id,
+														draft.trim(),
+														draftAttachments,
+													);
+													finishEditing();
+												}}
+												disabled={
+													!draft.trim() &&
+													draftAttachments.length ===
+														0
+												}
+											>
+												Save
+											</button>
+											<button
+												type="button"
+												onClick={finishEditing}
+											>
+												Cancel
+											</button>
+										</div>
+									</>
+								) : (
+									<>
+										<div className="agent-client-queued-prompt-text">
+											{prompt.content ||
+												"Attachment message"}
+										</div>
+										{prompt.attachments.length > 0 && (
+											<div className="agent-client-queued-prompt-attachment-count">
+												{prompt.attachments.length}{" "}
+												attachment
+												{prompt.attachments.length === 1
+													? ""
+													: "s"}
+											</div>
+										)}
+									</>
+								)}
+							</div>
+							{!isEditing && (
+								<div className="agent-client-queued-prompt-actions">
+									<button
+										type="button"
+										title="Edit queued message"
+										aria-label="Edit queued message"
+										onClick={() => {
+											if (isPaused) {
+												setResumeAfterEdit(false);
+											} else {
+												onPause();
+												setResumeAfterEdit(true);
+											}
+											setEditingId(prompt.id);
+											setDraft(prompt.content);
+											setDraftAttachments([
+												...prompt.attachments,
+											]);
+										}}
+										ref={(element) => {
+											if (element)
+												setIcon(element, "pencil");
+										}}
+									/>
+									<button
+										type="button"
+										title="Delete queued message"
+										aria-label="Delete queued message"
+										onClick={() => onRemove(prompt.id)}
+										ref={(element) => {
+											if (element)
+												setIcon(element, "trash-2");
+										}}
+									/>
+								</div>
+							)}
+						</article>
+					);
+				})}
+			</div>
+		</section>
+	);
+});

--- a/styles.css
+++ b/styles.css
@@ -947,7 +947,7 @@ If your plugin does not need CSS, delete this file.
 	color: var(--text-normal);
 	font-size: var(--font-ui-small);
 	line-height: 1.35;
-	word-break: break-word;
+	overflow-wrap: anywhere;
 }
 
 .agent-client-queued-prompt-attachment-count {

--- a/styles.css
+++ b/styles.css
@@ -851,6 +851,135 @@ If your plugin does not need CSS, delete this file.
 	position: relative;
 }
 
+/* Queued prompts */
+.agent-client-queued-prompts {
+	margin-bottom: 6px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	background-color: var(--background-secondary);
+	overflow: hidden;
+}
+
+.agent-client-queued-prompts-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 6px 8px;
+	border-bottom: 1px solid var(--background-modifier-border);
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+}
+
+.agent-client-queued-prompts-header button,
+.agent-client-queued-prompt-actions button,
+.agent-client-queued-prompt-edit-actions button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 4px;
+	min-width: 0;
+	min-height: 0;
+	margin: 0;
+	padding: 3px 6px;
+	border: none;
+	background: transparent;
+	box-shadow: none;
+	color: var(--text-muted);
+	cursor: pointer;
+}
+
+.agent-client-queued-prompts-header button:hover,
+.agent-client-queued-prompt-actions button:hover,
+.agent-client-queued-prompt-edit-actions button:hover {
+	background-color: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+.agent-client-queued-prompt-action-icon,
+.agent-client-queued-prompt-actions svg {
+	width: 14px;
+	height: 14px;
+}
+
+.agent-client-queued-prompts-list {
+	display: flex;
+	max-height: 180px;
+	flex-direction: column;
+	overflow-y: auto;
+}
+
+.agent-client-queued-prompt {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	padding: 7px 8px;
+	border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.agent-client-queued-prompt:last-child {
+	border-bottom: none;
+}
+
+.agent-client-queued-prompt-index {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 18px;
+	height: 18px;
+	flex: 0 0 18px;
+	border-radius: 50%;
+	background-color: var(--background-modifier-hover);
+	color: var(--text-muted);
+	font-size: 10px;
+}
+
+.agent-client-queued-prompt-body {
+	min-width: 0;
+	flex: 1;
+}
+
+.agent-client-queued-prompt-text {
+	display: -webkit-box;
+	overflow: hidden;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	color: var(--text-normal);
+	font-size: var(--font-ui-small);
+	line-height: 1.35;
+	word-break: break-word;
+}
+
+.agent-client-queued-prompt-attachment-count {
+	margin-top: 2px;
+	color: var(--text-faint);
+	font-size: var(--font-ui-smaller);
+}
+
+.agent-client-queued-prompt-actions,
+.agent-client-queued-prompt-edit-actions {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+}
+
+.agent-client-queued-prompt textarea {
+	width: 100%;
+	min-height: 48px;
+	resize: vertical;
+	font-family: inherit;
+	font-size: var(--font-ui-small);
+}
+
+.agent-client-queued-prompt-edit-actions {
+	justify-content: flex-end;
+	margin-top: 4px;
+}
+
+.agent-client-queued-prompt .agent-client-attachment-preview-strip {
+	padding: 6px 0;
+}
+
 /* Input box - outer container with border and background */
 .agent-client-chat-input-box {
 	display: flex;

--- a/test/message-queue.test.ts
+++ b/test/message-queue.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+	createQueuedPrompt,
+	removeQueuedPromptItem,
+	updateQueuedPromptItem,
+} from "../src/services/message-queue";
+import type { AttachedFile } from "../src/types/chat";
+
+const attachment: AttachedFile = {
+	id: "file-1",
+	kind: "file",
+	mimeType: "text/plain",
+	name: "notes.txt",
+	path: "/tmp/notes.txt",
+};
+
+describe("message queue transforms", () => {
+	it("preserves FIFO order", () => {
+		const first = createQueuedPrompt("first", [], "q1", new Date(1));
+		const second = createQueuedPrompt("second", [], "q2", new Date(2));
+		expect([first, second].map((item) => item.id)).toEqual(["q1", "q2"]);
+	});
+
+	it("edits an item without moving it", () => {
+		const queue = [
+			createQueuedPrompt("first", [], "q1"),
+			createQueuedPrompt("second", [], "q2"),
+		];
+		const updated = updateQueuedPromptItem(queue, "q1", {
+			content: "edited",
+			attachments: [attachment],
+		});
+
+		expect(updated.map((item) => item.id)).toEqual(["q1", "q2"]);
+		expect(updated[0]).toMatchObject({
+			content: "edited",
+			attachments: [attachment],
+		});
+		expect(queue[0].content).toBe("first");
+	});
+
+	it("removes only the requested item", () => {
+		const queue = [
+			createQueuedPrompt("first", [], "q1"),
+			createQueuedPrompt("second", [], "q2"),
+		];
+		expect(
+			removeQueuedPromptItem(queue, "q1").map((item) => item.id),
+		).toEqual(["q2"]);
+	});
+});

--- a/test/message-queue.test.ts
+++ b/test/message-queue.test.ts
@@ -15,10 +15,34 @@ const attachment: AttachedFile = {
 };
 
 describe("message queue transforms", () => {
-	it("preserves FIFO order", () => {
-		const first = createQueuedPrompt("first", [], "q1", new Date(1));
-		const second = createQueuedPrompt("second", [], "q2", new Date(2));
-		expect([first, second].map((item) => item.id)).toEqual(["q1", "q2"]);
+	it("creates an isolated prompt with the supplied fields", () => {
+		const attachments = [attachment];
+		const prompt = createQueuedPrompt(
+			"first",
+			attachments,
+			"q1",
+			new Date(1),
+		);
+		attachments.pop();
+
+		expect(prompt).toEqual({
+			id: "q1",
+			content: "first",
+			attachments: [attachment],
+			createdAt: new Date(1),
+		});
+	});
+
+	it("keeps FIFO order after append and removal", () => {
+		const queue = [
+			createQueuedPrompt("first", [], "q1"),
+			createQueuedPrompt("second", [], "q2"),
+		];
+		const appended = [...queue, createQueuedPrompt("third", [], "q3")];
+
+		expect(
+			removeQueuedPromptItem(appended, "q2").map((item) => item.id),
+		).toEqual(["q1", "q3"]);
 	});
 
 	it("edits an item without moving it", () => {
@@ -26,10 +50,12 @@ describe("message queue transforms", () => {
 			createQueuedPrompt("first", [], "q1"),
 			createQueuedPrompt("second", [], "q2"),
 		];
+		const attachments = [attachment];
 		const updated = updateQueuedPromptItem(queue, "q1", {
 			content: "edited",
-			attachments: [attachment],
+			attachments,
 		});
+		attachments.pop();
 
 		expect(updated.map((item) => item.id)).toEqual(["q1", "q2"]);
 		expect(updated[0]).toMatchObject({
@@ -37,6 +63,17 @@ describe("message queue transforms", () => {
 			attachments: [attachment],
 		});
 		expect(queue[0].content).toBe("first");
+	});
+
+	it("leaves the queue unchanged for an unknown id", () => {
+		const queue = [createQueuedPrompt("first", [], "q1")];
+		const updated = updateQueuedPromptItem(queue, "missing", {
+			content: "edited",
+			attachments: [],
+		});
+
+		expect(updated[0]).toBe(queue[0]);
+		expect(removeQueuedPromptItem(queue, "missing")).toEqual(queue);
 	});
 
 	it("removes only the requested item", () => {


### PR DESCRIPTION
## Description

Allow follow-up prompts to be submitted while the agent is still responding. Busy sends are stored in a session-local FIFO queue and dispatched one at a time after the active prompt settles.

The composer keeps its existing stop behavior when empty. When it contains text or attachments during an active turn, the button changes back to send and queues the prompt instead.

Queued prompts are shown above the composer and can be edited, have attachments removed, or be deleted before dispatch. Editing pauses the queue; send/preparation failures also pause remaining items so they are not dispatched blindly. Queue state is cleared when messages/session history are replaced.

The queue is intentionally in-memory for this initial implementation. Pure queue transforms are covered by unit tests.

## Related issue

Closes #393

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes (existing sentence-case warnings only)
- [x] `npm run build` passes
- [ ] Tested in Obsidian
- [x] Existing functionality still works (`npm test`: 203 tests passed)
- [x] Documentation updated if needed (no setup or configuration changes)

## Testing environment

- Agent: N/A for unit tests; dispatch remains agent-agnostic ACP prompt flow
- OS: macOS

## Screenshots

Not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for queuing messages while a response is generating.
  * Queued messages can be edited, removed, paused, and resumed.
  * Attachments are retained with queued messages.
  * Queued messages are processed in order once sending resumes.
  * Added queue controls, status indicators, attachment counts, and editing UI.
  * Improved send, queue, and stop button states for clearer actions.

* **Bug Fixes**
  * Preserved attachments when sending messages through chat actions.
  * Prevented queued content from being lost during message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->