### PR TITLE
feat: support dropping vault files into chat input

### DIFF
--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -292,6 +292,9 @@ export interface AttachedFile {
 	/** Absolute file path (only for kind === "file") */
 	path?: string;
 
+	/** Canonical vault-relative path for files dragged from Obsidian. */
+	vaultPath?: string;
+
 	/** File size in bytes (only for kind === "file", for display + resource_link) */
 	size?: number;
 }

--- a/src/types/obsidian-internals.d.ts
+++ b/src/types/obsidian-internals.d.ts
@@ -8,6 +8,13 @@ export {};
  * to be removed without notice.
  */
 declare module "obsidian" {
+	interface App {
+		/** Current Obsidian-native drag item (private runtime API). */
+		dragManager?: {
+			draggable?: unknown;
+		};
+	}
+
 	interface Vault {
 		getConfig(key: string): unknown;
 	}

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -22,6 +22,7 @@ import type { ErrorInfo } from "../types/errors";
 import type { AgentUpdateNotification } from "../services/update-checker";
 import { useSettings } from "../hooks/useSettings";
 import {
+	deduplicateAttachments,
 	extractVaultPathsFromInternalDrag,
 	extractVaultPathsFromObsidianUris,
 } from "../utils/vault-drag";
@@ -351,25 +352,7 @@ export function InputArea({
 		(newFiles: AttachedFile[]) => {
 			if (newFiles.length === 0) return;
 			const currentFiles = attachedFilesRef.current;
-			const existingKeys = new Set(
-				currentFiles.map((file) =>
-					file.vaultPath
-						? `vault:${file.vaultPath}`
-						: file.path
-							? `path:${file.path}`
-							: `id:${file.id}`,
-				),
-			);
-			const deduplicated = newFiles.filter((file) => {
-				const key = file.vaultPath
-					? `vault:${file.vaultPath}`
-					: file.path
-						? `path:${file.path}`
-						: `id:${file.id}`;
-				if (existingKeys.has(key)) return false;
-				existingKeys.add(key);
-				return true;
-			});
+			const deduplicated = deduplicateAttachments(currentFiles, newFiles);
 			if (deduplicated.length < newFiles.length) {
 				new Notice("[Agent Client] Duplicate attachments were skipped");
 			}

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 const { useRef, useState, useEffect, useCallback, useMemo } = React;
-import { setIcon, Notice } from "obsidian";
+import { FileSystemAdapter, Notice, setIcon, TFile } from "obsidian";
 
 import type AgentClientPlugin from "../plugin";
 import type { IChatViewHost } from "./view-host";
@@ -21,6 +21,10 @@ import { getLogger } from "../utils/logger";
 import type { ErrorInfo } from "../types/errors";
 import type { AgentUpdateNotification } from "../services/update-checker";
 import { useSettings } from "../hooks/useSettings";
+import {
+	extractVaultPathsFromInternalDrag,
+	extractVaultPathsFromObsidianUris,
+} from "../utils/vault-drag";
 
 // ============================================================================
 // Image Constants
@@ -44,6 +48,18 @@ const SUPPORTED_IMAGE_TYPES = [
 ] as const;
 
 type SupportedImageType = (typeof SUPPORTED_IMAGE_TYPES)[number];
+
+const MIME_BY_EXTENSION: Readonly<Record<string, string>> = {
+	md: "text/markdown",
+	txt: "text/plain",
+	json: "application/json",
+	pdf: "application/pdf",
+	png: "image/png",
+	jpg: "image/jpeg",
+	jpeg: "image/jpeg",
+	gif: "image/gif",
+	webp: "image/webp",
+};
 
 /**
  * Props for InputArea component
@@ -319,6 +335,8 @@ export function InputArea({
 	// Refs
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const dragCounterRef = useRef(0);
+	const attachedFilesRef = useRef(attachedFiles);
+	attachedFilesRef.current = attachedFiles;
 
 	// Clear attached files when agent changes
 	useEffect(() => {
@@ -332,22 +350,96 @@ export function InputArea({
 	const addAttachments = useCallback(
 		(newFiles: AttachedFile[]) => {
 			if (newFiles.length === 0) return;
-			const remaining = MAX_ATTACHMENT_COUNT - attachedFiles.length;
+			const currentFiles = attachedFilesRef.current;
+			const existingKeys = new Set(
+				currentFiles.map((file) =>
+					file.vaultPath
+						? `vault:${file.vaultPath}`
+						: file.path
+							? `path:${file.path}`
+							: `id:${file.id}`,
+				),
+			);
+			const deduplicated = newFiles.filter((file) => {
+				const key = file.vaultPath
+					? `vault:${file.vaultPath}`
+					: file.path
+						? `path:${file.path}`
+						: `id:${file.id}`;
+				if (existingKeys.has(key)) return false;
+				existingKeys.add(key);
+				return true;
+			});
+			if (deduplicated.length < newFiles.length) {
+				new Notice("[Agent Client] Duplicate attachments were skipped");
+			}
+			if (deduplicated.length === 0) return;
+			const remaining = MAX_ATTACHMENT_COUNT - currentFiles.length;
 			if (remaining <= 0) {
 				new Notice(
 					`[Agent Client] Maximum ${MAX_ATTACHMENT_COUNT} attachments allowed`,
 				);
 				return;
 			}
-			const toAdd = newFiles.slice(0, remaining);
-			if (toAdd.length < newFiles.length) {
+			const toAdd = deduplicated.slice(0, remaining);
+			if (toAdd.length < deduplicated.length) {
 				new Notice(
 					`[Agent Client] Maximum ${MAX_ATTACHMENT_COUNT} attachments allowed`,
 				);
 			}
-			onAttachedFilesChange([...attachedFiles, ...toAdd]);
+			const nextFiles = [...currentFiles, ...toAdd];
+			attachedFilesRef.current = nextFiles;
+			onAttachedFilesChange(nextFiles);
 		},
-		[attachedFiles, onAttachedFilesChange],
+		[onAttachedFilesChange],
+	);
+
+	const convertVaultPathsToAttachments = useCallback(
+		(paths: string[]): AttachedFile[] => {
+			const adapter = plugin.app.vault.adapter;
+			if (!(adapter instanceof FileSystemAdapter)) {
+				new Notice(
+					"[Agent Client] Vault file attachments require a local vault",
+				);
+				return [];
+			}
+
+			const attachments: AttachedFile[] = [];
+			let rejected = 0;
+			for (const path of paths) {
+				const file = plugin.app.vault.getAbstractFileByPath(path);
+				if (!(file instanceof TFile)) {
+					rejected++;
+					continue;
+				}
+				attachments.push({
+					id: crypto.randomUUID(),
+					kind: "file",
+					mimeType:
+						MIME_BY_EXTENSION[file.extension.toLowerCase()] ??
+						"application/octet-stream",
+					name: file.name,
+					path: adapter.getFullPath(file.path),
+					vaultPath: file.path,
+					size: file.stat.size,
+				});
+			}
+			if (rejected > 0) {
+				new Notice(
+					`[Agent Client] ${rejected} dropped item${rejected === 1 ? " was" : "s were"} not a readable vault file`,
+				);
+			}
+			return attachments;
+		},
+		[plugin],
+	);
+
+	const getInternalDragPaths = useCallback(
+		() =>
+			extractVaultPathsFromInternalDrag(
+				plugin.app.dragManager?.draggable,
+			),
+		[plugin],
 	);
 
 	/**
@@ -355,10 +447,14 @@ export function InputArea({
 	 */
 	const removeFile = useCallback(
 		(id: string) => {
-			onAttachedFilesChange(attachedFiles.filter((f) => f.id !== id));
+			const nextFiles = attachedFilesRef.current.filter(
+				(file) => file.id !== id,
+			);
+			attachedFilesRef.current = nextFiles;
+			onAttachedFilesChange(nextFiles);
 			textareaRef.current?.focus();
 		},
-		[attachedFiles, onAttachedFilesChange],
+		[onAttachedFilesChange],
 	);
 
 	/**
@@ -515,35 +611,62 @@ export function InputArea({
 	/**
 	 * Handle drag over event to allow drop.
 	 */
-	const handleDragOver = useCallback((e: React.DragEvent) => {
-		if (e.dataTransfer?.types.includes("Files")) {
-			e.preventDefault();
-			e.dataTransfer.dropEffect = "copy";
-		}
-	}, []);
+	const handleDragOver = useCallback(
+		(e: React.DragEvent) => {
+			if (
+				getInternalDragPaths().length > 0 ||
+				e.dataTransfer?.types.includes("Files") ||
+				e.dataTransfer?.types.includes("text/uri-list")
+			) {
+				e.preventDefault();
+				if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+			}
+		},
+		[getInternalDragPaths],
+	);
 
 	/**
 	 * Handle drag enter event for visual feedback.
 	 * Uses counter to handle child element enter/leave correctly.
 	 */
-	const handleDragEnter = useCallback((e: React.DragEvent) => {
-		if (e.dataTransfer?.types.includes("Files")) {
-			e.preventDefault();
-			dragCounterRef.current++;
-			if (dragCounterRef.current === 1) {
-				setIsDraggingOver(true);
+	const handleDragEnter = useCallback(
+		(e: React.DragEvent) => {
+			if (
+				getInternalDragPaths().length > 0 ||
+				e.dataTransfer?.types.includes("Files") ||
+				e.dataTransfer?.types.includes("text/uri-list")
+			) {
+				e.preventDefault();
+				dragCounterRef.current++;
+				if (dragCounterRef.current === 1) {
+					setIsDraggingOver(true);
+				}
 			}
-		}
-	}, []);
+		},
+		[getInternalDragPaths],
+	);
 
 	/**
 	 * Handle drag leave event to reset visual feedback.
 	 */
 	const handleDragLeave = useCallback((_e: React.DragEvent) => {
-		dragCounterRef.current--;
+		dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
 		if (dragCounterRef.current === 0) {
 			setIsDraggingOver(false);
 		}
+	}, []);
+
+	useEffect(() => {
+		const resetDragState = () => {
+			dragCounterRef.current = 0;
+			setIsDraggingOver(false);
+		};
+		document.addEventListener("dragend", resetDragState, true);
+		document.addEventListener("drop", resetDragState, true);
+		return () => {
+			document.removeEventListener("dragend", resetDragState, true);
+			document.removeEventListener("drop", resetDragState, true);
+		};
 	}, []);
 
 	/**
@@ -555,6 +678,26 @@ export function InputArea({
 		async (e: React.DragEvent) => {
 			dragCounterRef.current = 0;
 			setIsDraggingOver(false);
+
+			const internalPaths = getInternalDragPaths();
+			const uriPaths = e.dataTransfer
+				? extractVaultPathsFromObsidianUris(
+						[
+							e.dataTransfer.getData("text/uri-list"),
+							e.dataTransfer.getData("text/plain"),
+						].join("\n"),
+						plugin.app.vault.getName(),
+					)
+				: [];
+			const vaultPaths =
+				internalPaths.length > 0 ? internalPaths : uriPaths;
+			if (vaultPaths.length > 0) {
+				e.preventDefault();
+				e.stopPropagation();
+				addAttachments(convertVaultPathsToAttachments(vaultPaths));
+				textareaRef.current?.focus();
+				return;
+			}
 
 			const files = e.dataTransfer?.files;
 			if (!files || files.length === 0) return;
@@ -601,6 +744,9 @@ export function InputArea({
 			addAttachments(newAttachments);
 		},
 		[
+			plugin,
+			getInternalDragPaths,
+			convertVaultPathsToAttachments,
 			supportsImages,
 			convertImagesToAttachments,
 			convertFilesToAttachments,
@@ -1077,7 +1223,18 @@ export function InputArea({
 				</div>
 
 				{/* Attachment Preview Strip (images + file references) */}
-				<AttachmentStrip files={attachedFiles} onRemove={removeFile} />
+				<AttachmentStrip
+					files={attachedFiles}
+					onRemove={removeFile}
+					onOpen={(file) => {
+						if (file.vaultPath) {
+							void plugin.app.workspace.openLinkText(
+								file.vaultPath,
+								"",
+							);
+						}
+					}}
+				/>
 
 				{/* Input Actions (Config Options / Mode Selector / Model Selector + Send Button) */}
 				<InputToolbar

--- a/src/ui/shared/AttachmentStrip.tsx
+++ b/src/ui/shared/AttachmentStrip.tsx
@@ -6,6 +6,7 @@ import type { AttachedFile } from "../../types/chat";
 interface AttachmentStripProps {
 	files: AttachedFile[];
 	onRemove: (id: string) => void;
+	onOpen?: (file: AttachedFile) => void;
 }
 
 /** Remove button with a stable ref so setIcon runs once on mount. */
@@ -38,10 +39,7 @@ function FileIcon() {
 		if (ref.current) setIcon(ref.current, "file");
 	}, []);
 	return (
-		<span
-			ref={ref}
-			className="agent-client-attachment-preview-file-icon"
-		/>
+		<span ref={ref} className="agent-client-attachment-preview-file-icon" />
 	);
 }
 
@@ -50,7 +48,11 @@ function FileIcon() {
  * - Images: show thumbnail
  * - Files: show file icon with filename
  */
-export function AttachmentStrip({ files, onRemove }: AttachmentStripProps) {
+export function AttachmentStrip({
+	files,
+	onRemove,
+	onOpen,
+}: AttachmentStripProps) {
 	if (files.length === 0) return null;
 
 	return (
@@ -59,6 +61,7 @@ export function AttachmentStrip({ files, onRemove }: AttachmentStripProps) {
 				<div
 					key={file.id}
 					className="agent-client-attachment-preview-item"
+					title={file.vaultPath ?? file.path ?? file.name}
 				>
 					{file.kind === "image" && file.data ? (
 						<img
@@ -67,12 +70,27 @@ export function AttachmentStrip({ files, onRemove }: AttachmentStripProps) {
 							className="agent-client-attachment-preview-thumbnail"
 						/>
 					) : (
-						<div className="agent-client-attachment-preview-file">
+						<button
+							type="button"
+							className="agent-client-attachment-preview-file"
+							onClick={() => onOpen?.(file)}
+							disabled={!file.vaultPath || !onOpen}
+						>
 							<FileIcon />
-							<span className="agent-client-attachment-preview-file-name">
-								{file.name ?? "file"}
+							<span className="agent-client-attachment-preview-file-labels">
+								<span className="agent-client-attachment-preview-file-name">
+									{file.name ?? "file"}
+								</span>
+								{file.vaultPath?.includes("/") && (
+									<span className="agent-client-attachment-preview-file-path">
+										{file.vaultPath.slice(
+											0,
+											file.vaultPath.lastIndexOf("/"),
+										)}
+									</span>
+								)}
 							</span>
-						</div>
+						</button>
 					)}
 					<RemoveButton fileId={file.id} onRemove={onRemove} />
 				</div>

--- a/src/utils/vault-drag.ts
+++ b/src/utils/vault-drag.ts
@@ -1,0 +1,71 @@
+/** Pure helpers for resolving Obsidian file-explorer drag payloads. */
+
+interface PathLike {
+	path: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function toPathLike(value: unknown): PathLike | null {
+	if (!isRecord(value) || typeof value.path !== "string") return null;
+	const path = value.path.trim();
+	return path ? { path } : null;
+}
+
+function uniquePaths(paths: string[]): string[] {
+	return [...new Set(paths.map((path) => path.replace(/^\/+/, "")))].filter(
+		Boolean,
+	);
+}
+
+/** Extract vault-relative paths from Obsidian's current internal drag item. */
+export function extractVaultPathsFromInternalDrag(
+	draggable: unknown,
+): string[] {
+	if (!isRecord(draggable)) return [];
+
+	if (draggable.type === "file" || draggable.type === "link") {
+		const file = toPathLike(draggable.file);
+		return file ? [file.path] : [];
+	}
+
+	if (draggable.type === "files" && Array.isArray(draggable.files)) {
+		return uniquePaths(
+			draggable.files
+				.map(toPathLike)
+				.filter((file): file is PathLike => file !== null)
+				.map((file) => file.path),
+		);
+	}
+
+	return [];
+}
+
+/** Resolve current-vault `obsidian://open` links from a drag payload. */
+export function extractVaultPathsFromObsidianUris(
+	value: string,
+	activeVaultName: string,
+): string[] {
+	const paths: string[] = [];
+	const candidates = value
+		.split(/[\r\n\t ]+/)
+		.map((candidate) => candidate.trim())
+		.filter(Boolean);
+
+	for (const candidate of candidates) {
+		if (!candidate.startsWith("obsidian://open?")) continue;
+		try {
+			const url = new URL(candidate);
+			const vault = url.searchParams.get("vault");
+			const file = url.searchParams.get("file");
+			if (vault !== activeVaultName || !file) continue;
+			paths.push(file);
+		} catch {
+			// Ignore malformed drag data.
+		}
+	}
+
+	return uniquePaths(paths);
+}

--- a/src/utils/vault-drag.ts
+++ b/src/utils/vault-drag.ts
@@ -1,5 +1,7 @@
 /** Pure helpers for resolving Obsidian file-explorer drag payloads. */
 
+import type { AttachedFile } from "../types/chat";
+
 interface PathLike {
 	path: string;
 }
@@ -18,6 +20,27 @@ function uniquePaths(paths: string[]): string[] {
 	return [...new Set(paths.map((path) => path.replace(/^\/+/, "")))].filter(
 		Boolean,
 	);
+}
+
+function attachmentIdentityKeys(file: AttachedFile): string[] {
+	const keys: string[] = [];
+	if (file.vaultPath) keys.push(`vault:${file.vaultPath}`);
+	if (file.path) keys.push(`path:${file.path}`);
+	return keys.length > 0 ? keys : [`id:${file.id}`];
+}
+
+/** Remove candidate attachments matching any stable identity already present. */
+export function deduplicateAttachments(
+	existing: AttachedFile[],
+	candidates: AttachedFile[],
+): AttachedFile[] {
+	const existingKeys = new Set(existing.flatMap(attachmentIdentityKeys));
+	return candidates.filter((file) => {
+		const keys = attachmentIdentityKeys(file);
+		if (keys.some((key) => existingKeys.has(key))) return false;
+		keys.forEach((key) => existingKeys.add(key));
+		return true;
+	});
 }
 
 /** Extract vault-relative paths from Obsidian's current internal drag item. */

--- a/styles.css
+++ b/styles.css
@@ -1649,6 +1649,20 @@ If your plugin does not need CSS, delete this file.
 	border: 1px solid var(--background-modifier-border);
 	background-color: var(--background-primary);
 	overflow: hidden;
+	padding: 4px;
+	box-shadow: none;
+	color: inherit;
+}
+
+.agent-client-attachment-preview-file:disabled {
+	opacity: 1;
+	cursor: default;
+}
+
+.agent-client-attachment-preview-file-labels {
+	display: flex;
+	flex-direction: column;
+	max-width: 100%;
 }
 
 .agent-client-attachment-preview-file-icon {
@@ -1664,6 +1678,16 @@ If your plugin does not need CSS, delete this file.
 	font-size: 9px;
 	color: var(--text-muted);
 	text-align: center;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	padding: 0 4px;
+}
+
+.agent-client-attachment-preview-file-path {
+	font-size: 8px;
+	color: var(--text-faint);
 	max-width: 100%;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/test/vault-drag.test.ts
+++ b/test/vault-drag.test.ts
@@ -1,8 +1,42 @@
 import { describe, expect, it } from "vitest";
 import {
+	deduplicateAttachments,
 	extractVaultPathsFromInternalDrag,
 	extractVaultPathsFromObsidianUris,
 } from "../src/utils/vault-drag";
+import type { AttachedFile } from "../src/types/chat";
+
+describe("deduplicateAttachments", () => {
+	it("matches a vault attachment against an existing absolute path", () => {
+		const path = "/vault/Notes/Project.md";
+		const external: AttachedFile = {
+			id: "external",
+			kind: "file",
+			mimeType: "text/markdown",
+			path,
+		};
+		const vault: AttachedFile = {
+			...external,
+			id: "vault",
+			vaultPath: "Notes/Project.md",
+		};
+
+		expect(deduplicateAttachments([external], [vault])).toEqual([]);
+	});
+
+	it("deduplicates candidates added in the same batch", () => {
+		const file: AttachedFile = {
+			id: "one",
+			kind: "file",
+			mimeType: "text/plain",
+			path: "/vault/file.txt",
+		};
+
+		expect(
+			deduplicateAttachments([], [file, { ...file, id: "two" }]),
+		).toEqual([file]);
+	});
+});
 
 describe("extractVaultPathsFromInternalDrag", () => {
 	it("extracts a single Obsidian file drag", () => {

--- a/test/vault-drag.test.ts
+++ b/test/vault-drag.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+	extractVaultPathsFromInternalDrag,
+	extractVaultPathsFromObsidianUris,
+} from "../src/utils/vault-drag";
+
+describe("extractVaultPathsFromInternalDrag", () => {
+	it("extracts a single Obsidian file drag", () => {
+		expect(
+			extractVaultPathsFromInternalDrag({
+				type: "file",
+				file: { path: "Projects/Requirements.md" },
+			}),
+		).toEqual(["Projects/Requirements.md"]);
+	});
+
+	it("extracts and de-duplicates a multi-file drag", () => {
+		expect(
+			extractVaultPathsFromInternalDrag({
+				type: "files",
+				files: [
+					{ path: "a.md" },
+					{ path: "folder/b.md" },
+					{ path: "a.md" },
+				],
+			}),
+		).toEqual(["a.md", "folder/b.md"]);
+	});
+
+	it("rejects unsupported or malformed internal drag items", () => {
+		expect(extractVaultPathsFromInternalDrag(null)).toEqual([]);
+		expect(
+			extractVaultPathsFromInternalDrag({ type: "folder", file: {} }),
+		).toEqual([]);
+	});
+});
+
+describe("extractVaultPathsFromObsidianUris", () => {
+	it("decodes current-vault Obsidian links", () => {
+		expect(
+			extractVaultPathsFromObsidianUris(
+				"obsidian://open?vault=My%20Vault&file=Notes%2FProject%20plan.md",
+				"My Vault",
+			),
+		).toEqual(["Notes/Project plan.md"]);
+	});
+
+	it("handles multiple URI-list entries", () => {
+		expect(
+			extractVaultPathsFromObsidianUris(
+				[
+					"# dragged files",
+					"obsidian://open?vault=Vault&file=a.md",
+					"obsidian://open?vault=Vault&file=b%20c.md",
+				].join("\n"),
+				"Vault",
+			),
+		).toEqual(["a.md", "b c.md"]);
+	});
+
+	it("rejects other vaults and malformed values", () => {
+		expect(
+			extractVaultPathsFromObsidianUris(
+				"obsidian://open?vault=Other&file=secret.md not-a-url",
+				"Vault",
+			),
+		).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

- Accept single- and multi-file drags from the Obsidian file explorer.
- Fall back to current-vault `obsidian://open` payloads.
- Preserve external file/image drops, attachment limits, and openable vault previews.
- Deduplicate across every stable identity (`path` and `vaultPath`), including mixed external/vault drops.

Related to #288. Supersedes #387, which could not be reopened after the contributor fork was recreated.

## Validation

- Focused vault-drag tests: 8 passed
- `npm run build`: passed
- Changed-file ESLint: 0 errors (existing sentence-case warnings only)
- Changed-file Prettier: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attach files by dragging them from an Obsidian vault, including multiple files and URI-based drops.
  * Prevent duplicate attachments and preserve vault file paths and metadata.
  * Open vault-backed attachments directly in Obsidian from their previews.
  * Display filenames and vault locations for non-image attachments.

* **Bug Fixes**
  * Improved handling of malformed drops, files from other vaults, and drag-state cleanup.
  * Added clearer disabled states for attachments that cannot be opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->