### PR TITLE
fix: mount the floating button and chat windows in the main window document

### DIFF
--- a/src/ui/FloatingButton.tsx
+++ b/src/ui/FloatingButton.tsx
@@ -34,7 +34,9 @@ export class FloatingButtonContainer {
 	private containerEl: HTMLElement;
 
 	constructor(private plugin: AgentClientPlugin) {
-		this.containerEl = activeDocument.body.createDiv({
+		// Main-window document, not activeDocument: since Obsidian 1.13 the
+		// Settings dialog is its own window and may hold focus during (re)load.
+		this.containerEl = plugin.app.workspace.containerEl.doc.body.createDiv({
 			cls: "agent-client-floating-button-root",
 		});
 	}

--- a/src/ui/FloatingChatView.tsx
+++ b/src/ui/FloatingChatView.tsx
@@ -84,7 +84,9 @@ export class FloatingViewContainer implements IChatViewContainer {
 		this.plugin = plugin;
 		// viewId format: "floating-chat-{instanceId}" to match adapter key
 		this.viewId = `floating-chat-${instanceId}`;
-		this.containerEl = activeDocument.body.createDiv({
+		// Main-window document, not activeDocument: creation may run while the
+		// Settings window (its own window since Obsidian 1.13) holds focus.
+		this.containerEl = plugin.app.workspace.containerEl.doc.body.createDiv({
 			cls: "agent-client-floating-view-root",
 		});
 	}


### PR DESCRIPTION
## Description

Since Obsidian 1.13 the Settings dialog is its own window. The floating button and
floating chat windows were mounted into `activeDocument.body`, so any creation that
ran while the Settings window held focus (enabling the plugin from Community plugins,
toggling "Enable floating chat", plugin reload) placed their DOM roots inside the
Settings window's document:

- The button rendered inside the Settings window, overlapping its content — or
  off-viewport entirely, because its saved position is clamped against the main
  window's dimensions.
- Chat windows created there were invisible, and once the Settings window closed,
  the roots survived in a dead document while the registry entry and the agent
  process lived on (ghost view).

Fixed by mounting both roots into the main window's document, derived
deterministically from `plugin.app.workspace.containerEl.doc` (the workspace always
lives in the main window). This keeps the popout-compatibility review requirement
(no bare `document` global) that originally motivated the `activeDocument` usage,
and re-aligns the render target with the coordinate space used by the drag/clamp
logic. All other `activeDocument` call sites were audited and intentionally kept:
event listeners and `hasFocus()` want focus-time semantics; only these two permanent
mounts must not depend on focus.

## Related issue

Closes #391

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Not agent-specific (verified with a local ACP fixture agent)
- OS: macOS

## Screenshots

Before: see #391. After the fix, the exact failure condition was reproduced by
pointing `activeDocument` at the Settings window document, then disabling →
re-enabling the plugin and creating a floating chat: both roots land in the main
window's document (none in the Settings document), the button renders at its saved
position, and clicking it opens the chat.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved floating button and chat placement within the main workspace.
  * Floating UI now remains correctly attached when working across different panes or windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->