### PR TITLE
fix(settings): keep the scroll position across a settings re-render

### DIFF
--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -72,6 +72,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 	 */
 	private renderContent(): void {
 		const { containerEl } = this;
+		const scrollTop = containerEl.scrollTop;
 
 		containerEl.empty();
 		this.agentSelector = null;
@@ -882,6 +883,8 @@ export class AgentClientSettingTab extends PluginSettingTab {
 						});
 					}),
 			);
+
+		containerEl.scrollTop = scrollTop;
 	}
 
 	/**


### PR DESCRIPTION
## Description

Toggling anything in the settings tab that triggers a re-render scrolls the pane back to the top. Reported on Windows via the WSL mode toggle, but it is not platform-specific — the WSL section is just Windows-only UI.

**Cause.** `renderContent()` rebuilds the whole tab with `containerEl.empty()`. `containerEl` is the tab's scroll container, so emptying it collapses `scrollHeight` and the browser clamps `scrollTop` to 0; the rebuilt content then starts at the top.

**Fix.** Capture the offset immediately before the teardown and restore it after the rebuild. The change sits at the join point rather than in the individual handlers, so all eight `renderContent()` callers are fixed at once:

| Action | Location |
| --- | --- |
| Auto-collapse diffs toggle | `SettingsTab.ts:398` |
| Prompt injection toggle | `SettingsTab.ts:547` |
| WSL mode toggle | `SettingsTab.ts:619` |
| Include images toggle | `SettingsTab.ts:740` |
| Image location dropdown | `SettingsTab.ts:772` |
| Custom agent add | `SettingsTab.ts:1287` |
| Custom agent delete | `SettingsTab.ts:1324` |
| Auto-detect (on success) | `SettingsTab.ts:1618` |

`display()` needs no special case: a freshly opened tab reads 0 and restores 0. `renderContent()` is synchronous with a single exit point, so the restore covers every path.

This is the same class of bug as #321 (chat tab scroll position). The doc comment on `addEnabledToggleControl()` already noted that avoiding `renderContent()` is what "keeps open sections, scroll, and focus" — that comment's `scroll` clause is now handled centrally. I left it untouched to keep the diff minimal; happy to update it here or in a follow-up, whichever you prefer.

## Related issue

None filed — reporting and fixing together.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes (0 errors; the 50 `sentence-case` warnings are pre-existing)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [ ] Documentation updated if needed — n/a

## Testing environment

- Agent: n/a (settings UI only)
- OS: originally observed on Windows (WSL mode toggle); reproduced and verified on macOS

Reproduction used on macOS, since the WSL toggle does not render there:

1. Settings → Agent Client → scroll to **Export → Include images** and toggle it → jumps to top
2. Scroll to **Preset agents → Claude Code → Auto-detect** and click it (needs the command to resolve; the `Not found` branch does not re-render) → jumps to top
3. Bottom of the page → **Add custom agent** → jumps to top

All three keep their scroll position after this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the settings panel’s scroll position when refreshing its contents, preventing users from being returned to the top of the panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->