### PR TITLE
Move the plan display into a collapsible strip under the header

### DIFF
--- a/src/hooks/useCollapsibleToggle.ts
+++ b/src/hooks/useCollapsibleToggle.ts
@@ -1,0 +1,57 @@
+import * as React from "react";
+const { useCallback } = React;
+
+export interface CollapsibleToggleProps {
+	role: "button";
+	tabIndex: 0;
+	"aria-expanded": boolean;
+	onClick: (event: React.MouseEvent<HTMLElement>) => void;
+	onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
+}
+
+/**
+ * Props for a header element that toggles a collapsible region.
+ *
+ * Pointer and keyboard behave the same: click, Enter, or Space toggles
+ * (Space is prevented from scrolling the transcript). A click that
+ * completed a text selection inside the header is ignored, so copying
+ * never yanks the region away. The selection is read from
+ * `ownerDocument`, not `activeDocument`: the element may live in a
+ * window that does not hold focus (the floating chat).
+ */
+export function useCollapsibleToggle(
+	expanded: boolean,
+	onToggle: () => void,
+): CollapsibleToggleProps {
+	const handleClick = useCallback(
+		(event: React.MouseEvent<HTMLElement>) => {
+			const selection = event.currentTarget.ownerDocument.getSelection();
+			if (
+				selection &&
+				!selection.isCollapsed &&
+				event.currentTarget.contains(selection.anchorNode)
+			) {
+				return;
+			}
+			onToggle();
+		},
+		[onToggle],
+	);
+
+	const handleKeyDown = useCallback(
+		(event: React.KeyboardEvent<HTMLElement>) => {
+			if (event.key !== "Enter" && event.key !== " ") return;
+			event.preventDefault();
+			onToggle();
+		},
+		[onToggle],
+	);
+
+	return {
+		role: "button",
+		tabIndex: 0,
+		"aria-expanded": expanded,
+		onClick: handleClick,
+		onKeyDown: handleKeyDown,
+	};
+}

--- a/src/services/message-state.ts
+++ b/src/services/message-state.ts
@@ -11,6 +11,7 @@ import type {
 	MessageContent,
 	ActivePermission,
 	PermissionOption,
+	PlanEntry,
 } from "../types/chat";
 import type { SessionUpdate } from "../types/session";
 
@@ -438,4 +439,50 @@ export function selectOption(
 		if (fallbackOption) return fallbackOption;
 	}
 	return options[0];
+}
+
+// ============================================================================
+// Plan Helper Functions
+// ============================================================================
+
+/**
+ * Find the most recent plan in the transcript, newest message first.
+ * Returns null when no plan has arrived this session.
+ */
+export function findLatestPlan(messages: ChatMessage[]): PlanEntry[] | null {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		for (const content of messages[i].content) {
+			if (content.type === "plan") return content.entries;
+		}
+	}
+	return null;
+}
+
+/** Derived display state for the plan strip's collapsed line. */
+export interface PlanSummary {
+	completed: number;
+	total: number;
+	/** First in_progress entry, else first pending. Null when all done. */
+	current: PlanEntry | null;
+}
+
+/**
+ * Summarize plan entries for the strip's collapsed line.
+ *
+ * ACP puts no constraints on status distribution: all-pending is the
+ * routine first update (Claude Code writes the full list before starting),
+ * several in_progress at once is legal, and so is an empty array (the
+ * caller hides the strip for that). The "current" entry is the first
+ * in_progress, falling back to the first pending so the line always
+ * names what happens next.
+ */
+export function summarizePlan(entries: PlanEntry[]): PlanSummary {
+	const completed = entries.filter(
+		(entry) => entry.status === "completed",
+	).length;
+	const current =
+		entries.find((entry) => entry.status === "in_progress") ??
+		entries.find((entry) => entry.status === "pending") ??
+		null;
+	return { completed, total: entries.length, current };
 }

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -17,7 +17,12 @@ import {
 	computeSessionTitle,
 	getDefaultAgentId,
 } from "../services/session-helpers";
-import { countPendingPermissions } from "../services/message-state";
+import {
+	countPendingPermissions,
+	findLatestPlan,
+	summarizePlan,
+} from "../services/message-state";
+import { PlanStrip } from "./PlanStrip";
 import { useHistoryModal } from "../hooks/useHistoryModal";
 import { useChatActions } from "../hooks/useChatActions";
 import { ChangeDirectoryModal } from "./ChangeDirectoryModal";
@@ -159,7 +164,10 @@ function selectChatPanelSettings(s: AgentClientPluginSettings) {
 		// fields here).
 		presetAgents: s.presetAgents,
 		customAgents: s.customAgents,
-		displaySettings: { fontSize: s.displaySettings.fontSize },
+		displaySettings: {
+			fontSize: s.displaySettings.fontSize,
+			showEmojis: s.displaySettings.showEmojis,
+		},
 	};
 }
 
@@ -181,7 +189,8 @@ function chatPanelSettingsEqual(
 		// reference compare detects agent changes (and only those).
 		a.presetAgents === b.presetAgents &&
 		a.customAgents === b.customAgents &&
-		a.displaySettings.fontSize === b.displaySettings.fontSize
+		a.displaySettings.fontSize === b.displaySettings.fontSize &&
+		a.displaySettings.showEmojis === b.displaySettings.showEmojis
 	);
 }
 
@@ -348,9 +357,22 @@ export const ChatPanel = React.memo(function ChatPanel({
 			return next;
 		});
 	}, []);
+	// Plan strip: collapsed by default, derived from the transcript.
+	const [planExpanded, setPlanExpanded] = useState(false);
+	const togglePlan = useCallback(() => setPlanExpanded((v) => !v), []);
+	const planEntries = useMemo(() => findLatestPlan(messages), [messages]);
+	const planSummary = useMemo(
+		() =>
+			planEntries && planEntries.length > 0
+				? summarizePlan(planEntries)
+				: null,
+		[planEntries],
+	);
+
 	// Start every session collapsed; ids are only meaningful within one.
 	useEffect(() => {
 		setExpandedToolCalls(new Set());
+		setPlanExpanded(false);
 	}, [session.sessionId]);
 
 	// Requests waiting behind the active one, for the dialog's queue badge.
@@ -1478,6 +1500,17 @@ export const ChatPanel = React.memo(function ChatPanel({
 			</div>
 		) : null;
 
+	const planStrip =
+		planEntries && planEntries.length > 0 && planSummary ? (
+			<PlanStrip
+				entries={planEntries}
+				summary={planSummary}
+				expanded={planExpanded}
+				onToggle={togglePlan}
+				showEmojis={settings.displaySettings.showEmojis}
+			/>
+		) : null;
+
 	const messageListElement = (
 		<MessageList
 			messages={messages}
@@ -1551,6 +1584,7 @@ export const ChatPanel = React.memo(function ChatPanel({
 					{headerElement}
 				</div>
 				{cwdBanner}
+				{planStrip}
 				<div className="agent-client-floating-content">
 					<div className="agent-client-floating-messages-container">
 						{messageListElement}
@@ -1572,6 +1606,7 @@ export const ChatPanel = React.memo(function ChatPanel({
 					{headerElement}
 				</div>
 				{cwdBanner}
+				{planStrip}
 				<div className="agent-client-embedded-messages-container">
 					{messageListElement}
 				</div>
@@ -1589,6 +1624,7 @@ export const ChatPanel = React.memo(function ChatPanel({
 		>
 			{headerElement}
 			{cwdBanner}
+			{planStrip}
 			{messageListElement}
 			{inputAreaElement}
 		</div>

--- a/src/ui/MessageBubble.tsx
+++ b/src/ui/MessageBubble.tsx
@@ -203,45 +203,9 @@ function ContentBlock({
 				/>
 			);
 
-		case "plan": {
-			const showEmojis = plugin.settings.displaySettings.showEmojis;
-			return (
-				<div className="agent-client-message-plan">
-					<div className="agent-client-message-plan-title">
-						{showEmojis && (
-							<LucideIcon
-								name="list-checks"
-								className="agent-client-message-plan-label-icon"
-							/>
-						)}
-						Plan
-					</div>
-					{content.entries.map((entry, idx) => (
-						<div
-							key={idx}
-							className={`agent-client-message-plan-entry agent-client-plan-status-${entry.status}`}
-						>
-							{showEmojis && (
-								<span
-									className={`agent-client-message-plan-entry-icon agent-client-status-${entry.status}`}
-								>
-									<LucideIcon
-										name={
-											entry.status === "completed"
-												? "check"
-												: entry.status === "in_progress"
-													? "loader"
-													: "circle"
-										}
-									/>
-								</span>
-							)}{" "}
-							{entry.content}
-						</div>
-					))}
-				</div>
-			);
-		}
+		case "plan":
+			// Rendered as the strip under the header, not in the transcript.
+			return null;
 
 		case "terminal":
 			return (
@@ -390,6 +354,15 @@ export const MessageBubble = React.memo(function MessageBubble({
 	expandedToolCalls,
 	onToggleToolCall,
 }: MessageBubbleProps) {
+	// A plan-only message (plan followed by a tool call) would render as an
+	// empty shell — the strip under the header owns plan display.
+	if (
+		message.content.length > 0 &&
+		message.content.every((content) => content.type === "plan")
+	) {
+		return null;
+	}
+
 	const groups = groupContent(message.content);
 
 	return (

--- a/src/ui/PlanStrip.tsx
+++ b/src/ui/PlanStrip.tsx
@@ -1,0 +1,83 @@
+import type { PlanEntry } from "../types/chat";
+import type { PlanSummary } from "../services/message-state";
+import { LucideIcon } from "./shared/IconButton";
+import { useCollapsibleToggle } from "../hooks/useCollapsibleToggle";
+
+interface PlanStripProps {
+	entries: PlanEntry[];
+	summary: PlanSummary;
+	expanded: boolean;
+	onToggle: () => void;
+	showEmojis: boolean;
+}
+
+const STATUS_ICONS: Record<PlanEntry["status"], string> = {
+	completed: "check",
+	in_progress: "loader",
+	pending: "circle",
+};
+
+/**
+ * Ambient view of the agent's latest plan, shown under the header in
+ * every variant. Collapsed it is one line — progress plus the entry
+ * being worked on; expanded it lists every entry. The transcript does
+ * not render plans (the data still flows through messages, so session
+ * restore and Markdown export keep working unchanged).
+ */
+export function PlanStrip({
+	entries,
+	summary,
+	expanded,
+	onToggle,
+	showEmojis,
+}: PlanStripProps) {
+	const toggleProps = useCollapsibleToggle(expanded, onToggle);
+
+	return (
+		<div className="agent-client-plan-strip">
+			<div className="agent-client-plan-strip-summary" {...toggleProps}>
+				{showEmojis && (
+					<LucideIcon
+						name="list-checks"
+						className="agent-client-plan-strip-icon"
+					/>
+				)}
+				<span className="agent-client-plan-strip-count">
+					Plan {summary.completed}/{summary.total}
+				</span>
+				{summary.current && (
+					<span className="agent-client-plan-strip-current">
+						· {summary.current.content}
+					</span>
+				)}
+				<LucideIcon
+					name={expanded ? "chevron-down" : "chevron-right"}
+					className="agent-client-plan-strip-chevron"
+				/>
+			</div>
+			{expanded && (
+				<div className="agent-client-plan-strip-entries">
+					{entries.map((entry, idx) => (
+						<div
+							key={idx}
+							className={`agent-client-plan-strip-entry agent-client-plan-status-${entry.status}`}
+						>
+							{showEmojis && (
+								<span
+									className={`agent-client-plan-strip-entry-icon agent-client-status-${entry.status}`}
+								>
+									<LucideIcon
+										name={STATUS_ICONS[entry.status]}
+									/>
+								</span>
+							)}
+							<span className="agent-client-plan-strip-entry-text">
+								{entry.content}
+							</span>
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/ui/ToolCallBlock.tsx
+++ b/src/ui/ToolCallBlock.tsx
@@ -7,6 +7,7 @@ import type AgentClientPlugin from "../plugin";
 import { LucideIcon } from "./shared/IconButton";
 import { toRelativePath } from "../utils/paths";
 import { ToolCallContentView } from "./ToolCallContentView";
+import { useCollapsibleToggle } from "../hooks/useCollapsibleToggle";
 
 interface ToolCallBlockProps {
 	content: Extract<MessageContent, { type: "tool_call" }>;
@@ -40,33 +41,7 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 	const handleToggle = useCallback(() => {
 		onToggleExpanded?.(toolCallId);
 	}, [onToggleExpanded, toolCallId]);
-
-	// A drag-select over the title also fires a click; don't yank the body
-	// away. ownerDocument: the row's document, not the focused window's.
-	const handleClick = useCallback(
-		(event: React.MouseEvent<HTMLDivElement>) => {
-			const selection = event.currentTarget.ownerDocument.getSelection();
-			if (
-				selection &&
-				!selection.isCollapsed &&
-				event.currentTarget.contains(selection.anchorNode)
-			) {
-				return;
-			}
-			handleToggle();
-		},
-		[handleToggle],
-	);
-
-	const handleKeyDown = useCallback(
-		(event: React.KeyboardEvent<HTMLDivElement>) => {
-			if (event.key !== "Enter" && event.key !== " ") return;
-			// Space would scroll the transcript otherwise.
-			event.preventDefault();
-			handleToggle();
-		},
-		[handleToggle],
-	);
+	const toggleProps = useCollapsibleToggle(isExpanded, handleToggle);
 
 	// Images render beside the collapsed row, so they stay visible without
 	// expanding; everything else lives in the collapsible body.
@@ -123,11 +98,7 @@ export const ToolCallBlock = React.memo(function ToolCallBlock({
 			{/* The whole row is the toggle, pointer and keyboard alike. */}
 			<div
 				className="agent-client-message-tool-call-header agent-client-message-tool-call-header-toggle"
-				role="button"
-				tabIndex={0}
-				aria-expanded={isExpanded}
-				onClick={handleClick}
-				onKeyDown={handleKeyDown}
+				{...toggleProps}
 			>
 				<div className="agent-client-message-tool-call-title">
 					{showEmojis && (

--- a/styles.css
+++ b/styles.css
@@ -325,19 +325,12 @@ If your plugin does not need CSS, delete this file.
 .agent-client-message-tool-call-icon svg,
 .agent-client-collapsible-thought-label-icon svg,
 .agent-client-terminal-renderer-label-icon svg,
-.agent-client-error-overlay-suggestion-icon svg,
-.agent-client-message-plan-label-icon svg {
+.agent-client-error-overlay-suggestion-icon svg {
 	width: 14px;
 	height: 14px;
 	vertical-align: -2px;
 	margin-right: 4px;
 	color: var(--text-muted);
-}
-
-.agent-client-message-plan-entry-icon svg {
-	width: 12px;
-	height: 12px;
-	vertical-align: -2px;
 }
 
 /* ===== Message Content Components ===== */
@@ -467,61 +460,6 @@ If your plugin does not need CSS, delete this file.
 .agent-client-message-tool-call-command code {
 	font-family: var(--font-monospace);
 	font-size: 0.9em;
-}
-
-/* Plan */
-.agent-client-message-plan {
-	padding: 8px;
-	margin: 4px 0;
-	border: 1px solid var(--background-modifier-border);
-	border-radius: 4px;
-	font-size: 12px;
-	user-select: text;
-	overflow-wrap: break-word;
-	word-wrap: break-word;
-	word-break: break-word;
-	max-width: 100%;
-}
-
-.agent-client-message-plan-title {
-	font-weight: bold;
-	margin-bottom: 4px;
-	user-select: text;
-	overflow-wrap: break-word;
-	word-wrap: break-word;
-	word-break: break-word;
-}
-
-.agent-client-message-plan-entry {
-	margin: 2px 0;
-	padding: 2px 4px;
-	border-left: 2px solid var(--text-muted);
-	user-select: text;
-	overflow-wrap: break-word;
-	word-wrap: break-word;
-	word-break: break-word;
-}
-
-.agent-client-message-plan-entry-icon.agent-client-status-completed {
-	user-select: text;
-}
-
-.agent-client-message-plan-entry-icon.agent-client-status-in_progress {
-	user-select: text;
-}
-
-.agent-client-message-plan-entry-icon.agent-client-status-pending {
-	user-select: text;
-}
-
-/* Plan entry status text styles (for emoji-off mode) */
-.agent-client-message-plan-entry.agent-client-plan-status-completed {
-	text-decoration: line-through;
-	color: var(--text-muted);
-}
-
-.agent-client-message-plan-entry.agent-client-plan-status-in_progress {
-	font-weight: bold;
 }
 
 /* ===== Permission Request (vertical option list) ===== */
@@ -2308,6 +2246,131 @@ If your plugin does not need CSS, delete this file.
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+}
+
+/* ===== Plan strip (ambient, under the header) ===== */
+/* The row is in flow; the expanded list is an overlay dropdown, so
+   toggling never resizes the message area. */
+.agent-client-plan-strip {
+	position: relative;
+	padding: 0 12px 6px;
+	font-size: var(--font-ui-smaller);
+	user-select: text;
+}
+
+.agent-client-plan-strip-summary {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	cursor: pointer;
+	white-space: nowrap;
+	color: var(--text-muted);
+}
+
+.agent-client-plan-strip-summary:focus-visible {
+	outline: 2px solid var(--interactive-accent);
+	outline-offset: -2px;
+	border-radius: 4px;
+}
+
+.agent-client-plan-strip-icon,
+.agent-client-plan-strip-chevron {
+	flex-shrink: 0;
+}
+
+.agent-client-plan-strip-icon svg,
+.agent-client-plan-strip-chevron svg {
+	width: 14px;
+	height: 14px;
+}
+
+/* auto margin, not a flex-1 text column: the chevron stays pinned right
+   even when no current entry is shown (all-completed). */
+.agent-client-plan-strip-chevron {
+	margin-left: auto;
+	opacity: 0.7;
+}
+
+.agent-client-plan-strip-count {
+	flex-shrink: 0;
+	font-weight: 600;
+}
+
+.agent-client-plan-strip-current {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+/* Header-extension band over the transcript. 15 sits above the
+   scroll-to-bottom button (10) and below the permission dialog (20). */
+/* No margin-top: any gap lets the transcript show through above the band. */
+.agent-client-plan-strip-entries {
+	position: absolute;
+	top: 100%;
+	left: 0;
+	right: 0;
+	z-index: 15;
+	padding: 2px 12px 6px;
+	max-height: 200px;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+	background-color: var(--background-primary);
+	border-bottom: 1px solid var(--background-modifier-border);
+	color: var(--text-normal);
+}
+
+/* Match the surface the band extends: side docks paint
+   --background-secondary on their leaves. */
+.mod-sidedock .agent-client-plan-strip-entries {
+	background-color: var(--background-secondary);
+}
+
+/* ...except the embedded panel, which paints its own primary surface
+   wherever the host note lives. Order matters: same specificity. */
+.agent-client-embedded-chat-panel .agent-client-plan-strip-entries {
+	background-color: var(--background-primary);
+}
+
+/* Icon column + text column; the icon stays centered on the row's
+   full height however far the text wraps. */
+.agent-client-plan-strip-entry {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin: 2px 0;
+	padding: 2px 4px;
+	border-left: 2px solid var(--text-muted);
+}
+
+.agent-client-plan-strip-entry-icon {
+	flex-shrink: 0;
+	display: flex;
+}
+
+.agent-client-plan-strip-entry-icon svg {
+	width: 14px;
+	height: 14px;
+}
+
+.agent-client-plan-strip-entry-text {
+	min-width: 0;
+	overflow-wrap: break-word;
+}
+
+.agent-client-plan-strip-entry.agent-client-plan-status-completed {
+	color: var(--text-muted);
+}
+
+/* On the span, not the flex container: decoration does not reliably
+   propagate into flex items. */
+.agent-client-plan-strip-entry.agent-client-plan-status-completed
+	.agent-client-plan-strip-entry-text {
+	text-decoration: line-through;
+}
+
+.agent-client-plan-strip-entry.agent-client-plan-status-in_progress {
+	font-weight: bold;
 }
 
 .agent-client-change-dir-buttons {

--- a/test/message-state.test.ts
+++ b/test/message-state.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { findLatestPlan, summarizePlan } from "../src/services/message-state";
+import type { ChatMessage, PlanEntry } from "../src/types/chat";
+
+function msg(content: ChatMessage["content"]): ChatMessage {
+	return {
+		id: crypto.randomUUID(),
+		role: "assistant",
+		content,
+		timestamp: new Date("2026-01-01T00:00:00Z"),
+	};
+}
+
+const entry = (
+	status: PlanEntry["status"],
+	content: string = status,
+): PlanEntry => ({
+	content,
+	status,
+	priority: "medium",
+});
+
+describe("findLatestPlan", () => {
+	it("returns null when no message carries a plan", () => {
+		expect(findLatestPlan([msg([{ type: "text", text: "hi" }])])).toBeNull();
+	});
+
+	it("returns the plan from the newest message that has one", () => {
+		const older = [entry("completed", "old")];
+		const newer = [entry("pending", "new")];
+		const messages = [
+			msg([{ type: "plan", entries: older }]),
+			msg([{ type: "text", text: "..." }]),
+			msg([{ type: "plan", entries: newer }]),
+		];
+		expect(findLatestPlan(messages)).toBe(newer);
+	});
+
+	it("looks past newer messages without a plan", () => {
+		const entries = [entry("in_progress")];
+		const messages = [
+			msg([{ type: "plan", entries }]),
+			msg([{ type: "text", text: "the turn moved on" }]),
+		];
+		expect(findLatestPlan(messages)).toBe(entries);
+	});
+});
+
+describe("summarizePlan", () => {
+	it("prefers the first in_progress entry", () => {
+		const s = summarizePlan([
+			entry("completed"),
+			entry("in_progress", "current"),
+			entry("in_progress", "second"),
+			entry("pending"),
+		]);
+		expect(s).toMatchObject({ completed: 1, total: 4 });
+		expect(s.current?.content).toBe("current");
+	});
+
+	it("falls back to the first pending when nothing is in progress", () => {
+		const s = summarizePlan([
+			entry("completed"),
+			entry("pending", "next up"),
+			entry("pending"),
+		]);
+		expect(s.current?.content).toBe("next up");
+	});
+
+	it("handles the all-pending first update", () => {
+		const s = summarizePlan([entry("pending", "first"), entry("pending")]);
+		expect(s).toMatchObject({ completed: 0, total: 2 });
+		expect(s.current?.content).toBe("first");
+	});
+
+	it("returns no current entry when everything is done", () => {
+		const s = summarizePlan([entry("completed"), entry("completed")]);
+		expect(s).toMatchObject({ completed: 2, total: 2, current: null });
+	});
+});


### PR DESCRIPTION
## Description

After #390 collapsed thinking and tool calls into one-line rows, the plan was the last always-expanded card left in the transcript — an 8-entry plan permanently occupied the height of 8 tool calls.

The plan now lives in a collapsible strip under the header (below the cwd banner), in all three views (sidebar / floating / embedded):

- **Collapsed (default)**: a single line — `Plan 3/8 · <entry being worked on>`. The shown entry is the first `in_progress`, falling back to the first `pending`; when everything is completed the line is just `Plan 8/8`.
- **Expanded**: a full-width band that reads as an extension of the header and overlays the transcript, so toggling never resizes or scrolls the message area. Entries keep their previous look (status icons, strikethrough for completed, bold for in progress), laid out as an icon column vertically centered next to the text.
- The row toggles by click, Enter, or Space (`role="button"`, `aria-expanded`), with the same drag-select guard as tool-call rows.

The transcript no longer renders plans. Plan data still flows through messages, so **session restore and Markdown export are unchanged**; messages whose only content is a plan are skipped to avoid rendering empty bubbles.

Internals:

- The tool-call header's toggle behavior (click/Enter/Space + selection guard) is extracted into a shared `useCollapsibleToggle` hook; `ToolCallBlock` now consumes it (verbatim move, behavior unchanged).
- The current plan and its summary are derived from the transcript by pure helpers in `message-state.ts` (`findLatestPlan` / `summarizePlan`), mirroring the existing permission helpers, with unit tests covering the edge cases (all-pending first update, no in-progress, all-completed, empty, replacement).

## Related issue

None (from the internal backlog).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Claude Code (claude-agent-acp), [acp-fixture-agent](https://github.com/RAIT-09/acp-fixture-agent)
- OS: macOS

## Screenshots

<img width="383" height="363" alt="image" src="https://github.com/user-attachments/assets/d61a5463-62b0-43a5-95e4-7c7c2d5d795f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible plan-progress display showing completion counts and the current task.
  * Expanded plans now show each step with status indicators and optional emojis.
  * Added accessible keyboard and click interactions for expandable sections.
* **UI Improvements**
  * Plan details now appear in a dedicated progress strip instead of the message transcript.
  * Plan styling adapts across floating, embedded, and sidebar layouts.
* **Bug Fixes**
  * Prevented text-selection clicks from unintentionally toggling collapsible sections.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->