### PR TITLE
feat(agents): add the Pi preset (+ PATH fix for wrapper agents)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Client Plugin - LLM Developer Guide
 
 ## Overview
-Obsidian plugin for AI agent interaction (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, custom agents) via ACP.
+Obsidian plugin for AI agent interaction (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, Pi, custom agents) via ACP.
 
 **Tech**: React 19, TypeScript, Obsidian API, Agent Client Protocol (ACP)
 
@@ -337,6 +337,7 @@ interface ISettingsAccess {
 - OpenCode: `opencode-ai` (CLI-managed auth, no API key env)
 - Kiro: `kiro-cli` install script (KIRO_API_KEY, optional)
 - Hermes Agent: install script (CLI-managed auth, no API key env)
+- Pi: `pi-acp` npm package (requires `pi` CLI; CLI-managed auth, no API key env)
 - Custom: Any ACP-compatible agent
 
 ---

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,7 +40,7 @@ Zed の [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/age
 
 **管制室。** Session Manager が、サイドバー・タブ・フローティング・ノート内に開いている全会話をステータスアイコン付きで一覧します（権限待ちも見えます）。クリックでその場へジャンプ。
 
-**どの ACP エージェントでも。** 7つのプリセット — Claude Code、Codex、Gemini CLI、Mistral Vibe、OpenCode、Kiro、Hermes Agent — に加えて、ACP 互換エージェントならカスタムエージェントとして追加できます。明日新しいエージェントが ACP 対応しても、カスタムエージェントに登録するだけ — プラグインの更新を待つ必要はありません。
+**どの ACP エージェントでも。** 8つのプリセット — Claude Code、Codex、Gemini CLI、Mistral Vibe、OpenCode、Kiro、Hermes Agent、Pi — に加えて、ACP 互換エージェントならカスタムエージェントとして追加できます。明日新しいエージェントが ACP 対応しても、カスタムエージェントに登録するだけ — プラグインの更新を待つ必要はありません。
 
 ## 機能
 
@@ -69,7 +69,7 @@ Zed の [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/age
 
 1. 使いたいエージェントをセットアップガイドに従ってインストール・認証します:
 
-   [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html) · [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html) · [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html) · [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html) · [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html) · [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html) · [Hermes Agent](https://rait-09.github.io/obsidian-agent-client/agent-setup/hermes.html) · [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)
+   [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html) · [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html) · [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html) · [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html) · [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html) · [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html) · [Hermes Agent](https://rait-09.github.io/obsidian-agent-client/agent-setup/hermes.html) · [Pi](https://rait-09.github.io/obsidian-agent-client/agent-setup/pi.html) · [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)
 
 2. **設定 → Agent Client** でエージェントのパスを確認します — **Auto-detect** でほとんどの場合見つかります
 3. リボンのロボットアイコンをクリックしてチャット開始

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Built on the [Agent Client Protocol (ACP)](https://github.com/agentclientprotoco
 
 **Mission control.** The Session Manager lists every open conversation across sidebar, tabs, floating windows, and notes, with live status icons — including "waiting for permission". Click any entry to jump straight there.
 
-**Any ACP agent.** Seven presets — Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent — plus any ACP-compatible agent as a custom entry. New agent ships ACP support tomorrow? Add it as a custom entry — no plugin update needed.
+**Any ACP agent.** Eight presets — Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, Pi — plus any ACP-compatible agent as a custom entry. New agent ships ACP support tomorrow? Add it as a custom entry — no plugin update needed.
 
 ## Features
 
@@ -69,7 +69,7 @@ Built on the [Agent Client Protocol (ACP)](https://github.com/agentclientprotoco
 
 1. Install and authenticate an agent, following its setup guide:
 
-   [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html) · [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html) · [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html) · [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html) · [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html) · [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html) · [Hermes Agent](https://rait-09.github.io/obsidian-agent-client/agent-setup/hermes.html) · [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)
+   [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html) · [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html) · [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html) · [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html) · [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html) · [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html) · [Hermes Agent](https://rait-09.github.io/obsidian-agent-client/agent-setup/hermes.html) · [Pi](https://rait-09.github.io/obsidian-agent-client/agent-setup/pi.html) · [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)
 
 2. Open **Settings → Agent Client** and check the agent's path — **Auto-detect** usually finds it
 3. Click the robot icon in the ribbon and start chatting

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -63,6 +63,7 @@ export default defineConfig({
           { text: "OpenCode", link: "/agent-setup/opencode" },
           { text: "Kiro", link: "/agent-setup/kiro" },
           { text: "Hermes Agent", link: "/agent-setup/hermes" },
+          { text: "Pi", link: "/agent-setup/pi" },
           { text: "Custom Agents", link: "/agent-setup/custom-agents" },
         ],
       },

--- a/docs/agent-setup/index.md
+++ b/docs/agent-setup/index.md
@@ -13,13 +13,14 @@ Agent Client supports multiple AI agents through the [Agent Client Protocol (ACP
 | [OpenCode](./opencode) | Multi-provider | `opencode-ai` |
 | [Kiro](./kiro) | AWS | install script |
 | [Hermes Agent](./hermes) | Multi-provider | install script |
+| [Pi](./pi) | Multi-provider | `pi-acp` (npm) |
 | [Custom Agents](./custom-agents) | Various | Any ACP-compatible agent |
 
 ## Common Setup Steps
 
 All agents follow a similar setup pattern:
 
-1. **Install the agent** — see each agent's setup page for the exact command (npm for Claude Code / Codex / Gemini CLI; `curl` on macOS/Linux or `uv` on Windows for Mistral Vibe; `curl` or npm for OpenCode; `curl` on macOS/Linux or PowerShell on Windows for Kiro and Hermes Agent)
+1. **Install the agent** — see each agent's setup page for the exact command (npm for Claude Code / Codex / Gemini CLI; `curl` on macOS/Linux or `uv` on Windows for Mistral Vibe; `curl` or npm for OpenCode; `curl` on macOS/Linux or PowerShell on Windows for Kiro and Hermes Agent; npm for Pi)
 2. **Set up authentication** (API key or account login)
 
 The plugin resolves bare command names through your login shell's PATH, so path configuration is often not needed. If the agent is not found automatically, use `which` (macOS/Linux) or `where.exe` (Windows) to find the path and configure it in Settings → Agent Client.

--- a/docs/agent-setup/pi.md
+++ b/docs/agent-setup/pi.md
@@ -1,0 +1,58 @@
+# Pi Setup
+
+[Pi](https://github.com/earendil-works/pi) is a minimal, hackable terminal coding agent. It communicates via ACP through [pi-acp](https://github.com/svkozak/pi-acp), an adapter that spawns `pi --mode rpc` and bridges events between Agent Client and pi.
+
+## Install and Configure
+
+Open a terminal (Terminal on macOS/Linux, PowerShell on Windows) and run the following commands.
+
+1. Install pi and pi-acp (requires Node.js 22 or later):
+
+```bash
+npm install -g @earendil-works/pi-coding-agent pi-acp
+```
+
+2. Find the installation path:
+
+::: code-group
+
+```bash [macOS/Linux]
+which pi-acp
+# Example output: /Users/username/.npm-global/bin/pi-acp
+```
+
+```cmd [Windows]
+where.exe pi-acp
+```
+
+:::
+
+3. Open **Settings → Agent Client**. The default command (`pi-acp`) works in many cases. If the agent is not found automatically, set the **Pi path** to the path found above, or click **Auto-detect**.
+
+::: tip "Could not start pi" error
+`pi-acp` spawns `pi` as a child process, resolved via PATH. When an absolute Pi path is configured, Agent Client prepends that directory to PATH, so a `pi` installed next to `pi-acp` (the usual case) is found automatically. If `pi` lives in a different directory, make sure that directory is on your login shell's PATH (e.g. exported from `~/.zprofile`, not only `~/.zshrc`).
+:::
+
+## Authentication
+
+Pi manages provider credentials itself, so there is no API key field for it in Agent Client.
+
+1. Run pi in your terminal and complete the interactive setup — pick a model, sign in with `/login`, or configure a provider API key (see the [pi docs](https://github.com/earendil-works/pi)):
+
+```bash
+pi
+```
+
+Alternatively, `pi-acp --terminal-login` launches the same interactive login directly.
+
+2. Verify that a normal chat works in the terminal before connecting from Obsidian.
+
+Credentials are stored under `~/.pi/agent/` and are picked up by the `pi-acp` process that Agent Client starts.
+
+## Verify Setup
+
+1. Click the robot icon in the ribbon or use the command palette: **"Open chat view"**
+2. Switch to Pi from the agent dropdown in the chat header
+3. Try sending a message to verify the connection
+
+Having issues? See [Troubleshooting](/help/troubleshooting).

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -15,6 +15,7 @@ Agent Client supports multiple AI agents. Choose one to start:
 | **[OpenCode](/agent-setup/opencode)** | Multi-provider | with built-in ACP support (`opencode acp`) |
 | **[Kiro](/agent-setup/kiro)** | AWS | with built-in ACP support (`kiro-cli acp`) |
 | **[Hermes Agent](/agent-setup/hermes)** | Multi-provider | with built-in ACP support (`hermes acp`) |
+| **[Pi](/agent-setup/pi)** | Multi-provider | via [ACP adapter](https://github.com/svkozak/pi-acp) (`pi-acp`) |
 | **[Custom](/agent-setup/custom-agents)** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., Qwen Code) |
 
 ## Step 2: Install and Configure the Agent
@@ -28,6 +29,7 @@ Follow the setup guide for your chosen agent:
 - [OpenCode Setup](/agent-setup/opencode)
 - [Kiro Setup](/agent-setup/kiro)
 - [Hermes Agent Setup](/agent-setup/hermes)
+- [Pi Setup](/agent-setup/pi)
 - [Custom Agents](/agent-setup/custom-agents)
 
 Each guide covers installation, path configuration, and authentication.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -6,7 +6,7 @@ Frequently asked questions about Agent Client.
 
 ### What is Agent Client?
 
-Agent Client is an Obsidian plugin that lets you chat with AI agents directly within Obsidian. It supports Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, and any ACP-compatible agent. The plugin uses the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) to communicate with agents.
+Agent Client is an Obsidian plugin that lets you chat with AI agents directly within Obsidian. It supports Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, Pi, and any ACP-compatible agent. The plugin uses the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) to communicate with agents.
 
 ### Is this an official Anthropic/OpenAI/Google plugin?
 
@@ -81,7 +81,7 @@ Disabling only hides the agent from lists: already-open chats, restored sessions
 
 ### What is a custom agent?
 
-Any ACP-compatible agent beyond the preset ones (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent). You can add custom agents in **Settings → Agent Client → Custom agents**. See [Custom Agents](/agent-setup/custom-agents).
+Any ACP-compatible agent beyond the preset ones (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, Pi). You can add custom agents in **Settings → Agent Client → Custom agents**. See [Custom Agents](/agent-setup/custom-agents).
 
 ### Do all agents support the same features?
 
@@ -95,7 +95,7 @@ Slash commands are provided by the agent, not the plugin. If the input placehold
 
 ### Why are the commands different from what I expected?
 
-Each agent provides its own commands. Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, and Hermes Agent all have different command sets. Refer to your agent's documentation for available commands.
+Each agent provides its own commands. Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, and Pi all have different command sets. Refer to your agent's documentation for available commands.
 
 ## Permissions
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -65,6 +65,9 @@ The agent requires authentication before processing requests.
 **For Hermes Agent:**
 - Run `hermes model` in Terminal to configure a provider (there is no API key field in the plugin). See [Hermes Agent Setup](/agent-setup/hermes#authentication).
 
+**For Pi:**
+- Run `pi` in Terminal and complete the interactive setup for your provider (there is no API key field in the plugin). See [Pi Setup](/agent-setup/pi#authentication).
+
 ### "No Authentication Methods" error
 
 The agent didn't provide authentication options.

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ Agent Client is an Obsidian plugin that brings AI coding agents directly into yo
 | **[OpenCode](https://github.com/anomalyco/opencode)** | Multi-provider | with built-in ACP support (`opencode acp`) |
 | **[Kiro](https://kiro.dev/)** | AWS | with built-in ACP support (`kiro-cli acp`) |
 | **[Hermes Agent](https://github.com/NousResearch/hermes-agent)** | Multi-provider | with built-in ACP support (`hermes acp`) |
+| **[Pi](https://github.com/earendil-works/pi)** | Multi-provider | via [ACP adapter](https://github.com/svkozak/pi-acp) (`pi-acp`) |
 | **Custom** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., Qwen Code) |
 
 ### Key Features

--- a/docs/reference/acp-support.md
+++ b/docs/reference/acp-support.md
@@ -6,7 +6,7 @@ This page documents which Agent Client Protocol (ACP) features are supported by 
 
 The [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) is an open standard for communication between AI agents and client applications. It defines how clients send prompts, receive responses, handle permissions, and manage sessions.
 
-Agent Client implements ACP as a **client**, communicating with ACP-compatible agents like Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, and Hermes Agent.
+Agent Client implements ACP as a **client**, communicating with ACP-compatible agents like Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, and Pi.
 
 ## Methods
 

--- a/docs/usage/context-files.md
+++ b/docs/usage/context-files.md
@@ -23,6 +23,7 @@ Each agent uses its own context file:
 | OpenCode | `AGENTS.md` (falls back to `CLAUDE.md`) |
 | Kiro | `AGENTS.md` (also `.kiro/steering/*.md`) |
 | Hermes Agent | `AGENTS.md` (falls back to `CLAUDE.md`) |
+| Pi | `AGENTS.md` |
 
 Place the context file in your **vault root** to have the agent read it automatically.
 

--- a/src/services/preset-agents.ts
+++ b/src/services/preset-agents.ts
@@ -257,6 +257,20 @@ export const PRESET_AGENTS: readonly PresetAgentDefinition[] = [
 		},
 		docsPage: "hermes",
 	},
+	{
+		presetId: "pi-acp",
+		defaultDisplayName: "Pi",
+		defaultCommand: "pi-acp",
+		defaultArgs: [],
+		installHint: {
+			default: "npm install -g @earendil-works/pi-coding-agent pi-acp",
+		},
+		settingsCopy: {
+			pathDesc:
+				'Command name or path to pi-acp. Use just "pi-acp" to let the login shell resolve it, or enter an absolute path.',
+		},
+		docsPage: "pi",
+	},
 ];
 
 /**

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -579,10 +579,26 @@ export function prepareShellCommand(
 			commandString = command;
 		}
 
-		// Prepend PATH export if nodeDir is provided
+		// Prepend PATH exports: nodeDir (plugin setting) and, for absolute
+		// command paths, the command's own directory. Wrapper agents
+		// (e.g. pi-acp spawning `pi`) resolve sibling executables via PATH,
+		// and non-interactive login shells may not include that directory
+		// (npm-global bin, ~/.local/bin, ...).
+		const pathDirs: string[] = [];
 		if (options.nodeDir) {
-			const escapedNodeDir = options.nodeDir.replace(/'/g, "'\\''");
-			commandString = `export PATH='${escapedNodeDir}':"$PATH"; ${commandString}`;
+			pathDirs.push(options.nodeDir);
+		}
+		if (command.startsWith("/")) {
+			const commandDir = command.slice(0, command.lastIndexOf("/"));
+			if (commandDir && !pathDirs.includes(commandDir)) {
+				pathDirs.push(commandDir);
+			}
+		}
+		if (pathDirs.length > 0) {
+			const escapedDirs = pathDirs
+				.map((dir) => dir.replace(/'/g, "'\\''"))
+				.join(":");
+			commandString = `export PATH='${escapedDirs}':"$PATH"; ${commandString}`;
 		}
 
 		return {

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -589,8 +589,10 @@ export function prepareShellCommand(
 			pathDirs.push(options.nodeDir);
 		}
 		if (command.startsWith("/")) {
-			const commandDir = command.slice(0, command.lastIndexOf("/"));
-			if (commandDir && !pathDirs.includes(commandDir)) {
+			const lastSlash = command.lastIndexOf("/");
+			const commandDir =
+				lastSlash === 0 ? "/" : command.slice(0, lastSlash);
+			if (!pathDirs.includes(commandDir)) {
 				pathDirs.push(commandDir);
 			}
 		}

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -316,6 +316,14 @@ describe("prepareShellCommand", () => {
 		);
 	});
 
+	it("macOS: a root-level command resolves / as its directory", () => {
+		Platform.isMacOS = true;
+		const r = prepareShellCommand("/pi-acp", [], "/home/u", {
+			wslMode: false,
+		});
+		expect(r.args[2]).toContain(`export PATH='/':"$PATH";`);
+	});
+
 	it("macOS: bare command names get no PATH injection", () => {
 		Platform.isMacOS = true;
 		const r = prepareShellCommand("pi-acp", [], "/home/u", {

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -26,7 +26,9 @@ beforeEach(resetPlatform);
 
 describe("convertWindowsPathToWsl", () => {
 	it("converts a Windows drive path", () => {
-		expect(convertWindowsPathToWsl("C:\\Users\\me")).toBe("/mnt/c/Users/me");
+		expect(convertWindowsPathToWsl("C:\\Users\\me")).toBe(
+			"/mnt/c/Users/me",
+		);
 	});
 	it("lowercases the drive letter and normalizes slashes", () => {
 		expect(convertWindowsPathToWsl("D:/Foo/Bar")).toBe("/mnt/d/Foo/Bar");
@@ -41,7 +43,9 @@ describe("convertWindowsPathToWsl", () => {
 
 describe("convertWslPathToWindows", () => {
 	it("converts a /mnt path", () => {
-		expect(convertWslPathToWindows("/mnt/c/Users/me")).toBe("C:\\Users\\me");
+		expect(convertWslPathToWindows("/mnt/c/Users/me")).toBe(
+			"C:\\Users\\me",
+		);
 	});
 	it("passes through non-/mnt paths unchanged", () => {
 		expect(convertWslPathToWindows("/home/me")).toBe("/home/me");
@@ -253,14 +257,14 @@ describe("buildWslTerminalScript", () => {
 
 describe("wrapCommandForWsl — validation", () => {
 	it("rejects UNC working directories", () => {
-		expect(() =>
-			wrapCommandForWsl("/x", [], "\\\\server\\share"),
-		).toThrow(/UNC/);
+		expect(() => wrapCommandForWsl("/x", [], "\\\\server\\share")).toThrow(
+			/UNC/,
+		);
 	});
 	it("rejects invalid distribution names", () => {
-		expect(() =>
-			wrapCommandForWsl("/x", [], "C:\\v", "bad;name"),
-		).toThrow(/distribution/i);
+		expect(() => wrapCommandForWsl("/x", [], "C:\\v", "bad;name")).toThrow(
+			/distribution/i,
+		);
 	});
 });
 
@@ -297,6 +301,38 @@ describe("prepareShellCommand", () => {
 		expect(r.args[0]).toBe("-l");
 		expect(r.args[1]).toBe("-c");
 		expect(r.needsShell).toBe(false);
+	});
+
+	it("macOS: prepends an absolute command's own directory to PATH", () => {
+		Platform.isMacOS = true;
+		const r = prepareShellCommand(
+			"/Users/u/.local/bin/pi-acp",
+			[],
+			"/home/u",
+			{ wslMode: false },
+		);
+		expect(r.args[2]).toContain(
+			`export PATH='/Users/u/.local/bin':"$PATH";`,
+		);
+	});
+
+	it("macOS: bare command names get no PATH injection", () => {
+		Platform.isMacOS = true;
+		const r = prepareShellCommand("pi-acp", [], "/home/u", {
+			wslMode: false,
+		});
+		expect(r.args[2]).not.toContain("export PATH");
+	});
+
+	it("macOS: combines nodeDir with the command directory", () => {
+		Platform.isMacOS = true;
+		const r = prepareShellCommand("/opt/agent/bin/agent", [], "/home/u", {
+			wslMode: false,
+			nodeDir: "/opt/node/bin",
+		});
+		expect(r.args[2]).toContain(
+			`export PATH='/opt/node/bin:/opt/agent/bin':"$PATH";`,
+		);
 	});
 
 	it("Windows non-WSL: needs cmd.exe shell", () => {

--- a/test/session-helpers.test.ts
+++ b/test/session-helpers.test.ts
@@ -67,6 +67,7 @@ function makeSettings(
 			"hermes-agent": preset("hermes-agent", "Hermes Agent", "hermes", {
 				args: ["acp"],
 			}),
+			"pi-acp": preset("pi-acp", "Pi", "pi-acp"),
 		},
 		customAgents: [],
 		defaultAgentId: "",
@@ -87,6 +88,7 @@ describe("getAvailableAgentsFromSettings", () => {
 			{ id: "opencode", displayName: "OpenCode" },
 			{ id: "kiro-cli", displayName: "Kiro" },
 			{ id: "hermes-agent", displayName: "Hermes Agent" },
+			{ id: "pi-acp", displayName: "Pi" },
 			{ id: "my-custom", displayName: "My Custom" },
 		]);
 	});
@@ -119,6 +121,7 @@ describe("getAvailableAgentsFromSettings", () => {
 			"opencode",
 			"kiro-cli",
 			"hermes-agent",
+			"pi-acp",
 			"my-custom",
 		]);
 	});
@@ -140,6 +143,7 @@ describe("getAllAgentsFromSettings", () => {
 			{ id: "opencode", displayName: "OpenCode" },
 			{ id: "kiro-cli", displayName: "Kiro" },
 			{ id: "hermes-agent", displayName: "Hermes Agent" },
+			{ id: "pi-acp", displayName: "Pi" },
 			{ id: "off-custom", displayName: "Off Custom" },
 		]);
 	});


### PR DESCRIPTION
## Description

Adds [Pi](https://github.com/earendil-works/pi) as a preset agent via the [pi-acp](https://github.com/svkozak/pi-acp) ACP adapter, and fixes a spawn issue affecting wrapper-style agents that this preset surfaces.

**Preset** (`src/services/preset-agents.ts`, registry-driven as documented in AGENTS.md):
- id `pi-acp`, command `pi-acp`, no default args
- Login-only: pi manages provider credentials itself (like OpenCode / Hermes Agent) — no API key wiring, no custom-agent absorption
- Install hint: `npm install -g @earendil-works/pi-coding-agent pi-acp` (pi-acp requires the `pi` CLI, so one command installs both)

**Fix** (`prepareShellCommand`, macOS/Linux): `pi-acp` spawns `pi` as a child process resolved via PATH, but the non-interactive login shell (`zsh -l -c`) does not source `~/.zshrc`, so npm-global bin / `~/.local/bin`-style directories are missing and the child spawn fails with ENOENT (`Could not start pi: executable not found`). When the configured agent command is an absolute path (what Auto-detect sets), its own directory is now prepended to PATH in the login-shell wrapper — installers place the adapter and the CLI side by side, so this resolves transparently with no user shell-config changes. Bare command names are unaffected.

**Tests**: registry enumeration updated; 3 new `prepareShellCommand` cases (absolute-path injection, bare name untouched, nodeDir combination). 198/198 pass.

**Docs**: new `docs/agent-setup/pi.md` setup page (incl. a "Could not start pi" tip for the remaining split-directory edge case), sidebar, agent tables, FAQ, troubleshooting, ACP support, context files, README/README.ja, AGENTS.md.

## Related issue

Closes #404

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names) — 0 errors, no new warnings
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Pi (pi-acp 0.0.33, pi 0.84.2) — streaming, tool calls, permissions, slash commands all working
- OS: macOS

## Screenshots

<!-- N/A -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pi as a supported preset ACP agent.
  * Added Pi installation, authentication, configuration, verification, and troubleshooting guidance.
  * Added Pi references throughout supported-agent lists, quick starts, FAQs, and context-file documentation.
* **Bug Fixes**
  * Improved command launching on macOS and Linux by preserving required executable paths in `PATH`, including absolute command locations.
* **Tests**
  * Added coverage for command path handling and Pi agent configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->