### PR TITLE
Show the real file text in word-level diff highlights

### DIFF
--- a/src/ui/DiffRenderer.tsx
+++ b/src/ui/DiffRenderer.tsx
@@ -1,8 +1,13 @@
 import * as React from "react";
 const { useState, useMemo } = React;
-import * as Diff from "diff";
 import type AgentClientPlugin from "../plugin";
 import { LucideIcon } from "./shared/IconButton";
+import {
+	computeDiffLines,
+	isNewFileDiff,
+	type DiffLine,
+	type DiffWordPart,
+} from "../utils/diff-lines";
 
 // ============================================================
 // Diff renderer component
@@ -19,48 +24,8 @@ interface DiffRendererProps {
 	collapseThreshold?: number;
 }
 
-/**
- * Represents a single line in a diff view
- * @property type - The type of change: added, removed, or unchanged context
- * @property oldLineNumber - Line number in the old file (undefined for added lines)
- * @property newLineNumber - Line number in the new file (undefined for removed lines)
- * @property content - The text content of the line
- * @property wordDiff - Optional word-level diff for lines that were modified (adjacent removed+added pairs)
- */
-interface DiffLine {
-	type: "added" | "removed" | "context";
-	oldLineNumber?: number;
-	newLineNumber?: number;
-	content: string;
-	wordDiff?: { type: "added" | "removed" | "context"; value: string }[];
-}
-
-/**
- * Check if the diff represents a new file (no old content)
- */
-function isNewFile(diff: DiffRendererProps["diff"]): boolean {
-	return (
-		diff.oldText === null ||
-		diff.oldText === undefined ||
-		diff.oldText === ""
-	);
-}
-
-// Helper function to map diff parts to our internal format
-function mapDiffParts(
-	parts: Diff.Change[],
-): { type: "added" | "removed" | "context"; value: string }[] {
-	return parts.map((part) => ({
-		type: part.added ? "added" : part.removed ? "removed" : "context",
-		value: part.value,
-	}));
-}
-
 // Helper function to render word-level diffs
-function renderWordDiff(
-	wordDiff: { type: "added" | "removed" | "context"; value: string }[],
-	lineType: "added" | "removed",
-) {
+function renderWordDiff(wordDiff: DiffWordPart[], lineType: "added" | "removed") {
 	// Filter parts based on line type to avoid rendering null elements
 	const filteredParts = wordDiff.filter((part) => {
 		// For removed lines, skip added parts
@@ -102,103 +67,15 @@ function renderWordDiff(
 	);
 }
 
-// Number of context lines to show around changes
-const CONTEXT_LINES = 3;
-
 export function DiffRenderer({
 	diff,
 	autoCollapse = false,
 	collapseThreshold = 10,
 }: DiffRendererProps) {
-	// Generate diff using the diff library
-	const diffLines = useMemo(() => {
-		if (isNewFile(diff)) {
-			// New file - all lines are added
-			const lines = diff.newText.split("\n");
-			return lines.map(
-				(line, idx): DiffLine => ({
-					type: "added",
-					newLineNumber: idx + 1,
-					content: line,
-				}),
-			);
-		}
-
-		// Use structuredPatch to get a proper unified diff
-		// At this point, oldText is guaranteed to be a non-empty string (checked by isNewFile)
-		const oldText = diff.oldText || "";
-		const patch = Diff.structuredPatch(
-			"old",
-			"new",
-			oldText,
-			diff.newText,
-			"",
-			"",
-			{ context: CONTEXT_LINES },
-		);
-
-		const result: DiffLine[] = [];
-		let oldLineNum = 0;
-		let newLineNum = 0;
-
-		// Process hunks
-		for (const hunk of patch.hunks) {
-			// Add hunk header only if there are multiple hunks
-			// (helps users see gaps between different sections of changes)
-			if (patch.hunks.length > 1) {
-				result.push({
-					type: "context",
-					content: `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`,
-				});
-			}
-
-			oldLineNum = hunk.oldStart;
-			newLineNum = hunk.newStart;
-
-			for (const line of hunk.lines) {
-				const marker = line[0];
-				const content = line.substring(1);
-
-				if (marker === "+") {
-					result.push({
-						type: "added",
-						newLineNumber: newLineNum++,
-						content,
-					});
-				} else if (marker === "-") {
-					result.push({
-						type: "removed",
-						oldLineNumber: oldLineNum++,
-						content,
-					});
-				} else {
-					// Context line (unchanged)
-					result.push({
-						type: "context",
-						oldLineNumber: oldLineNum++,
-						newLineNumber: newLineNum++,
-						content,
-					});
-				}
-			}
-		}
-
-		// Add word-level diff for modified lines that are adjacent
-		for (let i = 0; i < result.length - 1; i++) {
-			const current = result[i];
-			const next = result[i + 1];
-
-			// If we have a removed line followed by an added line, compute word diff
-			if (current.type === "removed" && next.type === "added") {
-				const wordDiff = Diff.diffWords(current.content, next.content);
-				const mappedDiff = mapDiffParts(wordDiff);
-				current.wordDiff = mappedDiff;
-				next.wordDiff = mappedDiff;
-			}
-		}
-
-		return result;
-	}, [diff.oldText, diff.newText]);
+	const diffLines = useMemo(
+		() => computeDiffLines(diff.oldText, diff.newText),
+		[diff.oldText, diff.newText],
+	);
 
 	const renderLine = (line: DiffLine, idx: number) => {
 		const isHunkHeader =
@@ -250,7 +127,7 @@ export function DiffRenderer({
 
 	return (
 		<div className="agent-client-tool-call-diff">
-			{isNewFile(diff) ? (
+			{isNewFileDiff(diff.oldText) ? (
 				<div className="agent-client-diff-line-info">New file</div>
 			) : null}
 			<div className="agent-client-tool-call-diff-content">

--- a/src/utils/diff-lines.ts
+++ b/src/utils/diff-lines.ts
@@ -43,7 +43,9 @@ const CONTEXT_LINES = 3;
  *
  * Produces unified-diff lines with line numbers, hunk headers when there
  * is more than one hunk, and word-level highlight parts attached to
- * modified lines. A brand-new file renders every line as added.
+ * one-line replacements (in larger blocks no pairing is reliable, so
+ * those get line-level coloring only). A brand-new file renders every
+ * line as added.
  */
 export function computeDiffLines(
 	oldText: string | null | undefined,
@@ -121,22 +123,28 @@ export function computeDiffLines(
 		}
 	}
 
-	// Add word-level diff for modified lines that are adjacent
-	for (let i = 0; i < result.length - 1; i++) {
-		const current = result[i];
-		const next = result[i + 1];
-
-		// If we have a removed line followed by an added line, compute word diff
-		if (current.type === "removed" && next.type === "added") {
+	// Word-level highlights only for 1:1 replacements: in an N:M block the
+	// adjacent pairing is arbitrary and usually relates unrelated lines.
+	let i = 0;
+	while (i < result.length) {
+		if (result[i].type !== "removed") {
+			i++;
+			continue;
+		}
+		const removedStart = i;
+		while (i < result.length && result[i].type === "removed") i++;
+		const addedStart = i;
+		while (i < result.length && result[i].type === "added") i++;
+		if (addedStart - removedStart === 1 && i - addedStart === 1) {
+			const removed = result[removedStart];
+			const added = result[addedStart];
 			// Whitespace-sensitive: parts must reconstruct each side verbatim,
 			// or the deleted line renders with the added line's whitespace.
-			const wordDiff = Diff.diffWordsWithSpace(
-				current.content,
-				next.content,
+			const wordDiff = mapDiffParts(
+				Diff.diffWordsWithSpace(removed.content, added.content),
 			);
-			const mappedDiff = mapDiffParts(wordDiff);
-			current.wordDiff = mappedDiff;
-			next.wordDiff = mappedDiff;
+			removed.wordDiff = wordDiff;
+			added.wordDiff = wordDiff;
 		}
 	}
 

--- a/src/utils/diff-lines.ts
+++ b/src/utils/diff-lines.ts
@@ -128,7 +128,12 @@ export function computeDiffLines(
 
 		// If we have a removed line followed by an added line, compute word diff
 		if (current.type === "removed" && next.type === "added") {
-			const wordDiff = Diff.diffWords(current.content, next.content);
+			// Whitespace-sensitive: parts must reconstruct each side verbatim,
+			// or the deleted line renders with the added line's whitespace.
+			const wordDiff = Diff.diffWordsWithSpace(
+				current.content,
+				next.content,
+			);
 			const mappedDiff = mapDiffParts(wordDiff);
 			current.wordDiff = mappedDiff;
 			next.wordDiff = mappedDiff;

--- a/src/utils/diff-lines.ts
+++ b/src/utils/diff-lines.ts
@@ -1,0 +1,137 @@
+import * as Diff from "diff";
+
+/** One fragment of a word-level diff, tagged with how it changed. */
+export interface DiffWordPart {
+	type: "added" | "removed" | "context";
+	value: string;
+}
+
+/**
+ * Represents a single line in a diff view
+ * @property type - The type of change: added, removed, or unchanged context
+ * @property oldLineNumber - Line number in the old file (undefined for added lines)
+ * @property newLineNumber - Line number in the new file (undefined for removed lines)
+ * @property content - The text content of the line
+ * @property wordDiff - Optional word-level diff for lines that were modified
+ */
+export interface DiffLine {
+	type: "added" | "removed" | "context";
+	oldLineNumber?: number;
+	newLineNumber?: number;
+	content: string;
+	wordDiff?: DiffWordPart[];
+}
+
+/** Whether the diff represents a brand-new file (no old content). */
+export function isNewFileDiff(oldText: string | null | undefined): boolean {
+	return oldText === null || oldText === undefined || oldText === "";
+}
+
+// Helper function to map diff parts to our internal format
+function mapDiffParts(parts: Diff.Change[]): DiffWordPart[] {
+	return parts.map((part) => ({
+		type: part.added ? "added" : part.removed ? "removed" : "context",
+		value: part.value,
+	}));
+}
+
+// Number of context lines to show around changes
+const CONTEXT_LINES = 3;
+
+/**
+ * Turn an old/new text pair into displayable diff lines.
+ *
+ * Produces unified-diff lines with line numbers, hunk headers when there
+ * is more than one hunk, and word-level highlight parts attached to
+ * modified lines. A brand-new file renders every line as added.
+ */
+export function computeDiffLines(
+	oldText: string | null | undefined,
+	newText: string,
+): DiffLine[] {
+	if (isNewFileDiff(oldText)) {
+		// New file - all lines are added
+		const lines = newText.split("\n");
+		return lines.map(
+			(line, idx): DiffLine => ({
+				type: "added",
+				newLineNumber: idx + 1,
+				content: line,
+			}),
+		);
+	}
+
+	// Use structuredPatch to get a proper unified diff
+	// At this point, oldText is guaranteed to be a non-empty string (checked by isNewFileDiff)
+	const patch = Diff.structuredPatch(
+		"old",
+		"new",
+		oldText || "",
+		newText,
+		"",
+		"",
+		{ context: CONTEXT_LINES },
+	);
+
+	const result: DiffLine[] = [];
+	let oldLineNum = 0;
+	let newLineNum = 0;
+
+	// Process hunks
+	for (const hunk of patch.hunks) {
+		// Add hunk header only if there are multiple hunks
+		// (helps users see gaps between different sections of changes)
+		if (patch.hunks.length > 1) {
+			result.push({
+				type: "context",
+				content: `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`,
+			});
+		}
+
+		oldLineNum = hunk.oldStart;
+		newLineNum = hunk.newStart;
+
+		for (const line of hunk.lines) {
+			const marker = line[0];
+			const content = line.substring(1);
+
+			if (marker === "+") {
+				result.push({
+					type: "added",
+					newLineNumber: newLineNum++,
+					content,
+				});
+			} else if (marker === "-") {
+				result.push({
+					type: "removed",
+					oldLineNumber: oldLineNum++,
+					content,
+				});
+			} else {
+				// Context line (unchanged)
+				result.push({
+					type: "context",
+					oldLineNumber: oldLineNum++,
+					newLineNumber: newLineNum++,
+					content,
+				});
+			}
+		}
+	}
+
+	// Add word-level diff for modified lines that are adjacent
+	for (let i = 0; i < result.length - 1; i++) {
+		const current = result[i];
+		const next = result[i + 1];
+
+		// If we have a removed line followed by an added line, compute word diff
+		if (current.type === "removed" && next.type === "added") {
+			const wordDiff = Diff.diffWords(current.content, next.content);
+			const mappedDiff = mapDiffParts(wordDiff);
+			current.wordDiff = mappedDiff;
+			next.wordDiff = mappedDiff;
+		}
+	}
+
+	return result;
+}

--- a/src/utils/diff-lines.ts
+++ b/src/utils/diff-lines.ts
@@ -93,6 +93,8 @@ export function computeDiffLines(
 
 		for (const line of hunk.lines) {
 			const marker = line[0];
+			// jsdiff metadata, not file content ("\ No newline at end of file").
+			if (marker === "\\") continue;
 			const content = line.substring(1);
 
 			if (marker === "+") {

--- a/src/utils/diff-lines.ts
+++ b/src/utils/diff-lines.ts
@@ -54,6 +54,8 @@ export function computeDiffLines(
 	if (isNewFileDiff(oldText)) {
 		// New file - all lines are added
 		const lines = newText.split("\n");
+		// split() leaves an empty item after a terminal newline; not a real line.
+		if (lines[lines.length - 1] === "") lines.pop();
 		return lines.map(
 			(line, idx): DiffLine => ({
 				type: "added",

--- a/styles.css
+++ b/styles.css
@@ -1591,7 +1591,6 @@ If your plugin does not need CSS, delete this file.
 .agent-client-diff-word-removed {
 	background-color: rgba(248, 81, 73, 0.4);
 	font-weight: 600;
-	text-decoration: line-through;
 }
 
 /* Diff Expand/Collapse Bar */

--- a/test/diff-lines.test.ts
+++ b/test/diff-lines.test.ts
@@ -55,3 +55,74 @@ describe("word diff reconstructs each side verbatim", () => {
 		});
 	}
 });
+
+function joinLines(lines: string[]): string {
+	return lines.join("\n");
+}
+
+describe("word diff pairing", () => {
+	it("highlights a 1:1 replacement", () => {
+		const lines = computeDiffLines(
+			joinLines(["keep", "old line", "keep2"]),
+			joinLines(["keep", "new line", "keep2"]),
+		);
+		expect(lines.find((l) => l.type === "removed")?.wordDiff).toBeDefined();
+		expect(lines.find((l) => l.type === "added")?.wordDiff).toBeDefined();
+	});
+
+	it("shares one parts array between the pair", () => {
+		const lines = computeDiffLines("a", "b");
+		expect(lines.find((l) => l.type === "removed")?.wordDiff).toBe(
+			lines.find((l) => l.type === "added")?.wordDiff,
+		);
+	});
+
+	it("skips an N:N block entirely", () => {
+		const lines = computeDiffLines(
+			joinLines(["old 1", "old 2", "old 3"]),
+			joinLines(["new 1", "new 2", "new 3"]),
+		);
+		expect(lines.every((l) => l.wordDiff === undefined)).toBe(true);
+	});
+
+	it("skips unbalanced blocks (2:1 and 1:2)", () => {
+		const a = computeDiffLines(
+			joinLines(["x", "old 1", "old 2", "y"]),
+			joinLines(["x", "new", "y"]),
+		);
+		const b = computeDiffLines(
+			joinLines(["x", "old", "y"]),
+			joinLines(["x", "new 1", "new 2", "y"]),
+		);
+		expect([...a, ...b].every((l) => l.wordDiff === undefined)).toBe(true);
+	});
+
+	it("highlights each separate 1:1 block independently", () => {
+		const lines = computeDiffLines(
+			joinLines(["keep", "old a", "keep", "old b", "keep"]),
+			joinLines(["keep", "new a", "keep", "new b", "keep"]),
+		);
+		expect(lines.filter((l) => l.wordDiff !== undefined)).toHaveLength(4);
+	});
+
+	it("puts no highlights on pure deletions or additions", () => {
+		const del = computeDiffLines(
+			joinLines(["keep", "gone", "keep2"]),
+			joinLines(["keep", "keep2"]),
+		);
+		const add = computeDiffLines(
+			joinLines(["keep", "keep2"]),
+			joinLines(["keep", "born", "keep2"]),
+		);
+		expect([...del, ...add].every((l) => l.wordDiff === undefined)).toBe(
+			true,
+		);
+	});
+
+	it("renders a new file as added lines without highlights", () => {
+		const lines = computeDiffLines(null, joinLines(["a", "b"]));
+		expect(
+			lines.every((l) => l.type === "added" && l.wordDiff === undefined),
+		).toBe(true);
+	});
+});

--- a/test/diff-lines.test.ts
+++ b/test/diff-lines.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { computeDiffLines } from "../src/utils/diff-lines";
+
+describe("no-newline marker lines", () => {
+	// Texts without a trailing newline (the routine shape of snippet diffs)
+	// make structuredPatch emit "\ No newline at end of file" between sides.
+	it("are not rendered as diff rows", () => {
+		const lines = computeDiffLines("old", "new");
+		expect(lines.map((l) => l.content)).toEqual(["old", "new"]);
+	});
+
+	it("do not break word-diff adjacency for snippet diffs", () => {
+		const lines = computeDiffLines("old", "new");
+		expect(lines.find((l) => l.type === "removed")?.wordDiff).toBeDefined();
+		expect(lines.find((l) => l.type === "added")?.wordDiff).toBeDefined();
+	});
+});

--- a/test/diff-lines.test.ts
+++ b/test/diff-lines.test.ts
@@ -126,3 +126,28 @@ describe("word diff pairing", () => {
 		).toBe(true);
 	});
 });
+
+describe("new-file line splitting", () => {
+	it("drops the empty item after a terminal newline", () => {
+		expect(computeDiffLines(null, "a\n").map((l) => l.content)).toEqual([
+			"a",
+		]);
+	});
+
+	it("renders an empty file as no rows", () => {
+		expect(computeDiffLines(null, "")).toEqual([]);
+	});
+
+	it("keeps a real empty line before the terminal newline", () => {
+		expect(computeDiffLines(null, "a\n\n").map((l) => l.content)).toEqual([
+			"a",
+			"",
+		]);
+	});
+
+	it("handles text without a terminal newline", () => {
+		expect(computeDiffLines(null, "a").map((l) => l.content)).toEqual([
+			"a",
+		]);
+	});
+});

--- a/test/diff-lines.test.ts
+++ b/test/diff-lines.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect } from "vitest";
-import { computeDiffLines } from "../src/utils/diff-lines";
+import {
+	computeDiffLines,
+	type DiffLine,
+	type DiffWordPart,
+} from "../src/utils/diff-lines";
+
+/**
+ * Rebuild a line's display text the way DiffRenderer's renderWordDiff does:
+ * a removed line renders every part except "added" ones, an added line every
+ * part except "removed" ones. Mirrors the component's filter rule.
+ */
+function renderedText(line: DiffLine): string {
+	if (!line.wordDiff) return line.content;
+	const skip = line.type === "removed" ? "added" : "removed";
+	return line.wordDiff
+		.filter((part: DiffWordPart) => part.type !== skip)
+		.map((part) => part.value)
+		.join("");
+}
 
 describe("no-newline marker lines", () => {
 	// Texts without a trailing newline (the routine shape of snippet diffs)
@@ -14,4 +32,26 @@ describe("no-newline marker lines", () => {
 		expect(lines.find((l) => l.type === "removed")?.wordDiff).toBeDefined();
 		expect(lines.find((l) => l.type === "added")?.wordDiff).toBeDefined();
 	});
+});
+
+const RECONSTRUCTION_CASES: [string, string, string][] = [
+	["spaces to tabs", "  return 1;", "\t\treturn 1;"],
+	["indent halved plus arg change", "    foo(a);", "  foo(b);"],
+	["checkbox fill", "- [ ] task one", "- [x] task one"],
+	["cjk text", "日本語のテキストです", "日本語の文章です"],
+	["trailing whitespace dropped", "trailing  ", "trailing"],
+	["inner whitespace collapsed", "a,  b", "a, b"],
+];
+
+describe("word diff reconstructs each side verbatim", () => {
+	for (const [name, oldLine, newLine] of RECONSTRUCTION_CASES) {
+		it(name, () => {
+			const lines = computeDiffLines(oldLine, newLine);
+			const removed = lines.find((l) => l.type === "removed");
+			const added = lines.find((l) => l.type === "added");
+			expect(removed?.wordDiff).toBeDefined();
+			expect(renderedText(removed!)).toBe(oldLine);
+			expect(renderedText(added!)).toBe(newLine);
+		});
+	}
 });


### PR DESCRIPTION
## Description

The diff view highlights which words changed inside a modified line (strikethrough-red / green marks). Users read this surface to approve the agent's edits, but the highlighted text could differ from what is actually in the file. Four fixes:

- **Deleted lines borrowed the added line's whitespace.** Word matching used `diffWords`, which ignores whitespace, so the deleted line was rebuilt with the new line's whitespace: spaces displayed as tabs, indents halved, and a `- [ ]` → `- [x]` edit showed the deleted line as `- [] task one` — an ordinary task-completion edit looked like it was destroying the checkbox syntax. Now `diffWordsWithSpace` is used, and unit tests pin the guarantee that concatenating a line's highlight parts reproduces that side's text byte for byte.
- **jsdiff's `\ No newline at end of file` marker rendered as a phantom context row.** Texts without a trailing newline (the routine shape of the first, snippet-based diff claude-agent-acp sends for an Edit) put this marker between the removed and added lines — it rendered as file content, shifted line numbers, and broke word highlighting for exactly the single-line edits the feature targets. Marker lines are now skipped.
- **Multi-line blocks highlighted two unrelated lines.** `structuredPatch` emits all removals then all additions, and the old rule paired *adjacent* removed/added lines — so in a 3-line rewrite, only the last deleted and first added lines got word marks, as a diff of two lines that don't correspond. Word-level highlights now appear only for 1:1 replacements; larger blocks keep their line-level red/green, which already says everything reliable.
- **Strikethrough removed from deleted-word highlights.** With whitespace now honestly highlighted, a line-through over invisible characters drew a dash out of nothing (`- [ ]` appeared to contain a hyphen). Background + bold carry the signal, matching the added side — the convention word-level diffs use elsewhere.

Internals: the pure diff-line computation moved verbatim from `DiffRenderer` to `src/utils/diff-lines.ts`, with 15 unit tests covering the reconstruction guarantee and the pairing rules. Both surfaces that render diffs (transcript tool calls and the permission review) share this single implementation, so both are fixed at once.

## Related issue

None (from the internal backlog).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Claude Code (claude-agent-acp), [acp-fixture-agent](https://github.com/RAIT-09/acp-fixture-agent)
- OS: macOS

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added unified diff rendering with line numbers, context, and hunk headers for multi-section changes.
  - New files now display all lines as additions.
  - Added word-level highlighting for straightforward single-line replacements.

- **Bug Fixes**
  - Removed strike-through styling from removed-word highlights.
  - Improved handling of whitespace, Unicode text, and files without trailing newlines.
  - Prevented ambiguous multi-line changes from displaying misleading word-level highlights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->