### PR TITLE
Cancel pending permissions when the agent process dies

### DIFF
--- a/src/acp/acp-client.ts
+++ b/src/acp/acp-client.ts
@@ -306,6 +306,11 @@ export class AcpClient {
 				signal,
 			);
 
+			// A replaced process's late exit must not cancel the successor's work.
+			if (this.agentProcess === agentProcess) {
+				this.cancelAllOperations();
+			}
+
 			if (code === 127) {
 				this.logger.error(`[AcpClient] Command not found: ${command}`);
 


### PR DESCRIPTION
## Description

When the agent process died (crash, external kill) while a permission request was waiting, the approval dialog outlived the process. The `exit` handler logged and emitted a `process_error` for exit code 127, but never touched the permission queue — so while the in-flight prompt correctly rejected and showed the "ACP connection closed" error banner, the dialog kept asking for a decision that no longer mattered and could only be cleared by clicking it manually.

The `exit` handler now runs the same cleanup that manual cancel and `disconnect()` already use (`cancelAllOperations()`), so pending permissions are cancelled the moment the process dies: the dialog disappears on its own and the error banner stands alone. Every way of losing the process — manual cancel, disconnect, and now death — goes through the same cleanup path.

The call is guarded by process identity. Restarting or switching agents kills the old process and its `exit` event fires late (signal delivery is asynchronous); an unguarded call could cancel the successor session's fresh permission requests. The guard skips a replaced process's exit — `disconnect()` has already cleaned up in that case, and a switched-away session is discarded wholesale.

## Related issue

None (from the internal backlog).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: [acp-fixture-agent](https://github.com/RAIT-09/acp-fixture-agent), Claude Code (claude-agent-acp)
- OS: macOS

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented an exiting process from canceling operations belonging to a replacement process.
  * Pending operations are now canceled only when the exiting process is still the active agent process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->