### PR TITLE
Apply the chat font size setting in the floating chat

### DIFF
--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -1573,10 +1573,12 @@ export const ChatPanel = React.memo(function ChatPanel({
 	);
 
 	if (variant === "floating") {
-		// Floating layout: no wrapper div. Parent agent-client-floating-window is the flex container.
 		// Focus tracking uses containerElProp (from FloatingChatView's containerRef).
 		return (
-			<>
+			<div
+				className="agent-client-chat-view-container"
+				style={chatFontSizeStyle}
+			>
 				<div
 					className="agent-client-floating-header"
 					onMouseDown={onFloatingHeaderMouseDown}
@@ -1591,7 +1593,7 @@ export const ChatPanel = React.memo(function ChatPanel({
 					</div>
 					{inputAreaElement}
 				</div>
-			</>
+			</div>
 		);
 	}
 

--- a/styles.css
+++ b/styles.css
@@ -476,10 +476,7 @@ If your plugin does not need CSS, delete this file.
 
 /* ===== Permission dialog (above the input) ===== */
 
-/* Two selectors: the floating variant has no chat-view-container. With no
-   matching container, cqh silently falls back to the viewport. */
-.agent-client-chat-view-container,
-.agent-client-floating-window {
+.agent-client-chat-view-container {
 	container-type: size;
 	/* Header + input area + gap, measured on device; transient badges make
 	   the header taller, so this is a ceiling estimate. */


### PR DESCRIPTION
## Description

The font size setting (Settings → Display → Font size) had no effect on the floating chat — and even at the default, the floating chat rendered text at the UI font size instead of the editor text size (15px vs 14px with the default theme), so it never quite matched the sidebar.

Cause: the chat font size is distributed as a CSS variable (`--ac-chat-font-size`) defined on the shared `.agent-client-chat-view-container` wrapper — its default there is `var(--font-text-size)`, and the user's setting is injected as an inline style on the same element. The floating variant was the only one without that wrapper (it returned a bare fragment and let the window element do the flex layout), so the variable never resolved inside it: every `font-size: var(--ac-chat-font-size)` declaration was invalid at computed-value time and fell back to the inherited UI font size.

The floating panel now renders inside the same wrapper as the sidebar and embedded variants, which restores both the default (`--font-text-size`) and the setting for all five consumers (messages, input, slash-command hint, mention text, markdown). As a follow-up, the `container-type` rule that had been written across two selectors "because the floating variant has no chat-view-container" is folded back to the single shared one.

Verified on device: default size now matches the sidebar; the setting follows in all five spots; drag / resize / minimize / multiple windows / focus switching unchanged; permission dialog height control (container-query based) unchanged with the container boundary moved to the wrapper.

## Related issue

None (from the internal backlog).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: [acp-fixture-agent](https://github.com/RAIT-09/acp-fixture-agent)
- OS: macOS

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved styling consistency for the floating chat panel.
  * Corrected responsive sizing behavior for permission dialogs by ensuring container-based sizing is applied to the appropriate chat view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->