### PR TITLE
Export tool result content to markdown (text, images, audio, links, resources)

### DIFF
--- a/docs/usage/chat-export.md
+++ b/docs/usage/chat-export.md
@@ -22,9 +22,12 @@ Configure export options in **Settings → Agent Client → Export**:
 | **Auto-export on new chat** | Automatically export when starting a new chat |
 | **Auto-export on close chat** | Automatically export when closing the chat view |
 | **Open note after export** | Automatically open the exported note |
-| **Include images** | Save images attached in messages (default: enabled) |
+| **Include images** | Save images attached in messages and returned by tools (default: enabled) |
 | **Image location** | Where to save images: Obsidian's attachment folder, custom folder, or embed as Base64 |
 | **Custom image folder** | Folder path for images when using custom location |
+| **Include audio** | Save audio returned by tools (default: enabled) |
+| **Audio location** | Where to save audio: Obsidian's attachment folder or a custom folder |
+| **Custom audio folder** | Folder path for audio when using custom location |
 
 ## Export Format
 
@@ -68,6 +71,7 @@ This is an Obsidian plugin that integrates AI coding agents (Claude Code, Codex,
 - **Messages**: Full conversation history with timestamps
 - **Images**: Attached images (saved as files or embedded, based on settings)
 - **Tool calls**: Tool name, locations, status, and diffs
+- **Tool results**: Text output (fenced), images and audio (saved as attachments), resource links, and embedded resources; raw output when a tool returned no content
 - **Thinking**: Agent's reasoning (as collapsible callouts)
 - **Plans**: Task plans with status indicators
 - **Note mentions**: Auto-mention and manual mentions in `@[[note]]` format

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -138,6 +138,9 @@ export interface AgentClientPluginSettings {
 		includeImages: boolean;
 		imageLocation: "obsidian" | "custom" | "base64";
 		imageCustomFolder: string;
+		includeAudios: boolean;
+		audioLocation: "obsidian" | "custom";
+		audioCustomFolder: string;
 		frontmatterTag: string;
 	};
 	// WSL settings (Windows only)
@@ -202,6 +205,9 @@ const DEFAULT_SETTINGS: AgentClientPluginSettings = {
 		includeImages: true,
 		imageLocation: "obsidian",
 		imageCustomFolder: "Agent Client",
+		includeAudios: true,
+		audioLocation: "obsidian",
+		audioCustomFolder: "Agent Client",
 		frontmatterTag: "agent-client",
 	},
 	windowsWslMode: false,
@@ -1486,6 +1492,19 @@ export default class AgentClientPlugin extends Plugin {
 				imageCustomFolder: str(
 					re.imageCustomFolder,
 					D.exportSettings.imageCustomFolder,
+				),
+				includeAudios: bool(
+					re.includeAudios,
+					D.exportSettings.includeAudios,
+				),
+				audioLocation: enumVal(
+					re.audioLocation,
+					["obsidian", "custom"],
+					D.exportSettings.audioLocation,
+				),
+				audioCustomFolder: str(
+					re.audioCustomFolder,
+					D.exportSettings.audioCustomFolder,
 				),
 				frontmatterTag: str(
 					re.frontmatterTag,

--- a/src/services/chat-exporter.ts
+++ b/src/services/chat-exporter.ts
@@ -67,6 +67,14 @@ interface ConvertContext {
 	imageLocation: "obsidian" | "custom" | "base64";
 	/** Custom folder for images */
 	imageCustomFolder: string;
+	/** Counter for audio numbering (separate so image numbers stay stable) */
+	audioIndex: number;
+	/** Whether to include audio in export */
+	includeAudios: boolean;
+	/** Where to save audio (no base64 option) */
+	audioLocation: "obsidian" | "custom";
+	/** Custom folder for audio */
+	audioCustomFolder: string;
 }
 
 export class ChatExporter {
@@ -302,6 +310,10 @@ session_id: ${sessionId}${tagsLine}
 			includeImages: settings.includeImages,
 			imageLocation: settings.imageLocation,
 			imageCustomFolder: settings.imageCustomFolder,
+			audioIndex: 0,
+			includeAudios: settings.includeAudios,
+			audioLocation: settings.audioLocation,
+			audioCustomFolder: settings.audioCustomFolder,
 		};
 
 		let markdown = `# ${agentLabel}\n\n`;
@@ -448,6 +460,11 @@ session_id: ${sessionId}${tagsLine}
 							item.content,
 							context,
 						);
+					} else if (item.content.type === "audio") {
+						md += await this.convertAudioToMarkdown(
+							item.content,
+							context,
+						);
 					} else {
 						md +=
 							convertToolResultBlockToMarkdown(item.content) ??
@@ -507,6 +524,35 @@ session_id: ${sessionId}${tagsLine}
 
 		md += "```\n\n";
 		return md;
+	}
+
+	/**
+	 * Save tool-result audio as an attachment and embed it. There is no
+	 * base64 mode for audio (a data URI cannot play from markdown); when
+	 * saving fails the export carries a placeholder line instead.
+	 */
+	private async convertAudioToMarkdown(
+		audio: { data: string; mimeType: string },
+		context: ConvertContext,
+	): Promise<string> {
+		if (!context.includeAudios) return "";
+		try {
+			context.audioIndex++;
+			const attachmentPath = await this.saveMediaAsAttachment(
+				audio.data,
+				audio.mimeType,
+				context.exportFilePath,
+				context.audioIndex,
+				context.audioLocation,
+				context.audioCustomFolder,
+				"mp3",
+			);
+			const fileName = attachmentPath.split("/").pop();
+			return `![[${fileName}]]\n\n`;
+		} catch (error) {
+			this.logger.error(`Failed to save audio as attachment: ${error}`);
+			return `> Audio (${audio.mimeType}) could not be saved.\n\n`;
+		}
 	}
 
 	private convertPlanToMarkdown(

--- a/src/services/chat-exporter.ts
+++ b/src/services/chat-exporter.ts
@@ -354,7 +354,7 @@ session_id: ${sessionId}${tagsLine}
 				return `> [!info]- Thinking\n> ${content.text.split("\n").join("\n> ")}\n\n`;
 
 			case "tool_call":
-				return this.convertToolCallToMarkdown(content);
+				return this.convertToolCallToMarkdown(content, context);
 
 			case "terminal":
 				return `### 🖥️ Terminal: ${content.terminalId.slice(0, 8)}\n\n`;
@@ -419,9 +419,10 @@ session_id: ${sessionId}${tagsLine}
 		}
 	}
 
-	private convertToolCallToMarkdown(
+	private async convertToolCallToMarkdown(
 		content: Extract<MessageContent, { type: "tool_call" }>,
-	): string {
+		context: ConvertContext,
+	): Promise<string> {
 		let md = `### 🔧 ${content.title || "Tool"}\n\n`;
 
 		// Add locations if present
@@ -442,7 +443,16 @@ session_id: ${sessionId}${tagsLine}
 				if (item.type === "diff") {
 					md += this.convertDiffToMarkdown(item);
 				} else if (item.type === "content") {
-					md += convertToolResultBlockToMarkdown(item.content) ?? "";
+					if (item.content.type === "image") {
+						md += await this.convertImageToMarkdown(
+							item.content,
+							context,
+						);
+					} else {
+						md +=
+							convertToolResultBlockToMarkdown(item.content) ??
+							"";
+					}
 				}
 			}
 		}

--- a/src/services/chat-exporter.ts
+++ b/src/services/chat-exporter.ts
@@ -316,45 +316,56 @@ session_id: ${sessionId}${tagsLine}
 				return `[${content.name}](${content.uri})\n\n`;
 
 			case "image":
-				// Skip if images are not included
-				if (!context.includeImages) {
-					return "";
-				}
-
-				// External URI - use as-is
-				if (content.uri) {
-					return `![Image](${content.uri})\n\n`;
-				}
-
-				// Base64 embedding mode
-				if (context.imageLocation === "base64") {
-					return `![Image](data:${content.mimeType};base64,${content.data})\n\n`;
-				}
-
-				// Save as attachment (obsidian or custom)
-				try {
-					context.imageIndex++;
-					const attachmentPath = await this.saveImageAsAttachment(
-						content.data,
-						content.mimeType,
-						context.exportFilePath,
-						context.imageIndex,
-						context.imageLocation,
-						context.imageCustomFolder,
-					);
-					// Use filename only (Obsidian resolves it)
-					const fileName = attachmentPath.split("/").pop();
-					return `![[${fileName}]]\n\n`;
-				} catch (error) {
-					this.logger.error(
-						`Failed to save image as attachment: ${error}`,
-					);
-					// Fallback to base64 embedding
-					return `![Image](data:${content.mimeType};base64,${content.data})\n\n`;
-				}
+				return this.convertImageToMarkdown(content, context);
 
 			default:
 				return "";
+		}
+	}
+
+	/**
+	 * Convert a base64/uri image to markdown following the export image
+	 * policy: external uri as-is, base64 mode as a data URI, otherwise an
+	 * attachment file with a data-URI fallback when saving fails.
+	 */
+	private async convertImageToMarkdown(
+		image: { data: string; mimeType: string; uri?: string },
+		context: ConvertContext,
+	): Promise<string> {
+		// Skip if images are not included
+		if (!context.includeImages) {
+			return "";
+		}
+
+		// External URI - use as-is
+		if (image.uri) {
+			return `![Image](${image.uri})\n\n`;
+		}
+
+		// Base64 embedding mode
+		if (context.imageLocation === "base64") {
+			return `![Image](data:${image.mimeType};base64,${image.data})\n\n`;
+		}
+
+		// Save as attachment (obsidian or custom)
+		try {
+			context.imageIndex++;
+			const attachmentPath = await this.saveMediaAsAttachment(
+				image.data,
+				image.mimeType,
+				context.exportFilePath,
+				context.imageIndex,
+				context.imageLocation,
+				context.imageCustomFolder,
+				"png",
+			);
+			// Use filename only (Obsidian resolves it)
+			const fileName = attachmentPath.split("/").pop();
+			return `![[${fileName}]]\n\n`;
+		} catch (error) {
+			this.logger.error(`Failed to save image as attachment: ${error}`);
+			// Fallback to base64 embedding
+			return `![Image](data:${image.mimeType};base64,${image.data})\n\n`;
 		}
 	}
 
@@ -447,30 +458,31 @@ session_id: ${sessionId}${tagsLine}
 	}
 
 	/**
-	 * Save a base64-encoded image as an attachment file.
+	 * Save a base64-encoded media file (image or audio) as an attachment.
 	 * Uses Obsidian's attachment settings to determine the save location.
 	 * Skips saving if the file already exists.
 	 */
-	private async saveImageAsAttachment(
+	private async saveMediaAsAttachment(
 		base64Data: string,
 		mimeType: string,
 		exportFilePath: string,
-		imageIndex: number,
-		imageLocation: "obsidian" | "custom",
-		imageCustomFolder: string,
+		mediaIndex: number,
+		location: "obsidian" | "custom",
+		customFolder: string,
+		fallbackExt: string,
 	): Promise<string> {
-		const ext = this.getExtensionFromMimeType(mimeType);
+		const ext = this.getExtensionFromMimeType(mimeType, fallbackExt);
 
-		// Generate image filename based on export filename
+		// Generate media filename based on export filename
 		const exportFileName = exportFilePath.replace(/\.md$/, "");
-		const baseName = exportFileName.split("/").pop() || "image";
-		const imageFileName = `${baseName}_${String(imageIndex).padStart(3, "0")}.${ext}`;
+		const baseName = exportFileName.split("/").pop() || "media";
+		const imageFileName = `${baseName}_${String(mediaIndex).padStart(3, "0")}.${ext}`;
 
 		let attachmentPath: string;
 
-		if (imageLocation === "custom") {
+		if (location === "custom") {
 			// Save to custom folder
-			const folder = imageCustomFolder || "Agent Client";
+			const folder = customFolder || "Agent Client";
 			await this.ensureFolderExists(folder);
 			attachmentPath = `${folder}/${imageFileName}`;
 
@@ -518,14 +530,26 @@ session_id: ${sessionId}${tagsLine}
 	/**
 	 * Get file extension from MIME type.
 	 */
-	private getExtensionFromMimeType(mimeType: string): string {
+	private getExtensionFromMimeType(
+		mimeType: string,
+		fallback: string,
+	): string {
 		const map: Record<string, string> = {
 			"image/png": "png",
 			"image/jpeg": "jpg",
 			"image/gif": "gif",
 			"image/webp": "webp",
+			"audio/mpeg": "mp3",
+			"audio/mp3": "mp3",
+			"audio/wav": "wav",
+			"audio/x-wav": "wav",
+			"audio/ogg": "ogg",
+			"audio/mp4": "m4a",
+			"audio/m4a": "m4a",
+			"audio/flac": "flac",
+			"audio/webm": "webm",
 		};
-		return map[mimeType] || "png";
+		return map[mimeType] || fallback;
 	}
 
 	/**

--- a/src/services/chat-exporter.ts
+++ b/src/services/chat-exporter.ts
@@ -1,7 +1,57 @@
 import type AgentClientPlugin from "../plugin";
-import type { ChatMessage, MessageContent } from "../types/chat";
+import type {
+	ChatMessage,
+	MessageContent,
+	ToolResultContentBlock,
+} from "../types/chat";
 import { getLogger, Logger } from "../utils/logger";
 import { TFile } from "obsidian";
+
+/**
+ * Wrap text in a fenced code block whose fence is longer than any backtick
+ * run inside, so output that itself contains ``` cannot break out.
+ */
+export function fencedCodeBlock(text: string): string {
+	const ticks = text.match(/`+/g);
+	const run = ticks ? Math.max(...ticks.map((t) => t.length)) : 0;
+	const fence = "`".repeat(Math.max(3, run + 1));
+	return `${fence}\n${text}\n${fence}\n\n`;
+}
+
+/**
+ * Convert the pure (no vault I/O) tool-result blocks to markdown.
+ * Image and audio need the attachment pipeline and are handled by the
+ * exporter class; this returns null for them.
+ */
+export function convertToolResultBlockToMarkdown(
+	block: ToolResultContentBlock,
+): string | null {
+	switch (block.type) {
+		case "text":
+			return fencedCodeBlock(block.text);
+		case "resource_link": {
+			const label = block.title || block.name;
+			const desc = block.description ? ` — ${block.description}` : "";
+			return `[${label}](${block.uri})${desc}\n\n`;
+		}
+		case "resource":
+			return "text" in block.resource
+				? `**Resource**: \`${block.resource.uri}\`\n\n` +
+						fencedCodeBlock(block.resource.text)
+				: `**Resource**: \`${block.resource.uri}\` (binary · ${block.resource.mimeType || "unknown type"})\n\n`;
+		default:
+			return null;
+	}
+}
+
+/** Convert the raw-output fallback (shown when a tool returned no content). */
+export function convertRawOutputToMarkdown(rawOutput: unknown): string {
+	const text =
+		typeof rawOutput === "string"
+			? rawOutput
+			: JSON.stringify(rawOutput, null, 2);
+	return `**Raw output**:\n\n${fencedCodeBlock(text)}`;
+}
 
 /**
  * Context for content conversion, tracking state across messages.
@@ -386,13 +436,22 @@ session_id: ${sessionId}${tagsLine}
 
 		md += `**Status**: ${content.status}\n\n`;
 
-		// Only export diffs
+		// Terminals are ids of live processes; there is nothing to export.
 		if (content.content && content.content.length > 0) {
 			for (const item of content.content) {
 				if (item.type === "diff") {
 					md += this.convertDiffToMarkdown(item);
+				} else if (item.type === "content") {
+					md += convertToolResultBlockToMarkdown(item.content) ?? "";
 				}
 			}
+		}
+
+		if (
+			content.rawOutput !== undefined &&
+			(!content.content || content.content.length === 0)
+		) {
+			md += convertRawOutputToMarkdown(content.rawOutput);
 		}
 
 		return md;

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -726,7 +726,7 @@ export class AgentClientSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Include images")
-			.setDesc("Include images in exported markdown files")
+			.setDesc("Include images in exported Markdown files")
 			.addToggle((toggle) =>
 				toggle
 					.setValue(this.plugin.settings.exportSettings.includeImages)
@@ -795,6 +795,80 @@ export class AgentClientSettingTab extends PluginSettingTab {
 											...this.plugin.settings
 												.exportSettings,
 											imageCustomFolder: value,
+										},
+									},
+								);
+							}),
+					);
+			}
+		}
+
+		new Setting(containerEl)
+			.setName("Include audio")
+			.setDesc("Include tool result audio in exported Markdown files")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.exportSettings.includeAudios)
+					.onChange(async (value) => {
+						await this.plugin.settingsService.updateSettings({
+							exportSettings: {
+								...this.plugin.settings.exportSettings,
+								includeAudios: value,
+							},
+						});
+						this.renderContent();
+					}),
+			);
+
+		if (this.plugin.settings.exportSettings.includeAudios) {
+			new Setting(containerEl)
+				.setName("Audio location")
+				.setDesc("Where to save exported audio files")
+				.addDropdown((dropdown) =>
+					dropdown
+						.addOption(
+							"obsidian",
+							"Use Obsidian's attachment setting",
+						)
+						.addOption("custom", "Save to custom folder")
+						.setValue(
+							this.plugin.settings.exportSettings.audioLocation,
+						)
+						.onChange(async (value) => {
+							await this.plugin.settingsService.updateSettings({
+								exportSettings: {
+									...this.plugin.settings.exportSettings,
+									audioLocation: value as
+										| "obsidian"
+										| "custom",
+								},
+							});
+							this.renderContent();
+						}),
+				);
+
+			if (
+				this.plugin.settings.exportSettings.audioLocation === "custom"
+			) {
+				new Setting(containerEl)
+					.setName("Custom audio folder")
+					.setDesc(
+						"Folder path for exported audio (relative to vault root)",
+					)
+					.addText((text) =>
+						text
+							.setPlaceholder("Agent Client")
+							.setValue(
+								this.plugin.settings.exportSettings
+									.audioCustomFolder,
+							)
+							.onChange(async (value) => {
+								await this.plugin.settingsService.updateSettings(
+									{
+										exportSettings: {
+											...this.plugin.settings
+												.exportSettings,
+											audioCustomFolder: value,
 										},
 									},
 								);

--- a/test/chat-exporter.test.ts
+++ b/test/chat-exporter.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import {
+	fencedCodeBlock,
+	convertToolResultBlockToMarkdown,
+	convertRawOutputToMarkdown,
+} from "../src/services/chat-exporter";
+import type { ToolResultContentBlock } from "../src/types/chat";
+
+describe("fencedCodeBlock", () => {
+	it("wraps plain text in a triple-backtick fence", () => {
+		expect(fencedCodeBlock("hello\nworld")).toBe(
+			"```\nhello\nworld\n```\n\n",
+		);
+	});
+
+	it("uses a longer fence when the text contains a code fence", () => {
+		// The text contains a 3-backtick run, so the wrapper must use >= 4
+		// or the embedded fence would close the block and corrupt the export.
+		expect(fencedCodeBlock("before\n```\ncode\n```\nafter")).toBe(
+			"````\nbefore\n```\ncode\n```\nafter\n````\n\n",
+		);
+	});
+
+	it("outruns arbitrarily long backtick runs", () => {
+		expect(fencedCodeBlock("a `````culprit````` b")).toBe(
+			"``````\na `````culprit````` b\n``````\n\n",
+		);
+	});
+
+	it("handles empty text", () => {
+		expect(fencedCodeBlock("")).toBe("```\n\n```\n\n");
+	});
+});
+
+describe("convertToolResultBlockToMarkdown", () => {
+	it("fences text output", () => {
+		expect(
+			convertToolResultBlockToMarkdown({ type: "text", text: "ok" }),
+		).toBe("```\nok\n```\n\n");
+	});
+
+	it("renders a resource link with title and description", () => {
+		expect(
+			convertToolResultBlockToMarkdown({
+				type: "resource_link",
+				uri: "file:///report.md",
+				name: "report.md",
+				title: "Full report",
+				description: "120 findings",
+			}),
+		).toBe("[Full report](file:///report.md) — 120 findings\n\n");
+	});
+
+	it("falls back to the name when a resource link has no title", () => {
+		expect(
+			convertToolResultBlockToMarkdown({
+				type: "resource_link",
+				uri: "https://example.com",
+				name: "example",
+			}),
+		).toBe("[example](https://example.com)\n\n");
+	});
+
+	it("renders a text resource as a heading plus fence", () => {
+		expect(
+			convertToolResultBlockToMarkdown({
+				type: "resource",
+				resource: { uri: "file:///config.ini", text: "a = 1" },
+			}),
+		).toBe("**Resource**: `file:///config.ini`\n\n```\na = 1\n```\n\n");
+	});
+
+	it("renders a binary resource as a placeholder line", () => {
+		expect(
+			convertToolResultBlockToMarkdown({
+				type: "resource",
+				resource: {
+					uri: "file:///blob.bin",
+					mimeType: "application/octet-stream",
+					blob: "AAAA",
+				},
+			}),
+		).toBe(
+			"**Resource**: `file:///blob.bin` (binary · application/octet-stream)\n\n",
+		);
+	});
+
+	it("returns null for media blocks handled by the attachment pipeline", () => {
+		const image: ToolResultContentBlock = {
+			type: "image",
+			data: "AAAA",
+			mimeType: "image/png",
+		};
+		const audio: ToolResultContentBlock = {
+			type: "audio",
+			data: "AAAA",
+			mimeType: "audio/wav",
+		};
+		expect(convertToolResultBlockToMarkdown(image)).toBeNull();
+		expect(convertToolResultBlockToMarkdown(audio)).toBeNull();
+	});
+});
+
+describe("convertRawOutputToMarkdown", () => {
+	it("passes string output through into a fence", () => {
+		expect(convertRawOutputToMarkdown("done")).toBe(
+			"**Raw output**:\n\n```\ndone\n```\n\n",
+		);
+	});
+
+	it("pretty-prints non-string output as JSON", () => {
+		expect(convertRawOutputToMarkdown({ exit: 0 })).toBe(
+			'**Raw output**:\n\n```\n{\n  "exit": 0\n}\n```\n\n',
+		);
+	});
+});

--- a/test/chat-exporter.test.ts
+++ b/test/chat-exporter.test.ts
@@ -101,6 +101,50 @@ describe("convertToolResultBlockToMarkdown", () => {
 	});
 });
 
+describe("convertToolCallToMarkdown ordering", () => {
+	it("keeps content items in their received order", async () => {
+		// The private method touches the vault only for media; with images
+		// excluded a bare instance converts text and diffs purely.
+		const { ChatExporter } = await import("../src/services/chat-exporter");
+		const exporter = new ChatExporter(
+			{} as unknown as ConstructorParameters<typeof ChatExporter>[0],
+		);
+		const md = await (
+			exporter as unknown as {
+				convertToolCallToMarkdown(
+					c: unknown,
+					ctx: unknown,
+				): Promise<string>;
+			}
+		).convertToolCallToMarkdown(
+			{
+				type: "tool_call",
+				toolCallId: "t1",
+				status: "completed",
+				content: [
+					{ type: "content", content: { type: "text", text: "first" } },
+					{ type: "diff", path: "/f.ts", oldText: "a", newText: "b" },
+					{ type: "content", content: { type: "text", text: "last" } },
+				],
+			},
+			{
+				exportFilePath: "x.md",
+				imageIndex: 0,
+				includeImages: false,
+				imageLocation: "obsidian",
+				imageCustomFolder: "",
+			},
+		);
+		const order = [
+			md.indexOf("first"),
+			md.indexOf("```diff"),
+			md.indexOf("last"),
+		];
+		expect(order.every((i) => i >= 0)).toBe(true);
+		expect(order).toEqual([...order].sort((a, b) => a - b));
+	});
+});
+
 describe("convertRawOutputToMarkdown", () => {
 	it("passes string output through into a fence", () => {
 		expect(convertRawOutputToMarkdown("done")).toBe(


### PR DESCRIPTION
## Description

Since #388/#389 the plugin keeps ACP standard tool-result content on messages, and both the transcript and the permission review render all of it — but Markdown export still carried only diffs (`// Only export diffs`). Everything else in a tool result was silently dropped, even though the data sits in the exported session.

Tool call sections now export the full result, in the order it was received:

- **Text output** in a fenced code block. The fence is one backtick longer than any backtick run inside the output, so tool output that itself contains ``` cannot break out and corrupt the rest of the export.
- **Images** through the existing image pipeline (`Include images` / `Image location` / attachment naming and dedupe) — user-attached and tool-returned images now follow one policy and one code path.
- **Audio** saved as an attachment and embedded as an Obsidian audio embed, which plays directly from the exported note. Gated by new settings mirroring the image ones (`Include audio` / `Audio location` / `Custom audio folder`). There is intentionally no Base64 mode for audio — a data URI cannot play from Markdown — so a failed save leaves a placeholder line instead.
- **Resource links** as Markdown links (title with description); **embedded resources** as a URI heading plus fenced text, or a one-line placeholder for binary ones.
- **Raw output** when a tool returned no content, matching the transcript's fallback view.

Terminals stay un-exported: messages hold only a terminal id, and the output exists only in the live process.

Internals: the message-level image conversion moved into a shared method (both image sources use it), the attachment saver is generalized to media with audio extensions, and the pure formatting helpers are exported and covered by 13 new unit tests (241 total) pinning the fencing rules and item ordering.

## Related issue

None (from the internal backlog).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: [acp-fixture-agent](https://github.com/RAIT-09/acp-fixture-agent)
- OS: macOS

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added audio export support, with options to save audio as Obsidian attachments or to a custom folder.
  - Expanded exported tool results to include text, images, audio attachments, resource links, embedded resources, and raw output.
  - Improved rendering of tool-call content and media in exported chats.

- **Documentation**
  - Updated chat export documentation to describe audio settings and the expanded tool-result export behavior.

- **Bug Fixes**
  - Improved formatting and media handling for chat exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->