### PR TITLE
Scale diffs and terminals with the chat font size and drop the italics

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -324,7 +324,6 @@ If your plugin does not need CSS, delete this file.
 /* ===== Inline Lucide Icons (replace emojis) ===== */
 .agent-client-message-tool-call-icon svg,
 .agent-client-collapsible-thought-label-icon svg,
-.agent-client-terminal-renderer-label-icon svg,
 .agent-client-error-overlay-suggestion-icon svg {
 	width: 14px;
 	height: 14px;
@@ -700,6 +699,9 @@ If your plugin does not need CSS, delete this file.
 /* Main container */
 .agent-client-chat-view-container {
 	--ac-chat-font-size: var(--font-text-size);
+	/* Detail blocks (tool rows, diffs, terminals, thinking) share one ratio.
+	   calc, not em: nested boxes must not compound against the tool row. */
+	--ac-chat-detail-font-size: calc(var(--ac-chat-font-size) * 0.85);
 	height: 100%;
 	display: flex;
 	flex-direction: column;
@@ -1381,7 +1383,7 @@ If your plugin does not need CSS, delete this file.
 	background-color: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 4px;
-	font-size: 12px;
+	font-size: var(--ac-chat-detail-font-size);
 	font-family: var(--font-monospace);
 	white-space: pre-wrap;
 	word-break: break-word;
@@ -1395,7 +1397,7 @@ If your plugin does not need CSS, delete this file.
 	padding: 4px 8px;
 	color: white;
 	border-radius: 4px;
-	font-size: 11px;
+	font-size: 0.9em;
 	font-family: var(--font-interface);
 	user-select: text;
 }
@@ -1522,7 +1524,7 @@ If your plugin does not need CSS, delete this file.
 	border-radius: 4px;
 	overflow: hidden;
 	font-family: var(--font-monospace);
-	font-size: 12px;
+	font-size: var(--ac-chat-detail-font-size);
 }
 
 .agent-client-tool-call-diff-content {
@@ -1534,8 +1536,7 @@ If your plugin does not need CSS, delete this file.
 	padding: 4px 12px;
 	background-color: var(--background-secondary);
 	color: var(--text-muted);
-	font-size: 11px;
-	font-style: italic;
+	font-size: 0.9em;
 }
 
 .agent-client-diff-line {

--- a/styles.css
+++ b/styles.css
@@ -338,7 +338,7 @@ If your plugin does not need CSS, delete this file.
 .agent-client-message-tool-call {
 	margin-bottom: 12px;
 	background-color: transparent;
-	font-size: 0.85em;
+	font-size: var(--ac-chat-detail-font-size);
 	user-select: text;
 	overflow-wrap: break-word;
 	word-wrap: break-word;
@@ -1294,10 +1294,9 @@ If your plugin does not need CSS, delete this file.
 
 /* Collapsible Thought */
 .agent-client-collapsible-thought {
-	font-style: italic;
 	color: var(--text-muted);
 	background-color: transparent;
-	font-size: 0.9em;
+	font-size: var(--ac-chat-detail-font-size);
 	cursor: pointer;
 	overflow-wrap: break-word;
 	word-wrap: break-word;


### PR DESCRIPTION
## Description

Message blocks disagreed on typography, and two of them ignored the font size setting entirely:

| Block | Size | Typeface |
|---|---|---|
| Body text | follows the setting | normal |
| Thinking | 0.9em | *italic* |
| Tool call row | 0.85em | normal |
| Diff box | **12px fixed** | normal |
| "New file" label | **11px fixed** | *italic* |
| Terminal output | **12px fixed** | normal |
| Exit chip | **11px fixed** | normal |

Two changes:

- **Fixed px sizes now follow the font size setting.** A new `--ac-chat-detail-font-size` token (chat base × 0.85) is defined on the shared container and consumed by the tool call row, thinking, diff box, and terminal output; the small labels inside those boxes (exit chip, "New file") use 0.9em of their box. The token resolves against the chat base rather than the parent — diffs and terminals sit *inside* the tool call row in the transcript but *outside* it in the permission review, so a plain `0.85em` would have compounded to different sizes per surface. Verified on device: both surfaces render the diff at the same size, and at the default text size everything keeps its current dimensions (12px → 11.9px).
- **Italics are gone.** Thinking was the last message block in italics — now that every block is a frameless one-liner, the typeface difference just stuck out. The "New file" diff label loses its italics too. Muted colors stay, so the visual hierarchy is unchanged.

Also removes an orphaned selector left over from an older terminal markup (`.agent-client-terminal-renderer-label-icon svg` had no emitter).

Verified with a real `terminal/create` round trip (new fixture scenario): output streams live, and at a 24px font size setting the terminal and tool call rows scale together to 20.4px.

## Related issue

None (from the internal backlog).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: [acp-fixture-agent](https://github.com/RAIT-09/acp-fixture-agent), Claude Code (claude-agent-acp)
- OS: macOS

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved chat detail text sizing for more consistent readability across tool calls, thoughts, terminal output, and diffs.
  * Standardized inline icon sizing while preserving terminal renderer label behavior.
  * Removed italic styling from collapsible thoughts and diff line information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->