### PR TITLE
Document the custom-agent migration for the Pi preset

### DIFF
--- a/docs/agent-setup/pi.md
+++ b/docs/agent-setup/pi.md
@@ -30,7 +30,7 @@ where.exe pi-acp
 3. Open **Settings → Agent Client**. The default command (`pi-acp`) works in many cases. If the agent is not found automatically, set the **Pi path** to the path found above, or click **Auto-detect**.
 
 ::: tip "Could not start pi" error
-`pi-acp` spawns `pi` as a child process, resolved via PATH. When an absolute Pi path is configured, Agent Client prepends that directory to PATH, so a `pi` installed next to `pi-acp` (the usual case) is found automatically. If `pi` lives in a different directory, make sure that directory is on your login shell's PATH (e.g. exported from `~/.zprofile`, not only `~/.zshrc`).
+`pi-acp` spawns `pi` as a child process, resolved via PATH. When an absolute Pi path is configured, Agent Client prepends that directory to PATH, so a `pi` installed next to `pi-acp` (the usual case) is found automatically. If `pi` lives in a different directory, make sure that directory is on your login shell's PATH (e.g. exported from `~/.zprofile` for zsh or `~/.profile` for bash — not only `~/.zshrc` / `~/.bashrc`).
 :::
 
 ## Authentication
@@ -48,6 +48,10 @@ Alternatively, `pi-acp --terminal-login` launches the same interactive login dir
 2. Verify that a normal chat works in the terminal before connecting from Obsidian.
 
 Credentials are stored under `~/.pi/agent/` and are picked up by the `pi-acp` process that Agent Client starts.
+
+::: tip Migrating from a custom agent
+If you previously ran Pi as a custom agent, its settings are not migrated automatically. A custom agent with the id `pi-acp` is renamed to `pi-acp-2` to make room for the preset — copy any custom path or environment variables into the preset settings, then delete the leftover custom entry.
+:::
 
 ## Verify Setup
 


### PR DESCRIPTION
## Description

Follow-up to #405 (Pi preset), docs only.

- **Migration tip.** `pi-acp` is also the executable name, so anyone who ran Pi as a custom agent before the preset almost certainly used that id. On upgrade, the custom entry is renamed to `pi-acp-2` to make room for the preset, and saved sessions / pinned blocks that referenced `pi-acp` now resolve to the preset's defaults — silently. The Pi setup page now carries the same "Migrating from a custom agent" tip as the Hermes Agent page, telling users to copy their custom path / environment variables into the preset settings and delete the leftover entry.
- **PATH tip for bash.** The "Could not start pi" tip pointed only at `~/.zprofile` vs `~/.zshrc`. The fix from #405 applies to Linux too, so the tip now names the bash equivalents (`~/.profile` vs `~/.bashrc`).

## Related issue

Follow-up to #404 / #405.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: N/A (docs only; `npm run docs:build` passes)
- OS: macOS

## Screenshots

<!-- N/A -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated troubleshooting guidance to include `~/.profile` for Bash login-shell PATH configuration.
  * Clarified that login-shell profile files are preferred over interactive shell configuration files.
  * Added migration guidance for users with an existing custom `pi-acp` agent, including transferring settings and removing the legacy entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->