### PR TITLE
feat(floating): toggle all floating chat windows at once

### DIFF
--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -39,7 +39,7 @@ Control multiple chat views at once. See [Multi-Session Chat](/usage/multi-sessi
 | **Open new floating chat view** | Always create a new floating window |
 | **Minimize floating chat view** | Hide the focused floating window (session is preserved) |
 | **Close floating chat view** | Close the focused floating window and end the session |
-| **Toggle all floating chat views** | Minimize all floating windows, or expand all of them if none is open |
+| **Toggle all floating chat views** | Minimize all floating windows while any is expanded, or expand them all when every window is minimized |
 
 ## Agent Commands
 

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -39,6 +39,7 @@ Control multiple chat views at once. See [Multi-Session Chat](/usage/multi-sessi
 | **Open new floating chat view** | Always create a new floating window |
 | **Minimize floating chat view** | Hide the focused floating window (session is preserved) |
 | **Close floating chat view** | Close the focused floating window and end the session |
+| **Toggle all floating chat views** | Minimize all floating windows, or expand all of them if none is open |
 
 ## Agent Commands
 

--- a/docs/usage/floating-chat.md
+++ b/docs/usage/floating-chat.md
@@ -62,7 +62,7 @@ When multiple windows exist, clicking the floating button shows an instance menu
 To see the editor without closing anything, minimize every floating window at once:
 
 - Click **"Minimize all floating chats"** from the **⋮** (More) menu in any floating window
-- Or use the command **"Toggle all floating chat views"** — it minimizes all windows while any is open, and expands all of them otherwise, so one hotkey takes you to the editor and back
+- Or use the command **"Toggle all floating chat views"** — it minimizes all windows while any is expanded, and expands them all once every window is minimized, so one hotkey takes you to the editor and back
 
 Sessions keep running while minimized.
 
@@ -78,7 +78,7 @@ The focused floating window is always displayed in front of other floating windo
 | **Open new floating chat view** | Always create a new floating window |
 | **Minimize floating chat view** | Hide the focused floating window (session is preserved) |
 | **Close floating chat view** | Close the focused floating window and end the session |
-| **Toggle all floating chat views** | Minimize all floating windows, or expand all of them if none is open |
+| **Toggle all floating chat views** | Minimize all floating windows while any is expanded, or expand them all when every window is minimized |
 
 ::: tip
 Assign keyboard shortcuts to these commands in **Settings → Hotkeys** for quick access.

--- a/docs/usage/floating-chat.md
+++ b/docs/usage/floating-chat.md
@@ -43,7 +43,7 @@ Open more than one floating chat window to run parallel conversations.
 
 ### Opening Additional Windows
 
-- Click **"Open new view"** from the **⋮** (More) menu in the floating window header
+- Click **"Open new floating chat"** from the **⋮** (More) menu in the floating window header
 - Or use the command **"Open new floating chat view"** from the command palette
 
 ### Switching Between Windows
@@ -57,6 +57,15 @@ When multiple windows exist, clicking the floating button shows an instance menu
 - Click a session name to expand that window
 - Click **×** to close a session
 
+### Hiding All Windows
+
+To see the editor without closing anything, minimize every floating window at once:
+
+- Click **"Minimize all floating chats"** from the **⋮** (More) menu in any floating window
+- Or use the command **"Toggle all floating chat views"** — it minimizes all windows while any is open, and expands all of them otherwise, so one hotkey takes you to the editor and back
+
+Sessions keep running while minimized.
+
 ::: tip
 The focused floating window is always displayed in front of other floating windows.
 :::
@@ -69,6 +78,7 @@ The focused floating window is always displayed in front of other floating windo
 | **Open new floating chat view** | Always create a new floating window |
 | **Minimize floating chat view** | Hide the focused floating window (session is preserved) |
 | **Close floating chat view** | Close the focused floating window and end the session |
+| **Toggle all floating chat views** | Minimize all floating windows, or expand all of them if none is open |
 
 ::: tip
 Assign keyboard shortcuts to these commands in **Settings → Hotkeys** for quick access.

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -405,6 +405,18 @@ export default class AgentClientPlugin extends Plugin {
 			},
 		});
 
+		this.addCommand({
+			id: "toggle-all-floating-chat-views",
+			name: "Toggle all floating chat views",
+			checkCallback: (checking) => {
+				if (!this.settings.enableFloatingChat) return false;
+				if (this.viewRegistry.getByType("floating").length === 0)
+					return false;
+				if (checking) return true;
+				this.toggleAllFloatingChats();
+			},
+		});
+
 		this.addSettingTab(new AgentClientSettingTab(this.app, this));
 
 		this.registerMarkdownCodeBlockProcessor(
@@ -860,6 +872,39 @@ export default class AgentClientPlugin extends Plugin {
 		const view = this.viewRegistry.get(viewId);
 		if (view) {
 			view.expand();
+		}
+	}
+
+	/**
+	 * Minimize every floating chat window. Sessions are preserved.
+	 */
+	collapseAllFloatingChats(): void {
+		for (const view of this.viewRegistry.getByType("floating")) {
+			view.collapse();
+		}
+	}
+
+	/**
+	 * Expand every floating chat window.
+	 */
+	expandAllFloatingChats(): void {
+		for (const view of this.viewRegistry.getByType("floating")) {
+			view.expand();
+		}
+	}
+
+	/**
+	 * Toggle all floating chat windows at once: minimize all while any is
+	 * expanded, otherwise expand all. Never creates or closes a window.
+	 */
+	toggleAllFloatingChats(): void {
+		const anyExpanded = this.viewRegistry
+			.getByType("floating")
+			.some((view) => view.isExpanded());
+		if (anyExpanded) {
+			this.collapseAllFloatingChats();
+		} else {
+			this.expandAllFloatingChats();
 		}
 	}
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -879,18 +879,14 @@ export default class AgentClientPlugin extends Plugin {
 	 * Minimize every floating chat window. Sessions are preserved.
 	 */
 	collapseAllFloatingChats(): void {
-		for (const view of this.viewRegistry.getByType("floating")) {
-			view.collapse();
-		}
+		this.viewRegistry.toType("floating", (view) => view.collapse());
 	}
 
 	/**
 	 * Expand every floating chat window.
 	 */
 	expandAllFloatingChats(): void {
-		for (const view of this.viewRegistry.getByType("floating")) {
-			view.expand();
-		}
+		this.viewRegistry.toType("floating", (view) => view.expand());
 	}
 
 	/**

--- a/src/services/view-registry.ts
+++ b/src/services/view-registry.ts
@@ -120,6 +120,12 @@ export interface IChatViewContainer {
 	 */
 	collapse(): void;
 
+	/**
+	 * Whether the view is currently expanded.
+	 * Views without a collapsed state (sidebar, embedded) always return true.
+	 */
+	isExpanded(): boolean;
+
 	// ============================================================
 	// Broadcast Commands
 	// ============================================================

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -702,13 +702,15 @@ export const ChatPanel = React.memo(function ChatPanel({
 				});
 			}
 
-			menu.addItem((item: MenuItem) => {
-				item.setTitle("Minimize all floating chats")
-					.setIcon("minimize-2")
-					.onClick(() => {
-						plugin.collapseAllFloatingChats();
-					});
-			});
+			if (variant === "floating") {
+				menu.addItem((item: MenuItem) => {
+					item.setTitle("Minimize all floating chats")
+						.setIcon("minimize-2")
+						.onClick(() => {
+							plugin.collapseAllFloatingChats();
+						});
+				});
+			}
 
 			menu.addItem((item: MenuItem) => {
 				item.setTitle("Restart agent")
@@ -758,6 +760,7 @@ export const ChatPanel = React.memo(function ChatPanel({
 			handleOpenHistory,
 			handleExportChat,
 			onOpenNewWindow,
+			variant,
 			handleRestartAgent,
 			agentCwd,
 			handleNewChatInDirectory,

--- a/src/ui/ChatPanel.tsx
+++ b/src/ui/ChatPanel.tsx
@@ -703,6 +703,14 @@ export const ChatPanel = React.memo(function ChatPanel({
 			}
 
 			menu.addItem((item: MenuItem) => {
+				item.setTitle("Minimize all floating chats")
+					.setIcon("minimize-2")
+					.onClick(() => {
+						plugin.collapseAllFloatingChats();
+					});
+			});
+
+			menu.addItem((item: MenuItem) => {
 				item.setTitle("Restart agent")
 					.setIcon("refresh-cw")
 					.onClick(() => {

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -296,6 +296,10 @@ export class ChatView extends ItemView implements IChatViewContainer {
 		// Sidebar views don't have expand/collapse state - no-op
 	}
 
+	isExpanded(): boolean {
+		return true;
+	}
+
 	/**
 	 * Get the DOM container element for this view.
 	 */

--- a/src/ui/CodeBlockChatView.tsx
+++ b/src/ui/CodeBlockChatView.tsx
@@ -278,6 +278,10 @@ export class EmbeddedChatViewContainer implements IChatViewContainer {
 
 	collapse(): void {}
 
+	isExpanded(): boolean {
+		return true;
+	}
+
 	// Owned by the host note's code block (MarkdownRenderChild); cannot be
 	// closed from the session list.
 	closeContainer(): void {}

--- a/src/ui/FloatingChatView.tsx
+++ b/src/ui/FloatingChatView.tsx
@@ -209,6 +209,10 @@ export class FloatingViewContainer implements IChatViewContainer {
 		}
 	}
 
+	isExpanded(): boolean {
+		return this.isExpandedState;
+	}
+
 	getInputState(): ChatInputState | null {
 		return this.callbacks?.getInputState() ?? null;
 	}


### PR DESCRIPTION
## Description

Adds a way to hide every floating chat window in one step and bring them all back, so multiple concurrent sessions can be kept open while still reaching the editor.

- **New command: "Toggle all floating chat views"** — minimizes every floating window while any is expanded, otherwise expands them all. One hotkey takes you to the editor and back. The command is hidden while floating chat is disabled or no floating window exists, matching the existing floating commands.
- **New More (⋮) menu item: "Minimize all floating chats"** in floating windows, next to "Open new floating chat". Minimize only — the menu is only reachable from an open window.
- `IChatViewContainer` gains `isExpanded()` (sidebar and embedded views always return `true`), and the plugin gets `collapseAllFloatingChats` / `expandAllFloatingChats` / `toggleAllFloatingChats`, built on the registry's existing `toType` helper.
- Docs: new "Hiding All Windows" section and command table rows in `docs/usage/floating-chat.md` and `docs/usage/commands.md`. Also corrects the menu item name "Open new view" → "Open new floating chat" to match the UI.

Minimized windows keep their sessions running, as before. Nothing is persisted; window state is not saved across reloads today either.

## Related issue

Closes #410

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a command to toggle all floating chat windows between minimized and expanded states.
  - Added a context-menu option to minimize all floating chats.
  - Added the “Open new floating chat” menu label.
  - The toggle command minimizes all floating chats when any is expanded, and expands them when all are minimized.

- **Documentation**
  - Documented the new command and options for hiding or minimizing all floating chat windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->