### PR TITLE
feat(history): remember the session history filter choices

### DIFF
--- a/docs/usage/session-history.md
+++ b/docs/usage/session-history.md
@@ -29,6 +29,17 @@ Depending on the agent's capabilities, you can perform the following actions:
 Not all actions are available for every agent. The modal shows only the actions supported by your current agent.
 :::
 
+## Filtering the List
+
+When the agent supports listing sessions, two checkboxes above the list narrow it down:
+
+| Filter | Default | Description |
+|--------|---------|-------------|
+| **Show current vault only** | On | Ask the agent for sessions started in the current vault directory |
+| **Hide sessions without local data** | Off | Show only sessions that were started from Obsidian (the plugin has a saved transcript for them) |
+
+Your choices are remembered, so the modal reopens with the filters you last used.
+
 ## Session Storage
 
 Sessions are saved automatically when you send messages. The plugin stores:

--- a/src/hooks/useHistoryModal.ts
+++ b/src/hooks/useHistoryModal.ts
@@ -1,9 +1,11 @@
 import { useRef, useCallback, useEffect } from "react";
 import { Notice, Platform } from "obsidian";
 import { SessionHistoryModal } from "../ui/SessionHistoryModal";
+import { useSettingsSelector } from "./useSettings";
 import { getLogger } from "../utils/logger";
 import { convertWslPathToWindows } from "../utils/platform";
 import type AgentClientPlugin from "../plugin";
+import type { AgentClientPluginSettings } from "../plugin";
 import type { UseAgentReturn } from "./useAgent";
 import type { UseSessionHistoryReturn } from "./useSessionHistory";
 
@@ -20,6 +22,19 @@ import type { UseSessionHistoryReturn } from "./useSessionHistory";
  * @param isSessionReady - Whether the session is ready
  * @param debugMode - Whether debug mode is enabled
  */
+function selectHistoryFilters(s: AgentClientPluginSettings) {
+	return s.sessionHistoryFilters;
+}
+
+type HistoryFilters = ReturnType<typeof selectHistoryFilters>;
+
+function historyFiltersEqual(a: HistoryFilters, b: HistoryFilters): boolean {
+	return (
+		a.currentVaultOnly === b.currentVaultOnly &&
+		a.hideNonLocal === b.hideNonLocal
+	);
+}
+
 export function useHistoryModal(
 	plugin: AgentClientPlugin,
 	agent: UseAgentReturn,
@@ -33,6 +48,20 @@ export function useHistoryModal(
 } {
 	const logger = getLogger();
 	const historyModalRef = useRef<SessionHistoryModal | null>(null);
+	const filters = useSettingsSelector(
+		plugin,
+		selectHistoryFilters,
+		historyFiltersEqual,
+	);
+
+	const handleFiltersChange = useCallback(
+		(next: HistoryFilters) => {
+			void plugin.settingsService.updateSettings({
+				sessionHistoryFilters: next,
+			});
+		},
+		[plugin],
+	);
 
 	const handleRestoreSession = useCallback(
 		async (sessionId: string, cwd: string) => {
@@ -138,6 +167,8 @@ export function useHistoryModal(
 				localSessionIds: sessionHistory.localSessionIds,
 				isAgentReady: isSessionReady,
 				debugMode: debugMode,
+				filters,
+				onFiltersChange: handleFiltersChange,
 				onRestoreSession: handleRestoreSession,
 				onForkSession: handleForkSession,
 				onDeleteSession: handleDeleteSession,
@@ -147,7 +178,9 @@ export function useHistoryModal(
 			});
 		}
 		historyModalRef.current.open();
-		void sessionHistory.fetchSessions(vaultPath);
+		void sessionHistory.fetchSessions(
+			filters.currentVaultOnly ? vaultPath : undefined,
+		);
 	}, [
 		plugin.app,
 		sessionHistory.sessions,
@@ -163,6 +196,8 @@ export function useHistoryModal(
 		vaultPath,
 		isSessionReady,
 		debugMode,
+		filters,
+		handleFiltersChange,
 		handleRestoreSession,
 		handleForkSession,
 		handleDeleteSession,
@@ -187,6 +222,8 @@ export function useHistoryModal(
 				localSessionIds: sessionHistory.localSessionIds,
 				isAgentReady: isSessionReady,
 				debugMode: debugMode,
+				filters,
+				onFiltersChange: handleFiltersChange,
 				onRestoreSession: handleRestoreSession,
 				onForkSession: handleForkSession,
 				onDeleteSession: handleDeleteSession,
@@ -207,6 +244,8 @@ export function useHistoryModal(
 		vaultPath,
 		isSessionReady,
 		debugMode,
+		filters,
+		handleFiltersChange,
 		handleRestoreSession,
 		handleForkSession,
 		handleDeleteSession,

--- a/src/hooks/useHistoryModal.ts
+++ b/src/hooks/useHistoryModal.ts
@@ -9,19 +9,6 @@ import type { AgentClientPluginSettings } from "../plugin";
 import type { UseAgentReturn } from "./useAgent";
 import type { UseSessionHistoryReturn } from "./useSessionHistory";
 
-/**
- * Hook for managing the session history modal lifecycle.
- *
- * Encapsulates modal creation, props synchronization, and
- * session operation callbacks (restore, fork, delete).
- *
- * @param plugin - Plugin instance for app access
- * @param agent - Agent hook for clearMessages
- * @param sessionHistory - Session history hook for operations
- * @param vaultPath - Current working directory
- * @param isSessionReady - Whether the session is ready
- * @param debugMode - Whether debug mode is enabled
- */
 function selectHistoryFilters(s: AgentClientPluginSettings) {
 	return s.sessionHistoryFilters;
 }
@@ -35,6 +22,19 @@ function historyFiltersEqual(a: HistoryFilters, b: HistoryFilters): boolean {
 	);
 }
 
+/**
+ * Hook for managing the session history modal lifecycle.
+ *
+ * Encapsulates modal creation, props synchronization, and
+ * session operation callbacks (restore, fork, delete).
+ *
+ * @param plugin - Plugin instance for app access
+ * @param agent - Agent hook for clearMessages
+ * @param sessionHistory - Session history hook for operations
+ * @param vaultPath - Current working directory
+ * @param isSessionReady - Whether the session is ready
+ * @param debugMode - Whether debug mode is enabled
+ */
 export function useHistoryModal(
 	plugin: AgentClientPlugin,
 	agent: UseAgentReturn,

--- a/src/hooks/useHistoryModal.ts
+++ b/src/hooks/useHistoryModal.ts
@@ -179,7 +179,9 @@ export function useHistoryModal(
 		}
 		historyModalRef.current.open();
 		void sessionHistory.fetchSessions(
-			filters.currentVaultOnly ? vaultPath : undefined,
+			sessionHistory.canList && !filters.currentVaultOnly
+				? undefined
+				: vaultPath,
 		);
 	}, [
 		plugin.app,

--- a/src/hooks/useHistoryModal.ts
+++ b/src/hooks/useHistoryModal.ts
@@ -9,12 +9,14 @@ import type { AgentClientPluginSettings } from "../plugin";
 import type { UseAgentReturn } from "./useAgent";
 import type { UseSessionHistoryReturn } from "./useSessionHistory";
 
+/** Settings slice consumed by the history modal (filter checkbox states). */
 function selectHistoryFilters(s: AgentClientPluginSettings) {
 	return s.sessionHistoryFilters;
 }
 
 type HistoryFilters = ReturnType<typeof selectHistoryFilters>;
 
+/** Field-wise equality so the selector keeps a stable reference. */
 function historyFiltersEqual(a: HistoryFilters, b: HistoryFilters): boolean {
 	return (
 		a.currentVaultOnly === b.currentVaultOnly &&
@@ -179,7 +181,9 @@ export function useHistoryModal(
 		}
 		historyModalRef.current.open();
 		void sessionHistory.fetchSessions(
-			sessionHistory.canList && !filters.currentVaultOnly
+			sessionHistory.canList &&
+			(sessionHistory.canRestore || sessionHistory.canFork) &&
+			!filters.currentVaultOnly
 				? undefined
 				: vaultPath,
 		);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -167,6 +167,11 @@ export interface AgentClientPluginSettings {
 	lastUsedModes: Record<string, string>;
 	// Last used non-model/mode config options per agent (agentId → {optionId → value})
 	lastUsedConfigOptions: Record<string, Record<string, string>>;
+	// Session history modal filters, remembered across opens (not exposed in the settings tab)
+	sessionHistoryFilters: {
+		currentVaultOnly: boolean;
+		hideNonLocal: boolean;
+	};
 	// Floating chat settings
 	enableFloatingChat: boolean;
 	floatingButtonImage: string;
@@ -226,6 +231,7 @@ const DEFAULT_SETTINGS: AgentClientPluginSettings = {
 	lastUsedModels: {},
 	lastUsedModes: {},
 	lastUsedConfigOptions: {},
+	sessionHistoryFilters: { currentVaultOnly: true, hideNonLocal: false },
 	enableFloatingChat: false,
 	floatingButtonImage: "",
 	floatingWindowSize: { width: 400, height: 500 },
@@ -1596,6 +1602,19 @@ export default class AgentClientPlugin extends Plugin {
 			lastUsedModels: strRecord(raw.lastUsedModels),
 			lastUsedModes: strRecord(raw.lastUsedModes),
 			lastUsedConfigOptions: nestedStrRecord(raw.lastUsedConfigOptions),
+			sessionHistoryFilters: (() => {
+				const rf = obj(raw.sessionHistoryFilters) ?? {};
+				return {
+					currentVaultOnly: bool(
+						rf.currentVaultOnly,
+						D.sessionHistoryFilters.currentVaultOnly,
+					),
+					hideNonLocal: bool(
+						rf.hideNonLocal,
+						D.sessionHistoryFilters.hideNonLocal,
+					),
+				};
+			})(),
 			// Migration: enableFloatingChat ← showFloatingButton (old name)
 			enableFloatingChat: bool(
 				raw.enableFloatingChat,

--- a/src/ui/SessionHistoryModal.tsx
+++ b/src/ui/SessionHistoryModal.tsx
@@ -465,10 +465,15 @@ function SessionHistoryContent({
 		[onFiltersChange, filterByCurrentVault],
 	);
 
+	// Agent-side listing is only used when the agent can also restore or
+	// fork; otherwise sessions come from local storage and stay vault-scoped.
+	const canFilterByVault = canList && (canRestore || canFork);
+
 	const handleRetry = useCallback(() => {
-		const cwd = filterByCurrentVault ? currentCwd : undefined;
+		const cwd =
+			canFilterByVault && !filterByCurrentVault ? undefined : currentCwd;
 		onFetchSessions(cwd);
-	}, [filterByCurrentVault, currentCwd, onFetchSessions]);
+	}, [canFilterByVault, filterByCurrentVault, currentCwd, onFetchSessions]);
 
 	// Wrap onDeleteSession to show confirmation modal
 	const handleDeleteWithConfirmation = useCallback(
@@ -576,7 +581,7 @@ function SessionHistoryContent({
 			{canShowList && (
 				<>
 					{/* Filter toggles - only for agent session/list */}
-					{canList && canPerformAnyOperation && (
+					{canFilterByVault && (
 						<div className="agent-client-session-history-filter">
 							<label className="agent-client-session-history-filter-label">
 								<input

--- a/src/ui/SessionHistoryModal.tsx
+++ b/src/ui/SessionHistoryModal.tsx
@@ -127,6 +127,14 @@ interface SessionHistoryContentProps {
 	/** Whether debug mode is enabled (shows manual input form) */
 	debugMode: boolean;
 
+	/** Filter checkbox states to start from (remembered across opens) */
+	filters: { currentVaultOnly: boolean; hideNonLocal: boolean };
+	/** Callback when either filter checkbox changes */
+	onFiltersChange: (filters: {
+		currentVaultOnly: boolean;
+		hideNonLocal: boolean;
+	}) => void;
+
 	/** Callback when a session is restored */
 	onRestoreSession: (sessionId: string, cwd: string) => Promise<void>;
 	/** Callback when a session is forked (create new branch) */
@@ -414,6 +422,8 @@ function SessionHistoryContent({
 	localSessionIds,
 	isAgentReady,
 	debugMode,
+	filters,
+	onFiltersChange,
 	onRestoreSession,
 	onForkSession,
 	onDeleteSession,
@@ -422,17 +432,37 @@ function SessionHistoryContent({
 	onFetchSessions,
 	onClose,
 }: SessionHistoryContentProps) {
-	const [filterByCurrentVault, setFilterByCurrentVault] = useState(true);
-	const [hideNonLocalSessions, setHideNonLocalSessions] = useState(false);
+	const [filterByCurrentVault, setFilterByCurrentVault] = useState(
+		filters.currentVaultOnly,
+	);
+	const [hideNonLocalSessions, setHideNonLocalSessions] = useState(
+		filters.hideNonLocal,
+	);
 
 	const handleFilterChange = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
 			const checked = e.target.checked;
 			setFilterByCurrentVault(checked);
+			onFiltersChange({
+				currentVaultOnly: checked,
+				hideNonLocal: hideNonLocalSessions,
+			});
 			const cwd = checked ? currentCwd : undefined;
 			onFetchSessions(cwd);
 		},
-		[currentCwd, onFetchSessions],
+		[currentCwd, onFetchSessions, onFiltersChange, hideNonLocalSessions],
+	);
+
+	const handleHideNonLocalChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const checked = e.target.checked;
+			setHideNonLocalSessions(checked);
+			onFiltersChange({
+				currentVaultOnly: filterByCurrentVault,
+				hideNonLocal: checked,
+			});
+		},
+		[onFiltersChange, filterByCurrentVault],
 	);
 
 	const handleRetry = useCallback(() => {
@@ -560,11 +590,7 @@ function SessionHistoryContent({
 								<input
 									type="checkbox"
 									checked={hideNonLocalSessions}
-									onChange={(e) =>
-										setHideNonLocalSessions(
-											e.target.checked,
-										)
-									}
+									onChange={handleHideNonLocalChange}
 								/>
 								<span>Hide sessions without local data</span>
 							</label>

--- a/src/ui/SessionHistoryModal.tsx
+++ b/src/ui/SessionHistoryModal.tsx
@@ -576,7 +576,7 @@ function SessionHistoryContent({
 			{canShowList && (
 				<>
 					{/* Filter toggles - only for agent session/list */}
-					{canList && !isUsingLocalSessions && (
+					{canList && canPerformAnyOperation && (
 						<div className="agent-client-session-history-filter">
 							<label className="agent-client-session-history-filter-label">
 								<input


### PR DESCRIPTION
## Description

The two filter checkboxes in the session history modal — **Show current vault only** and **Hide sessions without local data** — reset to their defaults on every open. On Windows + WSL that meant re-ticking both every time, because the agent-side vault filter never matches there (agent-side issue: codex-acp#431, claude-agent-acp#1041). Persisting the choices turns that into a one-time adjustment, and is useful regardless of the upstream outcome.

- **The last used filter states are remembered** across opens and restarts, stored as `sessionHistoryFilters` alongside the other implicitly saved UI state (`lastUsedModes`, floating window position). Not exposed in the settings tab. Defaults are unchanged (vault filter on, local-data filter off).
- **The first fetch follows the saved filter too**, so the list opens already filtered the way you left it — not only after you touch a checkbox.
- The saved vault filter only applies where its checkbox is shown (agents that support `session/list`). For agents that fall back to locally saved sessions, the list stays scoped to the current vault as before.
- The modal stays props-driven: `useHistoryModal` subscribes to the two fields via `useSettingsSelector`, passes them in as the initial state, and saves changes through the settings service.
- Docs: new "Filtering the List" section in `docs/usage/session-history.md` (the filters were previously undocumented).

## Related issue

Closes #406

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Claude Code
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added session history filters for viewing sessions from the current vault and hiding sessions without local transcript data.
  - Filter selections persist between modal openings.
  - Session history results update according to the selected filters.
  - Filtering options are available when session listing and restore or fork actions are supported.

- **Documentation**
  - Added guidance for using the new session history filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->