### PR TITLE
feat(agents): add the Grok Build preset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Client Plugin - LLM Developer Guide
 
 ## Overview
-Obsidian plugin for AI agent interaction (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, custom agents) via ACP.
+Obsidian plugin for AI agent interaction (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, Grok Build, custom agents) via ACP.
 
 **Tech**: React 19, TypeScript, Obsidian API, Agent Client Protocol (ACP)
 
@@ -337,6 +337,7 @@ interface ISettingsAccess {
 - OpenCode: `opencode-ai` (CLI-managed auth, no API key env)
 - Kiro: `kiro-cli` install script (KIRO_API_KEY, optional)
 - Hermes Agent: install script (CLI-managed auth, no API key env)
+- Grok Build: `grok` install script (XAI_API_KEY, optional)
 - Custom: Any ACP-compatible agent
 
 ---

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,7 +40,7 @@ Zed の [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/age
 
 **管制室。** Session Manager が、サイドバー・タブ・フローティング・ノート内に開いている全会話をステータスアイコン付きで一覧します（権限待ちも見えます）。クリックでその場へジャンプ。
 
-**どの ACP エージェントでも。** 7つのプリセット — Claude Code、Codex、Gemini CLI、Mistral Vibe、OpenCode、Kiro、Hermes Agent — に加えて、ACP 互換エージェントならカスタムエージェントとして追加できます。明日新しいエージェントが ACP 対応しても、カスタムエージェントに登録するだけ — プラグインの更新を待つ必要はありません。
+**どの ACP エージェントでも。** 8つのプリセット — Claude Code、Codex、Gemini CLI、Mistral Vibe、OpenCode、Kiro、Hermes Agent、Grok Build — に加えて、ACP 互換エージェントならカスタムエージェントとして追加できます。明日新しいエージェントが ACP 対応しても、カスタムエージェントに登録するだけ — プラグインの更新を待つ必要はありません。
 
 ## 機能
 
@@ -69,7 +69,7 @@ Zed の [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/age
 
 1. 使いたいエージェントをセットアップガイドに従ってインストール・認証します:
 
-   [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html) · [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html) · [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html) · [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html) · [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html) · [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html) · [Hermes Agent](https://rait-09.github.io/obsidian-agent-client/agent-setup/hermes.html) · [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)
+   [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html) · [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html) · [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html) · [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html) · [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html) · [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html) · [Hermes Agent](https://rait-09.github.io/obsidian-agent-client/agent-setup/hermes.html) · [Grok Build](https://rait-09.github.io/obsidian-agent-client/agent-setup/grok-build.html) · [カスタムエージェント](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)
 
 2. **設定 → Agent Client** でエージェントのパスを確認します — **Auto-detect** でほとんどの場合見つかります
 3. リボンのロボットアイコンをクリックしてチャット開始

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Built on the [Agent Client Protocol (ACP)](https://github.com/agentclientprotoco
 
 **Mission control.** The Session Manager lists every open conversation across sidebar, tabs, floating windows, and notes, with live status icons — including "waiting for permission". Click any entry to jump straight there.
 
-**Any ACP agent.** Seven presets — Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent — plus any ACP-compatible agent as a custom entry. New agent ships ACP support tomorrow? Add it as a custom entry — no plugin update needed.
+**Any ACP agent.** Eight presets — Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, Grok Build — plus any ACP-compatible agent as a custom entry. New agent ships ACP support tomorrow? Add it as a custom entry — no plugin update needed.
 
 ## Features
 
@@ -69,7 +69,7 @@ Built on the [Agent Client Protocol (ACP)](https://github.com/agentclientprotoco
 
 1. Install and authenticate an agent, following its setup guide:
 
-   [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html) · [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html) · [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html) · [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html) · [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html) · [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html) · [Hermes Agent](https://rait-09.github.io/obsidian-agent-client/agent-setup/hermes.html) · [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)
+   [Claude Code](https://rait-09.github.io/obsidian-agent-client/agent-setup/claude-code.html) · [Codex](https://rait-09.github.io/obsidian-agent-client/agent-setup/codex.html) · [Gemini CLI](https://rait-09.github.io/obsidian-agent-client/agent-setup/gemini-cli.html) · [Mistral Vibe](https://rait-09.github.io/obsidian-agent-client/agent-setup/mistral-vibe.html) · [OpenCode](https://rait-09.github.io/obsidian-agent-client/agent-setup/opencode.html) · [Kiro](https://rait-09.github.io/obsidian-agent-client/agent-setup/kiro.html) · [Hermes Agent](https://rait-09.github.io/obsidian-agent-client/agent-setup/hermes.html) · [Grok Build](https://rait-09.github.io/obsidian-agent-client/agent-setup/grok-build.html) · [Custom Agents](https://rait-09.github.io/obsidian-agent-client/agent-setup/custom-agents.html)
 
 2. Open **Settings → Agent Client** and check the agent's path — **Auto-detect** usually finds it
 3. Click the robot icon in the ribbon and start chatting

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -63,6 +63,7 @@ export default defineConfig({
           { text: "OpenCode", link: "/agent-setup/opencode" },
           { text: "Kiro", link: "/agent-setup/kiro" },
           { text: "Hermes Agent", link: "/agent-setup/hermes" },
+          { text: "Grok Build", link: "/agent-setup/grok-build" },
           { text: "Custom Agents", link: "/agent-setup/custom-agents" },
         ],
       },

--- a/docs/agent-setup/grok-build.md
+++ b/docs/agent-setup/grok-build.md
@@ -1,6 +1,6 @@
 # Grok Build Setup
 
-Grok Build is xAI's coding agent. It communicates via ACP through the `grok agent stdio` command.
+Grok Build is xAI's coding agent. It communicates via ACP through the `grok agent stdio` command (Grok Build CLI **1.0** and later). Confirm with `grok --version`.
 
 This is the official xAI CLI (`grok`), not a third-party Grok wrapper.
 
@@ -61,12 +61,14 @@ grok login
 
 ### Option B: xAI API Key
 
-API keys are created at [console.x.ai](https://console.x.ai):
+Use this when there is **no** active `grok login` session — for example CI, a machine that never signed in, or after `grok logout`. API keys are created at [console.x.ai](https://console.x.ai) and bill API credits, which is a different account path from SuperGrok / X Premium+.
 
 1. Generate a key in the xAI console
 2. Enter it in **Settings → Agent Client → Preset agents → Grok Build → API key** (stored in Obsidian's Keychain)
 
-The API key is injected as `XAI_API_KEY` and takes precedence over browser credentials.
+The plugin injects the secret as `XAI_API_KEY`. An active `grok login` session in `~/.grok/auth.json` takes precedence over that environment variable, so a linked key does not override an existing browser login (and will not switch billing to the API-key account). To use the key, run `grok logout` first, or delete `~/.grok/auth.json`.
+
+A per-model `api_key` / `env_key` in `~/.grok/config.toml` is a separate, higher-precedence override. It is not the plugin API-key field.
 
 ::: tip Migrating from a custom agent
 If you previously ran Grok Build as a custom agent, its settings are not migrated automatically. A custom agent with the id `grok-build` is renamed to `grok-build-2` to make room for the preset — copy any custom path or environment variables into the preset settings, then delete the leftover custom entry. If your custom agent carried `XAI_API_KEY` in its environment variables, consider moving it to the **API key** field so it is stored in Obsidian's Keychain instead of plain text.

--- a/docs/agent-setup/grok-build.md
+++ b/docs/agent-setup/grok-build.md
@@ -28,7 +28,7 @@ Other options are listed in the [Grok Build docs](https://docs.x.ai/build/overvi
 
 ```bash [macOS/Linux]
 which grok
-# Example output: /Users/username/.grok/bin/grok
+# Example output: /Users/username/.local/bin/grok (a symlink to ~/.grok/bin/grok)
 ```
 
 ```cmd [Windows]
@@ -40,7 +40,7 @@ where.exe grok
 3. Open **Settings → Agent Client**. The default command (`grok`) works in many cases. If the agent is not found automatically, set the **Grok Build path** to the path found above, or click **Auto-detect**.
 
 ::: tip "grok" not found
-The installer adds `~/.grok/bin` to your shell's PATH through `~/.zshrc` or `~/.bashrc`, but Agent Client starts agents from a login shell that does not read those files. If the default command is not found, set the **Grok Build path** to the absolute path (usually `~/.grok/bin/grok`), or export the directory from `~/.zprofile` for zsh or `~/.profile` for bash.
+The installer puts `grok` in `~/.grok/bin` and, when `~/.local/bin` or `/usr/local/bin` is already on your PATH, symlinks it there too. Agent Client starts agents from a login shell that reads `~/.zprofile` / `~/.profile` but not `~/.zshrc` / `~/.bashrc`, so the default command resolves only if one of those directories is exported there. If it is not found, click **Auto-detect** or set the **Grok Build path** to `~/.grok/bin/grok`.
 :::
 
 4. Leave **Arguments** as `agent stdio` (set by default). Agent Client handles permission prompts in the chat, so do not add `--always-approve`.

--- a/docs/agent-setup/grok-build.md
+++ b/docs/agent-setup/grok-build.md
@@ -39,8 +39,8 @@ where.exe grok
 
 3. Open **Settings → Agent Client**. The default command (`grok`) works in many cases. If the agent is not found automatically, set the **Grok Build path** to the path found above, or click **Auto-detect**.
 
-::: tip "grok" not found
-The installer puts `grok` in `~/.grok/bin` and, when `~/.local/bin` or `/usr/local/bin` is already on your PATH, symlinks it there too. Agent Client starts agents from a login shell that reads `~/.zprofile` / `~/.profile` but not `~/.zshrc` / `~/.bashrc`, so the default command resolves only if one of those directories is exported there. If it is not found, click **Auto-detect** or set the **Grok Build path** to `~/.grok/bin/grok`.
+::: tip "grok" not found (macOS/Linux)
+The installer puts `grok` in `~/.grok/bin` and, when `~/.local/bin` or `/usr/local/bin` is already on your PATH, symlinks it there too. Agent Client starts agents from a login shell that reads `~/.zprofile` / `~/.profile` but not `~/.zshrc` / `~/.bashrc`, so the default command resolves only if one of those directories is exported there. If it is not found, click **Auto-detect** or set the **Grok Build path** to `~/.grok/bin/grok`. On Windows the installer adds `%USERPROFILE%\.grok\bin` to your user PATH, which Agent Client reads directly.
 :::
 
 4. Leave **Arguments** as `agent stdio` (set by default). Agent Client handles permission prompts in the chat, so do not add `--always-approve`.

--- a/docs/agent-setup/grok-build.md
+++ b/docs/agent-setup/grok-build.md
@@ -1,8 +1,6 @@
 # Grok Build Setup
 
-Grok Build is xAI's coding agent. It communicates via ACP through the `grok agent stdio` command (Grok Build CLI **1.0** and later). Confirm with `grok --version`.
-
-This is the official xAI CLI (`grok`), not a third-party Grok wrapper.
+Grok Build is xAI's coding agent. This page covers the official xAI CLI (`grok`) — not a third-party Grok wrapper — which communicates via ACP through the `grok agent stdio` command (available since Grok Build CLI 1.0).
 
 ## Install and Configure
 
@@ -30,7 +28,7 @@ Other options are listed in the [Grok Build docs](https://docs.x.ai/build/overvi
 
 ```bash [macOS/Linux]
 which grok
-# Example output: /Users/username/.local/bin/grok
+# Example output: /Users/username/.grok/bin/grok
 ```
 
 ```cmd [Windows]
@@ -41,7 +39,11 @@ where.exe grok
 
 3. Open **Settings → Agent Client**. The default command (`grok`) works in many cases. If the agent is not found automatically, set the **Grok Build path** to the path found above, or click **Auto-detect**.
 
-Leave the arguments as `agent` and `stdio`. Agent Client handles permission prompts in the chat, so do not add `--always-approve`.
+::: tip "grok" not found
+The installer adds `~/.grok/bin` to your shell's PATH through `~/.zshrc` or `~/.bashrc`, but Agent Client starts agents from a login shell that does not read those files. If the default command is not found, set the **Grok Build path** to the absolute path (usually `~/.grok/bin/grok`), or export the directory from `~/.zprofile` for zsh or `~/.profile` for bash.
+:::
+
+4. Leave **Arguments** as `agent stdio` (set by default). Agent Client handles permission prompts in the chat, so do not add `--always-approve`.
 
 ## Authentication
 
@@ -55,20 +57,18 @@ Choose one of the following methods:
 grok login
 ```
 
-2. Complete the browser sign-in (SuperGrok or X Premium+).
+2. Complete the browser sign-in.
 
 3. In **Settings → Agent Client**, leave the **API key field empty** — the `grok agent stdio` process started by Agent Client reuses your session from `~/.grok/auth.json`.
 
 ### Option B: xAI API Key
 
-Use this when there is **no** active `grok login` session — for example CI, a machine that never signed in, or after `grok logout`. API keys are created at [console.x.ai](https://console.x.ai) and bill API credits, which is a different account path from SuperGrok / X Premium+.
+API keys are created at [console.x.ai](https://console.x.ai) and bill API credits rather than a SuperGrok / X Premium subscription:
 
 1. Generate a key in the xAI console
 2. Enter it in **Settings → Agent Client → Preset agents → Grok Build → API key** (stored in Obsidian's Keychain)
 
-The plugin injects the secret as `XAI_API_KEY`. An active `grok login` session in `~/.grok/auth.json` takes precedence over that environment variable, so a linked key does not override an existing browser login (and will not switch billing to the API-key account). To use the key, run `grok logout` first, or delete `~/.grok/auth.json`.
-
-A per-model `api_key` / `env_key` in `~/.grok/config.toml` is a separate, higher-precedence override. It is not the plugin API-key field.
+A signed-in session takes precedence over the API key, so setting a key never breaks an existing login. To use the key instead, run `grok logout`.
 
 ::: tip Migrating from a custom agent
 If you previously ran Grok Build as a custom agent, its settings are not migrated automatically. A custom agent with the id `grok-build` is renamed to `grok-build-2` to make room for the preset — copy any custom path or environment variables into the preset settings, then delete the leftover custom entry. If your custom agent carried `XAI_API_KEY` in its environment variables, consider moving it to the **API key** field so it is stored in Obsidian's Keychain instead of plain text.

--- a/docs/agent-setup/grok-build.md
+++ b/docs/agent-setup/grok-build.md
@@ -1,0 +1,81 @@
+# Grok Build Setup
+
+Grok Build is xAI's coding agent. It communicates via ACP through the `grok agent stdio` command.
+
+This is the official xAI CLI (`grok`), not a third-party Grok wrapper.
+
+## Install and Configure
+
+Open a terminal (Terminal on macOS/Linux, PowerShell on Windows) and run the following commands.
+
+1. Install Grok Build:
+
+::: code-group
+
+```bash [macOS/Linux]
+curl -fsSL https://x.ai/cli/install.sh | bash
+```
+
+```powershell [Windows]
+irm https://x.ai/cli/install.ps1 | iex
+```
+
+:::
+
+Other options are listed in the [Grok Build docs](https://docs.x.ai/build/overview).
+
+2. Find the installation path:
+
+::: code-group
+
+```bash [macOS/Linux]
+which grok
+# Example output: /Users/username/.local/bin/grok
+```
+
+```cmd [Windows]
+where.exe grok
+```
+
+:::
+
+3. Open **Settings → Agent Client**. The default command (`grok`) works in many cases. If the agent is not found automatically, set the **Grok Build path** to the path found above, or click **Auto-detect**.
+
+Leave the arguments as `agent` and `stdio`. Agent Client handles permission prompts in the chat, so do not add `--always-approve`.
+
+## Authentication
+
+Choose one of the following methods:
+
+### Option A: Sign In (Interactive)
+
+1. Run the login flow in your terminal:
+
+```bash
+grok login
+```
+
+2. Complete the browser sign-in (SuperGrok or X Premium+).
+
+3. In **Settings → Agent Client**, leave the **API key field empty** — the `grok agent stdio` process started by Agent Client reuses your session from `~/.grok/auth.json`.
+
+### Option B: xAI API Key
+
+API keys are created at [console.x.ai](https://console.x.ai):
+
+1. Generate a key in the xAI console
+2. Enter it in **Settings → Agent Client → Preset agents → Grok Build → API key** (stored in Obsidian's Keychain)
+
+The API key is injected as `XAI_API_KEY` and takes precedence over browser credentials.
+
+::: tip Migrating from a custom agent
+If you previously ran Grok Build as a custom agent, its settings are not migrated automatically. A custom agent with the id `grok-build` is renamed to `grok-build-2` to make room for the preset — copy any custom path or environment variables into the preset settings, then delete the leftover custom entry. If your custom agent carried `XAI_API_KEY` in its environment variables, consider moving it to the **API key** field so it is stored in Obsidian's Keychain instead of plain text.
+:::
+
+## Verify Setup
+
+1. Click the robot icon in the ribbon or use the command palette: **"Open chat view"**
+2. Switch to Grok Build from the agent dropdown in the chat header
+3. Try sending a message to verify the connection
+
+Having issues? See [Troubleshooting](/help/troubleshooting).

--- a/docs/agent-setup/index.md
+++ b/docs/agent-setup/index.md
@@ -13,13 +13,14 @@ Agent Client supports multiple AI agents through the [Agent Client Protocol (ACP
 | [OpenCode](./opencode) | Multi-provider | `opencode-ai` |
 | [Kiro](./kiro) | AWS | install script |
 | [Hermes Agent](./hermes) | Multi-provider | install script |
+| [Grok Build](./grok-build) | xAI | install script |
 | [Custom Agents](./custom-agents) | Various | Any ACP-compatible agent |
 
 ## Common Setup Steps
 
 All agents follow a similar setup pattern:
 
-1. **Install the agent** — see each agent's setup page for the exact command (npm for Claude Code / Codex / Gemini CLI; `curl` on macOS/Linux or `uv` on Windows for Mistral Vibe; `curl` or npm for OpenCode; `curl` on macOS/Linux or PowerShell on Windows for Kiro and Hermes Agent)
+1. **Install the agent** — see each agent's setup page for the exact command (npm for Claude Code / Codex / Gemini CLI; `curl` on macOS/Linux or `uv` on Windows for Mistral Vibe; `curl` or npm for OpenCode; `curl` on macOS/Linux or PowerShell on Windows for Kiro, Hermes Agent, and Grok Build)
 2. **Set up authentication** (API key or account login)
 
 The plugin resolves bare command names through your login shell's PATH, so path configuration is often not needed. If the agent is not found automatically, use `which` (macOS/Linux) or `where.exe` (Windows) to find the path and configure it in Settings → Agent Client.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -15,6 +15,7 @@ Agent Client supports multiple AI agents. Choose one to start:
 | **[OpenCode](/agent-setup/opencode)** | Multi-provider | with built-in ACP support (`opencode acp`) |
 | **[Kiro](/agent-setup/kiro)** | AWS | with built-in ACP support (`kiro-cli acp`) |
 | **[Hermes Agent](/agent-setup/hermes)** | Multi-provider | with built-in ACP support (`hermes acp`) |
+| **[Grok Build](/agent-setup/grok-build)** | xAI | with built-in ACP support (`grok agent stdio`) |
 | **[Custom](/agent-setup/custom-agents)** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., Qwen Code) |
 
 ## Step 2: Install and Configure the Agent
@@ -28,6 +29,7 @@ Follow the setup guide for your chosen agent:
 - [OpenCode Setup](/agent-setup/opencode)
 - [Kiro Setup](/agent-setup/kiro)
 - [Hermes Agent Setup](/agent-setup/hermes)
+- [Grok Build Setup](/agent-setup/grok-build)
 - [Custom Agents](/agent-setup/custom-agents)
 
 Each guide covers installation, path configuration, and authentication.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -6,7 +6,7 @@ Frequently asked questions about Agent Client.
 
 ### What is Agent Client?
 
-Agent Client is an Obsidian plugin that lets you chat with AI agents directly within Obsidian. It supports Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, and any ACP-compatible agent. The plugin uses the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) to communicate with agents.
+Agent Client is an Obsidian plugin that lets you chat with AI agents directly within Obsidian. It supports Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, Grok Build, and any ACP-compatible agent. The plugin uses the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) to communicate with agents.
 
 ### Is this an official Anthropic/OpenAI/Google plugin?
 
@@ -81,7 +81,7 @@ Disabling only hides the agent from lists: already-open chats, restored sessions
 
 ### What is a custom agent?
 
-Any ACP-compatible agent beyond the preset ones (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent). You can add custom agents in **Settings → Agent Client → Custom agents**. See [Custom Agents](/agent-setup/custom-agents).
+Any ACP-compatible agent beyond the preset ones (Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, Grok Build). You can add custom agents in **Settings → Agent Client → Custom agents**. See [Custom Agents](/agent-setup/custom-agents).
 
 ### Do all agents support the same features?
 
@@ -95,7 +95,7 @@ Slash commands are provided by the agent, not the plugin. If the input placehold
 
 ### Why are the commands different from what I expected?
 
-Each agent provides its own commands. Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, and Hermes Agent all have different command sets. Refer to your agent's documentation for available commands.
+Each agent provides its own commands. Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, and Grok Build all have different command sets. Refer to your agent's documentation for available commands.
 
 ## Permissions
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -65,6 +65,9 @@ The agent requires authentication before processing requests.
 **For Hermes Agent:**
 - Run `hermes model` in Terminal to configure a provider (there is no API key field in the plugin). See [Hermes Agent Setup](/agent-setup/hermes#authentication).
 
+**For Grok Build:**
+- Run `grok login` in Terminal first to sign in, or link an API key in **Settings → Agent Client → Preset agents → Grok Build → API key**. See [Grok Build Setup](/agent-setup/grok-build#authentication).
+
 ### "No Authentication Methods" error
 
 The agent didn't provide authentication options.

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -67,8 +67,9 @@ The agent requires authentication before processing requests.
 
 **For Pi:**
 - Run `pi` in Terminal and complete the interactive setup for your provider (there is no API key field in the plugin). See [Pi Setup](/agent-setup/pi#authentication).
+
 **For Grok Build:**
-- Run `grok login` in Terminal first to sign in. A linked API key in **Settings → Agent Client → Preset agents → Grok Build → API key** is used only when no login session is active (`grok logout` first if you intend the key). See [Grok Build Setup](/agent-setup/grok-build#authentication).
+- Run `grok login` in Terminal first to sign in, or link an API key (used only when no login session is active) in **Settings → Agent Client → Preset agents → Grok Build → API key**. See [Grok Build Setup](/agent-setup/grok-build#authentication).
 
 ### "No Authentication Methods" error
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -66,7 +66,7 @@ The agent requires authentication before processing requests.
 - Run `hermes model` in Terminal to configure a provider (there is no API key field in the plugin). See [Hermes Agent Setup](/agent-setup/hermes#authentication).
 
 **For Grok Build:**
-- Run `grok login` in Terminal first to sign in, or link an API key in **Settings → Agent Client → Preset agents → Grok Build → API key**. See [Grok Build Setup](/agent-setup/grok-build#authentication).
+- Run `grok login` in Terminal first to sign in. A linked API key in **Settings → Agent Client → Preset agents → Grok Build → API key** is used only when no login session is active (`grok logout` first if you intend the key). See [Grok Build Setup](/agent-setup/grok-build#authentication).
 
 ### "No Authentication Methods" error
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ Agent Client is an Obsidian plugin that brings AI coding agents directly into yo
 | **[OpenCode](https://github.com/anomalyco/opencode)** | Multi-provider | with built-in ACP support (`opencode acp`) |
 | **[Kiro](https://kiro.dev/)** | AWS | with built-in ACP support (`kiro-cli acp`) |
 | **[Hermes Agent](https://github.com/NousResearch/hermes-agent)** | Multi-provider | with built-in ACP support (`hermes acp`) |
+| **[Grok Build](https://docs.x.ai/build/overview)** | xAI | with built-in ACP support (`grok agent stdio`) |
 | **Custom** | Various | [Any ACP-compatible agent](https://agentclientprotocol.com/overview/agents) (e.g., Qwen Code) |
 
 ### Key Features

--- a/docs/reference/acp-support.md
+++ b/docs/reference/acp-support.md
@@ -6,7 +6,7 @@ This page documents which Agent Client Protocol (ACP) features are supported by 
 
 The [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) is an open standard for communication between AI agents and client applications. It defines how clients send prompts, receive responses, handle permissions, and manage sessions.
 
-Agent Client implements ACP as a **client**, communicating with ACP-compatible agents like Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, and Hermes Agent.
+Agent Client implements ACP as a **client**, communicating with ACP-compatible agents like Claude Code, Codex, Gemini CLI, Mistral Vibe, OpenCode, Kiro, Hermes Agent, and Grok Build.
 
 ## Methods
 

--- a/docs/usage/context-files.md
+++ b/docs/usage/context-files.md
@@ -23,6 +23,7 @@ Each agent uses its own context file:
 | OpenCode | `AGENTS.md` (falls back to `CLAUDE.md`) |
 | Kiro | `AGENTS.md` (also `.kiro/steering/*.md`) |
 | Hermes Agent | `AGENTS.md` (falls back to `CLAUDE.md`) |
+| Grok Build | `AGENTS.md` (also `CLAUDE.md`) |
 
 Place the context file in your **vault root** to have the agent read it automatically.
 

--- a/src/services/preset-agents.ts
+++ b/src/services/preset-agents.ts
@@ -257,6 +257,28 @@ export const PRESET_AGENTS: readonly PresetAgentDefinition[] = [
 		},
 		docsPage: "hermes",
 	},
+	{
+		presetId: "grok-build",
+		defaultDisplayName: "Grok Build",
+		defaultCommand: "grok",
+		defaultArgs: ["agent", "stdio"],
+		apiKey: {
+			envVarName: "XAI_API_KEY",
+			settingDesc:
+				"xAI API key. Required only for API-key auth — leave empty when signing in with grok login. Select from Obsidian's Keychain or create a new secret.",
+		},
+		installHint: {
+			default: "curl -fsSL https://x.ai/cli/install.sh | bash",
+			nativeWindows: "irm https://x.ai/cli/install.ps1 | iex",
+		},
+		settingsCopy: {
+			pathDesc:
+				'Command name or path to grok. Use just "grok" to let the login shell resolve it, or enter an absolute path.',
+			argsDescSuffix:
+				'(Currently, Grok Build requires the "agent stdio" options.)',
+		},
+		docsPage: "grok-build",
+	},
 ];
 
 /**

--- a/test/session-helpers.test.ts
+++ b/test/session-helpers.test.ts
@@ -67,6 +67,9 @@ function makeSettings(
 			"hermes-agent": preset("hermes-agent", "Hermes Agent", "hermes", {
 				args: ["acp"],
 			}),
+			"grok-build": preset("grok-build", "Grok Build", "grok", {
+				args: ["agent", "stdio"],
+			}),
 		},
 		customAgents: [],
 		defaultAgentId: "",
@@ -87,6 +90,7 @@ describe("getAvailableAgentsFromSettings", () => {
 			{ id: "opencode", displayName: "OpenCode" },
 			{ id: "kiro-cli", displayName: "Kiro" },
 			{ id: "hermes-agent", displayName: "Hermes Agent" },
+			{ id: "grok-build", displayName: "Grok Build" },
 			{ id: "my-custom", displayName: "My Custom" },
 		]);
 	});
@@ -119,6 +123,7 @@ describe("getAvailableAgentsFromSettings", () => {
 			"opencode",
 			"kiro-cli",
 			"hermes-agent",
+			"grok-build",
 			"my-custom",
 		]);
 	});
@@ -140,6 +145,7 @@ describe("getAllAgentsFromSettings", () => {
 			{ id: "opencode", displayName: "OpenCode" },
 			{ id: "kiro-cli", displayName: "Kiro" },
 			{ id: "hermes-agent", displayName: "Hermes Agent" },
+			{ id: "grok-build", displayName: "Grok Build" },
 			{ id: "off-custom", displayName: "Off Custom" },
 		]);
 	});
@@ -252,6 +258,7 @@ describe("buildAgentConfigWithApiKey", () => {
 		["gemini-cli", "GEMINI_API_KEY"],
 		["mistral-vibe", "MISTRAL_API_KEY"],
 		["kiro-cli", "KIRO_API_KEY"],
+		["grok-build", "XAI_API_KEY"],
 	])("attaches the %s secret as %s", (agentId, envVarName) => {
 		const agentSettings = preset(agentId, "Name", "cmd", {
 			apiKeySecretId: "my-secret",


### PR DESCRIPTION
## Description

Adds [Grok Build](https://docs.x.ai/build/overview) (xAI's official `grok` CLI) as a preset agent, spawned with `grok agent stdio`. Includes #419 by @meschkemaes, merged into this staging branch as is, plus the follow-ups below.

- **Preset** (registry entry only): `grok-build`, command `grok`, args `agent stdio`, optional `XAI_API_KEY` wiring (same pattern as Kiro), install hints for macOS/Linux and Windows. No custom-agent absorption.
- **Merged with `dev`**: resolves the conflicts with the Pi preset (#405) across the agent tables, README (now "Nine presets"), AGENTS.md, the registry, and the enumeration tests.
- **Setup page aligned with the sibling pages** (Kiro / Hermes / Pi): one-paragraph intro, arguments as a numbered step, the API-key section in the Kiro form, and the troubleshooting entry as a one-liner.
- **Facts verified against the xai-org/grok-build source and docs.x.ai**: any grok.com / X account can sign in (only four slash commands are tier-gated, so the "SuperGrok or X Premium+" requirement was dropped); the installer puts `grok` in `~/.grok/bin` and symlinks it into `~/.local/bin` when that is on PATH; a signed-in session takes precedence over the API key.
- **PATH note**: the installer only edits `~/.zshrc` / `~/.bashrc`, which the login shell does not read, so the page explains when the default command resolves and points to Auto-detect or the absolute path otherwise.

Deliberately not done: no `--no-auto-update` in the default args (the stdio updater only stages a new binary for the next spawn and writes to stderr), and `~/.grok/bin` is not added to Auto-detect's static directory list (consistent with Kiro / Hermes).

## Related issue

Includes #419

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Grok Build 1.0.13 (`grok agent stdio`), signed in with `grok login`
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Grok Build as a supported preset agent.
  - Added installation options for macOS, Linux, and Windows.
  - Added interactive sign-in and XAI API key authentication.
  - Added configuration and verification guidance for connecting Grok Build.

- **Documentation**
  - Updated English and Japanese guides, FAQs, troubleshooting content, and agent lists with Grok Build setup information.
  - Documented Grok Build’s supported context files and ACP compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->