### PR TITLE
fix(chat): drop user_message_chunk echoes while a prompt is in flight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ FloatingChatView uses `onRegisterExpanded` callback (not CustomEvent) for expand
 - RAF batching: streaming updates accumulated per-frame via `requestAnimationFrame`
 - Tool call index: `Map<string, number>` for O(1) upsert
 - `ignoreUpdatesRef`: suppresses history replay during session/load
+- `sendPromiseRef`: serializes sends and gates out `user_message_chunk` echoes while the prompt RPC is open
 - Permission: `activePermission` (useMemo derivation), approve/reject callbacks
 
 **useSuggestions**: @mention + /command (unified)

--- a/src/hooks/useAgentMessages.ts
+++ b/src/hooks/useAgentMessages.ts
@@ -154,6 +154,14 @@ export function useAgentMessages(
 	const enqueueUpdate = useCallback(
 		(update: SessionUpdate) => {
 			if (ignoreUpdatesRef.current) return;
+			// Some agents echo the prompt back as a user_message_chunk while
+			// the prompt RPC is still open; the transcript already holds it.
+			if (
+				update.type === "user_message_chunk" &&
+				sendPromiseRef.current !== null
+			) {
+				return;
+			}
 			pendingUpdatesRef.current.push(update);
 			if (!flushScheduledRef.current) {
 				flushScheduledRef.current = true;


### PR DESCRIPTION
## Description

Some agents send the user's prompt back as a live `user_message_chunk` right after receiving it. Grok Build does this on every prompt (confirmed on the wire with Debug Mode: the chunk arrives immediately after `session/prompt`, before the first thought). The chat treated that chunk the way it treats session/load replay, appending the text to the last user message, so every user message showed twice ("hihi").

- **Fix**: while the prompt RPC is still open (`sendPromiseRef` is set), `user_message_chunk` updates are dropped at the enqueue gate, next to the existing session/load gate. The transcript already holds the message the user just sent.
- **Why the RPC lifecycle and not `isSending`**: `session/cancel` is a notification, so a cancelled turn's prompt RPC stays open until the agent answers. Keying the gate off the RPC itself means a late echo after cancel is still dropped, and there is no second flag to keep in sync.
- **Unaffected**: session/load replay (it never runs during a prompt), Claude Code and Codex (they do not echo), the `ignoreUpdatesRef` path for restores with local history.
- Docs: one line in AGENTS.md's Key Components for `sendPromiseRef`.

Verified manually: fixture echo scenario (one copy shown), Grok Build (one copy), session/load replay without local history (user turns still rebuilt from the agent's replay), cancel then resend, Claude Code and Codex normal sends.

## Related issue

None (found while verifying #420)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] `npm run lint` passes ("Use sentence case for UI text" errors are acceptable for brand names)
- [x] `npm run build` passes
- [x] Tested in Obsidian
- [x] Existing functionality still works
- [x] Documentation updated if needed

## Testing environment

- Agent: Grok Build 1.0.13, Claude Code, Codex, [acp-fixture-agent](https://github.com/RAIT-09/acp-fixture-agent)
- OS: macOS

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicated user messages in the conversation transcript when agents echo the prompt during an active send.
  * Preserved processing of other incoming message updates while a send is in progress.

* **Documentation**
  * Added documentation describing how outgoing messages are serialized and echoed prompt chunks are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->